### PR TITLE
fix(minimax): add provider schema and refresh model catalog

### DIFF
--- a/xpertai/.changeset/fuzzy-snails-burn.md
+++ b/xpertai/.changeset/fuzzy-snails-burn.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-minimax": patch
+---
+
+Fix the MiniMax provider schema and refresh the built-in model catalog.

--- a/xpertai/models/minimax/README.md
+++ b/xpertai/models/minimax/README.md
@@ -52,7 +52,7 @@ During validation, the plugin checks that both `api_key` and `group_id` are prov
 - `MiniMax-M2.1-highspeed` - Historical high-speed variant of M2.1
 - `MiniMax-M2` - Historical MiniMax M2 model with 204.8K total context
 - `M2-her` - Specialized for role-playing and multi-turn conversations (65K context)
-- `MiniMax-M1` - Historical MiniMax M1 model (1M context)
+- `minimax-m1` - Historical MiniMax M1 model (1M context)
 
 ### Text Embedding Models
 - `embo-01` - MiniMax embedding model

--- a/xpertai/models/minimax/README.md
+++ b/xpertai/models/minimax/README.md
@@ -10,7 +10,7 @@
 - Implements `MiniMaxLargeLanguageModel`, a LangChain-powered adapter built on `ChatOAICompatReasoningModel` that supports streaming chat completions, function calling, and token accounting callbacks for agent telemetry.
 - Provides `MiniMaxTextEmbeddingModel`, a custom implementation that handles MiniMax's specific embedding API format with support for document and query embedding types.
 - Exposes `MiniMaxTTSModel`, which supports streaming text-to-speech synthesis with multiple voice options and audio formats.
-- Shares a console-ready `manifest.yaml` that drives the XpertAI UI forms (icons, help links, credential prompts) for quick operator onboarding.
+- Ships a `minimax.yaml` provider schema for XpertAI's model-provider UI and a `manifest.yaml` plugin manifest for packaging metadata.
 
 ## Installation
 
@@ -31,7 +31,7 @@ npm install @xpert-ai/plugin-minimax
 
 ## Credentials & Model Configuration
 
-The plugin schema backs the form fields you see in the console:
+The provider schema in `src/minimax.yaml` backs the form fields you see in the console:
 
 | Field | Description |
 | --- | --- |
@@ -44,13 +44,15 @@ During validation, the plugin checks that both `api_key` and `group_id` are prov
 ## Supported Models
 
 ### Large Language Models (LLM)
-- `MiniMax-M2.5` - Latest flagship model, excels at coding and agentic tasks (196K context)
+- `MiniMax-M2.7` - Latest flagship model for software engineering and agent workflows (204.8K total context)
+- `MiniMax-M2.7-highspeed` - High-speed variant of M2.7 with higher throughput
+- `MiniMax-M2.5` - Previous flagship model for coding and agentic tasks (204.8K total context)
 - `MiniMax-M2.5-highspeed` - High-speed variant of M2.5 with 100 tokens/s throughput
-- `MiniMax-M2.1` - Enhanced reasoning model with 230B parameters (196K context)
-- `MiniMax-M2.1-highspeed` - High-speed variant of M2.1
-- `MiniMax-M2` - MiniMax M2 model with agentic capabilities (196K context)
+- `MiniMax-M2.1` - Historical reasoning model with 204.8K total context
+- `MiniMax-M2.1-highspeed` - Historical high-speed variant of M2.1
+- `MiniMax-M2` - Historical MiniMax M2 model with 204.8K total context
 - `M2-her` - Specialized for role-playing and multi-turn conversations (65K context)
-- `minimax-m1` - MiniMax M1 open-source model (1M context)
+- `MiniMax-M1` - Historical MiniMax M1 model (1M context)
 
 ### Text Embedding Models
 - `embo-01` - MiniMax embedding model

--- a/xpertai/models/minimax/scripts/copy-assets.mjs
+++ b/xpertai/models/minimax/scripts/copy-assets.mjs
@@ -21,6 +21,27 @@ if (existsSync(sourceDir)) {
 const srcRoot = path.join(packageRoot, 'src')
 const distRoot = path.join(packageRoot, 'dist')
 
+function removeYamlFiles(dir) {
+  if (!existsSync(dir)) {
+    return
+  }
+
+  const entries = readdirSync(dir)
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry)
+    const stats = statSync(entryPath)
+
+    if (stats.isDirectory()) {
+      removeYamlFiles(entryPath)
+      if (readdirSync(entryPath).length === 0) {
+        rmSync(entryPath, { recursive: true, force: true })
+      }
+    } else if (entry.endsWith('.yaml') || entry.endsWith('.yml')) {
+      rmSync(entryPath, { force: true })
+    }
+  }
+}
+
 function copyYamlFiles(srcDir, destDir) {
   const entries = readdirSync(srcDir)
   for (const entry of entries) {
@@ -39,6 +60,7 @@ function copyYamlFiles(srcDir, destDir) {
 }
 
 if (existsSync(srcRoot)) {
+  removeYamlFiles(distRoot)
   copyYamlFiles(srcRoot, distRoot)
   // console.info('Copied all .yaml files from src to dist.')
 } else {

--- a/xpertai/models/minimax/src/llm/_position.yaml
+++ b/xpertai/models/minimax/src/llm/_position.yaml
@@ -6,4 +6,4 @@
 - MiniMax-M2.1
 - MiniMax-M2.1-highspeed
 - MiniMax-M2
-- MiniMax-M1
+- minimax-m1

--- a/xpertai/models/minimax/src/llm/_position.yaml
+++ b/xpertai/models/minimax/src/llm/_position.yaml
@@ -1,0 +1,9 @@
+- MiniMax-M2.7
+- MiniMax-M2.7-highspeed
+- MiniMax-M2.5
+- MiniMax-M2.5-highspeed
+- M2-her
+- MiniMax-M2.1
+- MiniMax-M2.1-highspeed
+- MiniMax-M2
+- MiniMax-M1

--- a/xpertai/models/minimax/src/llm/minimax-m1.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m1.yaml
@@ -1,4 +1,4 @@
-model: MiniMax-M1
+model: minimax-m1
 label:
   en_US: MiniMax-M1
 deprecated: true

--- a/xpertai/models/minimax/src/llm/minimax-m2.1-highspeed.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.1-highspeed.yaml
@@ -1,6 +1,7 @@
 model: MiniMax-M2.1-highspeed
 label:
   en_US: MiniMax-M2.1-highspeed
+deprecated: true
 model_type: llm
 features:
   - agent-thought
@@ -8,7 +9,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 196000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -31,7 +32,7 @@ parameter_rules:
   - name: frequency_penalty
     use_template: frequency_penalty
 pricing:
-  input: "2.1"
-  output: "8.4"
+  input: "4.2"
+  output: "16.8"
   unit: "0.000001"
   currency: RMB

--- a/xpertai/models/minimax/src/llm/minimax-m2.1.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.1.yaml
@@ -1,6 +1,7 @@
 model: MiniMax-M2.1
 label:
   en_US: MiniMax-M2.1
+deprecated: true
 model_type: llm
 features:
   - agent-thought
@@ -8,7 +9,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 196000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature

--- a/xpertai/models/minimax/src/llm/minimax-m2.5-highspeed.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.5-highspeed.yaml
@@ -8,7 +8,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 196000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -31,7 +31,7 @@ parameter_rules:
   - name: frequency_penalty
     use_template: frequency_penalty
 pricing:
-  input: "2.1"
+  input: "4.2"
   output: "16.8"
   unit: "0.000001"
   currency: RMB

--- a/xpertai/models/minimax/src/llm/minimax-m2.5.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.5.yaml
@@ -8,7 +8,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 196000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature

--- a/xpertai/models/minimax/src/llm/minimax-m2.7-highspeed.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.7-highspeed.yaml
@@ -1,7 +1,6 @@
-model: MiniMax-M1
+model: MiniMax-M2.7-highspeed
 label:
-  en_US: MiniMax-M1
-deprecated: true
+  en_US: MiniMax-M2.7-highspeed
 model_type: llm
 features:
   - agent-thought
@@ -9,7 +8,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 1000000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,15 +23,15 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     required: true
-    default: 8192
+    default: 10240
     min: 1
-    max: 80000
+    max: 128000
   - name: presence_penalty
     use_template: presence_penalty
   - name: frequency_penalty
     use_template: frequency_penalty
 pricing:
-  input: "0.8"
-  output: "8"
+  input: "4.2"
+  output: "16.8"
   unit: "0.000001"
   currency: RMB

--- a/xpertai/models/minimax/src/llm/minimax-m2.7.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.7.yaml
@@ -1,7 +1,6 @@
-model: MiniMax-M1
+model: MiniMax-M2.7
 label:
-  en_US: MiniMax-M1
-deprecated: true
+  en_US: MiniMax-M2.7
 model_type: llm
 features:
   - agent-thought
@@ -9,7 +8,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 1000000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature
@@ -24,15 +23,15 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     required: true
-    default: 8192
+    default: 10240
     min: 1
-    max: 80000
+    max: 128000
   - name: presence_penalty
     use_template: presence_penalty
   - name: frequency_penalty
     use_template: frequency_penalty
 pricing:
-  input: "0.8"
-  output: "8"
+  input: "2.1"
+  output: "8.4"
   unit: "0.000001"
   currency: RMB

--- a/xpertai/models/minimax/src/llm/minimax-m2.yaml
+++ b/xpertai/models/minimax/src/llm/minimax-m2.yaml
@@ -1,6 +1,7 @@
 model: MiniMax-M2
 label:
   en_US: MiniMax-M2
+deprecated: true
 model_type: llm
 features:
   - agent-thought
@@ -8,7 +9,7 @@ features:
   - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 196000
+  context_size: 204800
 parameter_rules:
   - name: temperature
     use_template: temperature

--- a/xpertai/models/minimax/src/manifest.yaml
+++ b/xpertai/models/minimax/src/manifest.yaml
@@ -18,7 +18,7 @@ meta:
 name: minimax
 plugins:
   models:
-  - provider/minimax.yaml
+  - minimax.yaml
 resource:
   memory: 1048576
   permission:

--- a/xpertai/models/minimax/src/minimax.yaml
+++ b/xpertai/models/minimax/src/minimax.yaml
@@ -1,0 +1,53 @@
+provider: minimax
+label:
+  en_US: MiniMax
+  zh_Hans: MiniMax
+description:
+  en_US: MiniMax models for chat, text embedding, and text-to-speech.
+  zh_Hans: MiniMax 提供的对话、文本嵌入和语音合成模型。
+icon_small:
+  en_US: icon_s_en.png
+icon_large:
+  en_US: icon_l_en.png
+background: '#EFF3FF'
+help:
+  title:
+    en_US: Get your API Key and Group ID from MiniMax
+    zh_Hans: 从 MiniMax 获取 API Key 和 Group ID
+  url:
+    en_US: https://platform.minimaxi.com/user-center/basic-information/interface-key
+supported_model_types:
+  - llm
+  - text-embedding
+  - tts
+configurate_methods:
+  - predefined-model
+provider_credential_schema:
+  credential_form_schemas:
+    - variable: api_key
+      label:
+        en_US: API Key
+        zh_Hans: API Key
+      type: secret-input
+      required: true
+      placeholder:
+        en_US: Enter your API Key
+        zh_Hans: 在此输入您的 API Key
+    - variable: group_id
+      label:
+        en_US: Group ID
+        zh_Hans: Group ID
+      type: text-input
+      required: true
+      placeholder:
+        en_US: Enter your Group ID
+        zh_Hans: 在此输入您的 Group ID
+    - variable: base_url
+      label:
+        en_US: Custom API endpoint URL
+        zh_Hans: 自定义 API endpoint 地址
+      type: text-input
+      required: false
+      placeholder:
+        en_US: Base URL, e.g. https://api.minimaxi.com/v1 or https://api.minimaxi.com
+        zh_Hans: Base URL，例如 https://api.minimaxi.com/v1 或 https://api.minimaxi.com

--- a/xpertai/models/minimax/src/types.ts
+++ b/xpertai/models/minimax/src/types.ts
@@ -30,7 +30,7 @@ export const SUPPORTED_LLM_MODELS = [
   'MiniMax-M2.1-highspeed',
   'MiniMax-M2',
   'M2-her',
-  'MiniMax-M1'
+  'minimax-m1'
 ];
 
 export const SUPPORTED_EMBEDDING_MODELS = ['embo-01'];

--- a/xpertai/models/minimax/src/types.ts
+++ b/xpertai/models/minimax/src/types.ts
@@ -22,13 +22,15 @@ export type MiniMaxModelCredentials = MiniMaxCredentials & {
 };
 
 export const SUPPORTED_LLM_MODELS = [
+  'MiniMax-M2.7',
+  'MiniMax-M2.7-highspeed',
   'MiniMax-M2.5',
   'MiniMax-M2.5-highspeed',
   'MiniMax-M2.1',
   'MiniMax-M2.1-highspeed',
   'MiniMax-M2',
   'M2-her',
-  'minimax-m1'
+  'MiniMax-M1'
 ];
 
 export const SUPPORTED_EMBEDDING_MODELS = ['embo-01'];

--- a/xpertai/tsconfig.json
+++ b/xpertai/tsconfig.json
@@ -148,6 +148,9 @@
       "path": "./middlewares/view-image"
     },
     {
+      "path": "./middlewares/file-memory-system"
+    },
+    {
       "path": "./models/siliconflow"
     },
     {


### PR DESCRIPTION
## Summary
- add the missing MiniMax provider schema so the plugin renders in the model provider UI
- refresh the MiniMax built-in LLM catalog with M2.7 and M2.7-highspeed, and mark older models as historical
- sync the xpertai workspace release metadata with a changeset and the required TypeScript project reference

## Validation
- `cd xpertai && pnpm install --lockfile-only`
- `cd xpertai && CI=true pnpm install --frozen-lockfile`
- `pnpm -C plugin-dev-harness build`
- `pnpm -C xpertai exec nx build @xpert-ai/plugin-minimax`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin ./models/minimax --verbose`
- verified the hot-patched plugin in the running xpert-pro instance and confirmed the MiniMax provider rendered correctly in settings

## Notes
- PR intentionally includes only MiniMax plugin files, the xpertai changeset, and the minimal workspace tsconfig sync needed for Nx TypeScript validation.
- `xpertai/pnpm-lock.yaml` did not change after `pnpm install --lockfile-only`.
