### PR TITLE
fix(minimax): align plugin metadata and icon

### DIFF
--- a/xpertai/.changeset/minimax-branding-cleanup.md
+++ b/xpertai/.changeset/minimax-branding-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-minimax": patch
+---
+
+Align the MiniMax plugin metadata, empty config schema, and icon handling with the XpertAI plugin conventions.

--- a/xpertai/models/minimax/src/index.ts
+++ b/xpertai/models/minimax/src/index.ts
@@ -1,26 +1,19 @@
 import { readFileSync } from 'fs';
-import { join } from 'path';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 import { z } from 'zod';
 import type { XpertPlugin } from '@xpert-ai/plugin-sdk';
 import { MiniMaxModule } from './minimax.module.js';
+import { SvgIcon } from './types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const pkg = JSON.parse(
-  readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+  readFileSync(join(__dirname, '../package.json'), 'utf8')
 ) as { name: string; version: string };
 
-const ConfigSchema = z.object({
-  api_key: z.string().min(1, 'API Key is required'),
-  group_id: z.string().min(1, 'Group ID is required'),
-  base_url: z.string().url().optional().describe('Optional base URL, defaults to https://api.minimaxi.com')
-});
-
-const SvgIcon = `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="24" height="24" rx="6" fill="#111827"/>
-<path d="M12 4C12 4 8 8 8 12C8 16 12 20 12 20C12 20 16 16 16 12C16 8 12 4 12 4Z" fill="white" fill-opacity="0.88"/>
-<path d="M12 8C10 8 8 10 8 12C8 14 10 16 12 16C14 16 16 14 16 12C16 10 14 8 12 8Z" fill="white"/>
-</svg>`;
-
-const plugin: XpertPlugin<z.infer<typeof ConfigSchema>> = {
+const plugin: XpertPlugin<any> = {
   meta: {
     name: pkg.name,
     version: pkg.version,
@@ -31,7 +24,9 @@ const plugin: XpertPlugin<z.infer<typeof ConfigSchema>> = {
     keywords: ['minimax', 'openai-compatible', 'llm', 'embedding', 'tts'],
     author: 'XpertAI Team'
   },
-  config: { schema: ConfigSchema },
+  config: {
+    schema: z.object({})
+  },
   register(ctx) {
     ctx.logger.log('Register MiniMax plugin');
     return { module: MiniMaxModule, global: true };
@@ -44,5 +39,4 @@ const plugin: XpertPlugin<z.infer<typeof ConfigSchema>> = {
   }
 };
 
-export { ConfigSchema };
 export default plugin;

--- a/xpertai/models/minimax/src/manifest.yaml
+++ b/xpertai/models/minimax/src/manifest.yaml
@@ -1,4 +1,4 @@
-author: langgenius
+author: XpertAI
 created_at: '2024-09-20T00:13:50.29298939-04:00'
 description: 
   en_US: Minimax AI models for LLM, text embedding, and text-to-speech

--- a/xpertai/models/minimax/src/types.ts
+++ b/xpertai/models/minimax/src/types.ts
@@ -1,4 +1,15 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const moduleDir = dirname(fileURLToPath(import.meta.url));
+
 export const MiniMax = 'minimax';
+const MiniMaxIconPngBase64 = readFileSync(join(moduleDir, '_assets/icon_s_en.png')).toString('base64');
+
+export const SvgIcon = `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <image width="24" height="24" href="data:image/png;base64,${MiniMaxIconPngBase64}"/>
+</svg>`;
 
 export interface MiniMaxCredentials {
   api_key: string;


### PR DESCRIPTION
## Summary
- align the MiniMax plugin metadata with XpertAI branding and remove the leftover `langgenius` author
- match the plugin entry config pattern used by `zhipuai` by using an empty inline schema instead of a plugin-level credential schema
- replace the placeholder `SvgIcon` with one that reuses the real MiniMax icon asset and add a patch changeset for `@xpert-ai/plugin-minimax`

## Validation
- `CI=true pnpm -C xpertai install --frozen-lockfile`
- `pnpm -C plugin-dev-harness build`
- `env NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-minimax --outputStyle=static`
- `npx -y node@20 plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin ./models/minimax --verbose`

## Notes
- PR intentionally includes only the MiniMax plugin files and its changeset.
- This PR was cut from `main` on a dedicated branch so it does not inherit the unrelated `feat/openai-gpt54` branch history.