### PR TITLE
fix(openai-compatible): honor runtime thinking toggle

### DIFF
--- a/xpertai/.changeset/clean-forks-wave.md
+++ b/xpertai/.changeset/clean-forks-wave.md
@@ -1,0 +1,10 @@
+---
+"@xpert-ai/plugin-openai-compatible": patch
+---
+
+Fix runtime thinking toggle propagation for OpenAI-compatible models.
+
+- allow `copilotModel.options.enable_thinking` to override credential defaults at runtime
+- normalize thinking toggle values (`true/false`, `'true'/'false'`, `1/0`)
+- keep request payload compatibility for endpoints expecting `enable_thinking` and `chat_template_kwargs.enable_thinking`
+- update unit tests for thinking toggle true/false override behavior

--- a/xpertai/models/openai-compatible/src/llm/llm.spec.ts
+++ b/xpertai/models/openai-compatible/src/llm/llm.spec.ts
@@ -99,9 +99,66 @@ describe('getCustomizableModelSchemaFromCredentials', () => {
     expect(model).toBeDefined()
     expect(model.model).toBe('test-model')
     const invocationParams = model.invocationParams()
-    console.log(invocationParams)
+    expect(invocationParams['enable_thinking']).toBe(true)
     expect(invocationParams['chat_template_kwargs']).toEqual({
       enable_thinking: true
+    })
+  })
+
+  it('should pass enable_thinking from copilot model options', () => {
+    const credentials: OpenAICompatModelCredentials = {
+      api_key: 'test-key',
+      endpoint_url: 'http://test.com',
+      endpoint_model_name: 'test-model',
+      mode: 'chat',
+      context_size: '4096',
+      max_tokens_to_sample: '4096',
+      vision_support: 'no_support'
+    }
+    const model = llm.getChatModel(
+      {
+        model: 'test-model',
+        options: {
+          enable_thinking: true
+        }
+      },
+      { modelProperties: credentials } as unknown as TChatModelOptions,
+      null
+    )
+
+    const invocationParams = model.invocationParams()
+    expect(invocationParams['enable_thinking']).toBe(true)
+    expect(invocationParams['chat_template_kwargs']).toEqual({
+      enable_thinking: true
+    })
+  })
+
+  it('should pass enable_thinking false from copilot model options', () => {
+    const credentials: OpenAICompatModelCredentials = {
+      api_key: 'test-key',
+      endpoint_url: 'http://test.com',
+      endpoint_model_name: 'test-model',
+      mode: 'chat',
+      context_size: '4096',
+      max_tokens_to_sample: '4096',
+      vision_support: 'no_support',
+      enable_thinking: true
+    }
+    const model = llm.getChatModel(
+      {
+        model: 'test-model',
+        options: {
+          enable_thinking: false
+        }
+      },
+      { modelProperties: credentials } as unknown as TChatModelOptions,
+      null
+    )
+
+    const invocationParams = model.invocationParams()
+    expect(invocationParams['enable_thinking']).toBe(false)
+    expect(invocationParams['chat_template_kwargs']).toEqual({
+      enable_thinking: false
     })
   })
 })

--- a/xpertai/models/openai-compatible/src/llm/llm.ts
+++ b/xpertai/models/openai-compatible/src/llm/llm.ts
@@ -1,4 +1,4 @@
-import { ChatOpenAI, ChatOpenAIFields, ClientOptions } from '@langchain/openai'
+import { ChatOpenAIFields, ClientOptions } from '@langchain/openai'
 import {
   AIModelEntity,
   AiModelTypeEnum,
@@ -20,6 +20,10 @@ import { OpenAICompatModelCredentials, toCredentialKwargs } from '../types.js'
 import { OpenAICompatibleProviderStrategy } from '../provider.strategy.js'
 
 export type TOAIAPICompatLLMParams = ChatOpenAIFields & { configuration: ClientOptions }
+
+function toBoolean(value: unknown): boolean {
+  return value === true || value === 'true' || value === 1 || value === '1'
+}
 
 @Injectable()
 export class OAIAPICompatLargeLanguageModel extends LargeLanguageModel {
@@ -63,7 +67,12 @@ export class OAIAPICompatLargeLanguageModel extends LargeLanguageModel {
     const { handleLLMTokens } = options ?? {}
 
     credentials ??= options?.modelProperties as OpenAICompatModelCredentials
-    const params = toCredentialKwargs(credentials, copilotModel.model)
+    const runtimeEnableThinking = copilotModel.options?.['enable_thinking']
+    const runtimeCredentials = {
+      ...(credentials ?? {}),
+      ...(runtimeEnableThinking !== undefined ? { enable_thinking: toBoolean(runtimeEnableThinking) } : {})
+    } as OpenAICompatModelCredentials
+    const params = toCredentialKwargs(runtimeCredentials, copilotModel.model)
 
     return this.createChatModel({
       ...params,
@@ -72,7 +81,7 @@ export class OAIAPICompatLargeLanguageModel extends LargeLanguageModel {
       maxTokens: copilotModel.options?.['max_tokens'],
       streamUsage: false,
       verbose: options?.verbose,
-      callbacks: [...this.createHandleUsageCallbacks(copilot, params.model, credentials, handleLLMTokens)]
+      callbacks: [...this.createHandleUsageCallbacks(copilot, params.model, runtimeCredentials, handleLLMTokens)]
     })
   }
 

--- a/xpertai/models/openai-compatible/src/types.ts
+++ b/xpertai/models/openai-compatible/src/types.ts
@@ -17,6 +17,10 @@ export interface OpenAICompatModelCredentials extends CommonChatModelParameters 
   enable_thinking?: boolean
 }
 
+function toBoolean(value: unknown): boolean {
+  return value === true || value === 'true' || value === 1 || value === '1'
+}
+
 export function toCredentialKwargs(
   credentials: OpenAICompatModelCredentials,
   model?: string
@@ -37,8 +41,10 @@ export function toCredentialKwargs(
 
   const modelKwargs = {}
   if (credentials.enable_thinking != null) {
+    const thinkingEnabled = toBoolean(credentials.enable_thinking)
+    modelKwargs['enable_thinking'] = thinkingEnabled
     modelKwargs['chat_template_kwargs'] ??= {}
-    modelKwargs['chat_template_kwargs']['enable_thinking'] = !!credentials.enable_thinking
+    modelKwargs['chat_template_kwargs']['enable_thinking'] = thinkingEnabled
   }
 
   return {


### PR DESCRIPTION
# Plugin Submission Form

## 1. Metadata
<!--
Please provide the following metadata of your plugin to make it easier for the reviewer to check the changes.
  - Plugin Author : The author of the plugin which is defined in your manifest.yaml
  - Plugin Name   : The name of the plugin which is defined in your manifest.yaml
  - Repository URL: The URL of the repository where the source code of your plugin is hosted
-->

- **Plugin Author**: 
- **Plugin Name**: 
- **Repository URL**: 

## 2. Submission Type

- [ ] New plugin submission
- [x] Version update for existing plugin

## 3. Description
<!-- Please briefly describe the purpose of the new plugin or the updates made to the existing plugin -->

## 4. Checklist

- [ ] I have read and followed the Publish to Xpert Marketplace guidelines
- [ ] I have read and comply with the Plugin Developer Agreement
- [ ] I confirm my plugin works properly on both Xpert Community Edition and Cloud Version
- [ ] I confirm my plugin has been thoroughly tested for completeness and functionality
- [ ] My plugin brings new value to Xpert

## 5. Documentation Checklist

Please confirm that your plugin README includes all necessary information:

- [ ] Step-by-step setup instructions
- [ ] Detailed usage instructions
- [ ] All required APIs and credentials are clearly listed
- [ ] Connection requirements and configuration details
- [ ] Link to the repository for the plugin source code

## 6. Privacy Protection Information

Based on Xpert Plugin Privacy Protection [Guidelines](#):

### Data Collection
<!-- Does your plugin collect any user personal data? If yes, please list what types of user personal data are being collected according to the Plugin Privacy Protection Guidelines (for example: Email address, IP address, Age, etc) -->

### Privacy Policy

- [ ] I confirm that I have prepared and included a privacy policy in my plugin package based on the Plugin Privacy Protection Guidelines