### PR TITLE
fix(model-retry): honor aborts and terminal failures

### DIFF
--- a/xpertai/.changeset/model-retry-abort-fixes.md
+++ b/xpertai/.changeset/model-retry-abort-fixes.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-model-retry": patch
+---
+
+Respect runtime abort signals during backoff, avoid retrying cancellation-style errors, and default exhausted retries to rethrowing the last error.

--- a/xpertai/middlewares/model-retry/README.md
+++ b/xpertai/middlewares/model-retry/README.md
@@ -10,6 +10,7 @@
 - Wraps retry attempts with `WrapWorkflowNodeExecutionCommand` so middleware-level execution tracking remains visible in Xpert.
 - Registers as a global middleware plugin so the strategy is available across the platform.
 - Treats `AIMessage.response_metadata.finish_reason === "network_error"` as a retryable model failure, even when the provider returns a message instead of throwing.
+- Respects runtime abort signals and never retries cancellation-style errors.
 
 ## Installation
 
@@ -58,7 +59,7 @@ npm install @xpert-ai/plugin-model-retry
 | `retryableErrorNames` | string[] | Retry only matching `error.name` values when `retryAllErrors=false`. | `[]` |
 | `retryableStatusCodes` | number[] | Retry matching HTTP-style status codes from `status`, `statusCode`, or `response.status`. | `[]` |
 | `retryableMessageIncludes` | string[] | Retry when the error message contains any configured fragment. Matching is case-insensitive. | `[]` |
-| `onFailure` | `"continue"` \| `"error"` | Return an `AIMessage` or rethrow after retries are exhausted. | `"continue"` |
+| `onFailure` | `"continue"` \| `"error"` | Return an `AIMessage` or rethrow after retries are exhausted. | `"error"` |
 
 ## LangChain Differences
 
@@ -66,6 +67,7 @@ npm install @xpert-ai/plugin-model-retry
 - Retry matching uses declarative JSON fields instead of runtime classes or callback functions.
 - Retry attempts are execution-tracked with Xpert workflow commands, but no model client is recreated during retries.
 - Provider responses that finish with `network_error` are normalized into an internal `ModelNetworkError` and routed through the same retry policy.
+- Abort and cancel errors are treated as terminal and are never retried or converted into fallback `AIMessage` content.
 
 ## Development & Testing
 

--- a/xpertai/middlewares/model-retry/src/lib/modelRetry.spec.ts
+++ b/xpertai/middlewares/model-retry/src/lib/modelRetry.spec.ts
@@ -34,7 +34,7 @@ jest.mock('@metad/contracts', () => ({
 }))
 
 import { AIMessage } from '@langchain/core/messages'
-import { calculateRetryDelay } from './retry'
+import { calculateRetryDelay, sleep } from './retry'
 const { ModelRetryMiddleware } = require('./modelRetry')
 
 describe('ModelRetryMiddleware', () => {
@@ -46,7 +46,7 @@ describe('ModelRetryMiddleware', () => {
     tools: new Map(),
   })
 
-  const createRuntime = () => ({
+  const createRuntime = (signal?: AbortSignal) => ({
     configurable: {
       thread_id: 'thread-1',
       executionId: 'exec-1',
@@ -54,14 +54,15 @@ describe('ModelRetryMiddleware', () => {
       checkpoint_id: 'checkpoint-1',
       subscriber: undefined,
     },
+    signal,
   })
 
-  const createRequest = () => ({
+  const createRequest = (options?: { signal?: AbortSignal }) => ({
     model: { model: 'mock-model' },
     messages: [],
     tools: [],
     state: { messages: [] },
-    runtime: createRuntime(),
+    runtime: createRuntime(options?.signal),
   })
 
   async function createMiddleware(config: any) {
@@ -144,6 +145,7 @@ describe('ModelRetryMiddleware', () => {
       retryableErrorNames: ['RateLimitError'],
       initialDelayMs: 0,
       jitter: false,
+      onFailure: 'continue',
     })
     const handler = jest.fn().mockRejectedValue(new Error('boom'))
 
@@ -200,15 +202,31 @@ describe('ModelRetryMiddleware', () => {
   })
 
   it('rethrows after retries are exhausted when onFailure is error', async () => {
-    const { middleware } = await createMiddleware({
-      maxRetries: 0,
-      onFailure: 'error',
-    })
+    const { middleware } = await createMiddleware({ maxRetries: 0 })
     const handler = jest.fn().mockRejectedValue(new Error('fatal'))
 
     await expect(middleware.wrapModelCall?.(createRequest(), handler as any)).rejects.toThrow(
       'fatal'
     )
+  })
+
+  it('does not retry abort-like model errors', async () => {
+    const abortError = new Error('This operation was aborted')
+    abortError.name = 'AbortError'
+
+    const { strategy, middleware } = await createMiddleware({
+      maxRetries: 2,
+      initialDelayMs: 0,
+      jitter: false,
+    })
+    const handler = jest.fn().mockRejectedValue(abortError)
+
+    await expect(
+      middleware.wrapModelCall?.(createRequest({ signal: new AbortController().signal }), handler as any)
+    ).rejects.toThrow('This operation was aborted')
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(strategy.commandBus.execute).not.toHaveBeenCalled()
   })
 
   it('validates matcher configuration when retryAllErrors is false', async () => {
@@ -254,5 +272,17 @@ describe('ModelRetryMiddleware', () => {
     ).toBe(1250)
 
     randomSpy.mockRestore()
+  })
+
+  it('rejects sleep when the runtime is aborted during backoff', async () => {
+    const abortController = new AbortController()
+    const pending = sleep(50, abortController.signal)
+
+    abortController.abort('Request canceled')
+
+    await expect(pending).rejects.toMatchObject({
+      name: 'AbortError',
+      message: 'Request canceled',
+    })
   })
 })

--- a/xpertai/middlewares/model-retry/src/lib/modelRetry.ts
+++ b/xpertai/middlewares/model-retry/src/lib/modelRetry.ts
@@ -23,11 +23,13 @@ import { AIMessage } from '@langchain/core/messages'
 import { ModelRetryIcon } from './types.js'
 import {
   calculateRetryDelay,
+  isAbortLikeError,
   normalizeError,
   normalizeRetryConfig,
   retryBaseSchema,
   shouldRetryError,
   sleep,
+  throwIfAborted,
 } from './retry.js'
 
 export type ModelRetryMiddlewareConfig = z.input<typeof retryBaseSchema>
@@ -157,7 +159,7 @@ const configSchemaProperties: JsonSchemaObjectType['properties'] = {
   onFailure: {
     type: 'string',
     enum: ['continue', 'error'],
-    default: 'continue',
+    default: 'error',
     title: {
       en_US: 'On Failure',
       zh_Hans: '失败处理',
@@ -282,10 +284,16 @@ export class ModelRetryMiddleware implements IAgentMiddlewareStrategy {
         request: ModelRequest<AgentBuiltInState>,
         handler: WrapModelCallHandler
       ): Promise<AIMessage> => {
+        const signal = request.runtime?.signal
+
         try {
+          throwIfAborted(signal)
           return await this.invokeModel(request, handler)
         } catch (error) {
           let lastError = normalizeError(error)
+          if (isAbortLikeError(lastError)) {
+            throw lastError
+          }
 
           if (!shouldRetryError(lastError, retryConfig) || retryConfig.maxRetries === 0) {
             return handleFailure(lastError, 1)
@@ -294,13 +302,18 @@ export class ModelRetryMiddleware implements IAgentMiddlewareStrategy {
           for (let retryAttempt = 1; retryAttempt <= retryConfig.maxRetries; retryAttempt++) {
             const delay = calculateRetryDelay(retryConfig, retryAttempt - 1)
             if (delay > 0) {
-              await sleep(delay)
+              await sleep(delay, signal)
             }
 
             try {
+              throwIfAborted(signal)
               return await this.executeTrackedRetry(request, handler, context)
             } catch (retryError) {
               lastError = normalizeError(retryError)
+              if (isAbortLikeError(lastError)) {
+                throw lastError
+              }
+
               const attemptsMade = retryAttempt + 1
 
               if (!shouldRetryError(lastError, retryConfig) || retryAttempt === retryConfig.maxRetries) {

--- a/xpertai/middlewares/model-retry/src/lib/retry.ts
+++ b/xpertai/middlewares/model-retry/src/lib/retry.ts
@@ -13,7 +13,7 @@ export const retryBaseSchema = z
     retryableErrorNames: z.array(z.string().trim().min(1)).optional(),
     retryableStatusCodes: z.array(z.number().int()).optional(),
     retryableMessageIncludes: z.array(z.string().trim().min(1)).optional(),
-    onFailure: z.enum(['continue', 'error']).default('continue'),
+    onFailure: z.enum(['continue', 'error']).default('error'),
   })
   .superRefine((data, ctx) => {
     const hasMatchers =
@@ -46,6 +46,8 @@ export interface NormalizedRetryConfig {
   onFailure: RetryOnFailureMode
 }
 
+const DEFAULT_ABORT_MESSAGE = 'This operation was aborted'
+
 const normalizeStringList = (values?: string[], lowercase = false): string[] => {
   const normalized = (values ?? [])
     .map((value) => value.trim())
@@ -69,7 +71,7 @@ export function normalizeRetryConfig(input: RetryBaseConfigInput): NormalizedRet
     retryableErrorNames: normalizeStringList(input.retryableErrorNames),
     retryableStatusCodes: normalizeNumberList(input.retryableStatusCodes),
     retryableMessageIncludes: normalizeStringList(input.retryableMessageIncludes, true),
-    onFailure: input.onFailure ?? 'continue',
+    onFailure: input.onFailure ?? 'error',
   }
 }
 
@@ -89,6 +91,44 @@ export function normalizeError(error: unknown): Error {
   }
 
   return new Error(typeof error === 'string' ? error : String(error))
+}
+
+export function isAbortLikeError(error: Error): boolean {
+  const name = error.name.toLowerCase()
+  const message = error.message.toLowerCase()
+
+  return name === 'aborterror' || message.includes('abort') || message.includes('cancel')
+}
+
+export function createAbortError(signal?: AbortSignal): Error {
+  const reason = signal?.reason
+  if (reason instanceof Error) {
+    if (reason.name === 'AbortError') {
+      return reason
+    }
+
+    const abortError = new Error(reason.message || DEFAULT_ABORT_MESSAGE)
+    abortError.name = 'AbortError'
+    Object.assign(abortError, { cause: reason })
+    return abortError
+  }
+
+  const abortError = new Error(
+    typeof reason === 'string' && reason.trim().length > 0 ? reason : DEFAULT_ABORT_MESSAGE
+  )
+  abortError.name = 'AbortError'
+  if (reason !== undefined) {
+    Object.assign(abortError, { reason })
+  }
+  return abortError
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return
+  }
+
+  throw createAbortError(signal)
 }
 
 const toStatusCode = (value: unknown): number | null => {
@@ -125,6 +165,10 @@ const extractStatusCodes = (error: Error): number[] => {
 }
 
 export function shouldRetryError(error: Error, config: NormalizedRetryConfig): boolean {
+  if (isAbortLikeError(error)) {
+    return false
+  }
+
   if (config.retryAllErrors) {
     return true
   }
@@ -157,12 +201,29 @@ export function calculateRetryDelay(
   return Math.max(0, Math.round(Math.min(config.maxDelayMs, baseDelay * jitterFactor)))
 }
 
-export async function sleep(ms: number): Promise<void> {
+export async function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  throwIfAborted(signal)
+
   if (ms <= 0) {
     return
   }
 
-  await new Promise<void>((resolve) => {
-    setTimeout(resolve, ms)
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = () => {
+      signal?.removeEventListener('abort', onAbort)
+    }
+
+    const onAbort = () => {
+      clearTimeout(timer)
+      cleanup()
+      reject(createAbortError(signal))
+    }
+
+    const timer = setTimeout(() => {
+      cleanup()
+      resolve()
+    }, ms)
+
+    signal?.addEventListener('abort', onAbort, { once: true })
   })
 }


### PR DESCRIPTION
## Summary
- fix `@xpert-ai/plugin-model-retry` so runtime aborts stop retries immediately, including during backoff sleeps
- treat abort and cancel style errors as terminal so they are never retried or converted into fallback `AIMessage` content
- change the default exhausted-retry behavior to rethrow the last error and add a changeset for release
- release-relevant files updated: `xpertai/.changeset/model-retry-abort-fixes.md`; no lockfile or `tsconfig` changes were required

## Validation
- `pnpm -C plugin-dev-harness build`
- `NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-model-retry`
- `NX_DAEMON=false pnpm -C xpertai exec nx test @xpert-ai/plugin-model-retry`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin ./middlewares/model-retry --verbose`
- `cd xpertai && CI=true pnpm install --frozen-lockfile`

## Notes
- PR intentionally includes only model-retry plugin files plus its changeset.
- A dedicated branch was created from `main` to avoid unrelated OpenAI and MiniMax branch history.