### PR TITLE
feat(xpertai): add advisor middleware plugin

### DIFF
--- a/xpertai/middlewares/advisor/.spec.swcrc
+++ b/xpertai/middlewares/advisor/.spec.swcrc
@@ -1,0 +1,22 @@
+{
+  "jsc": {
+    "target": "es2017",
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true,
+      "dynamicImport": true
+    },
+    "transform": {
+      "decoratorMetadata": true,
+      "legacyDecorator": true
+    },
+    "keepClassNames": true,
+    "externalHelpers": true,
+    "loose": true
+  },
+  "module": {
+    "type": "es6"
+  },
+  "sourceMaps": true,
+  "exclude": []
+}

--- a/xpertai/middlewares/advisor/README.md
+++ b/xpertai/middlewares/advisor/README.md
@@ -1,0 +1,39 @@
+# Advisor Middleware
+
+`@xpert-ai/plugin-advisor` adds a generic `advisor` tool to the agent runtime.
+
+The tool lets the executor consult a separately configured model for:
+
+- hard debugging
+- architecture tradeoffs
+- risky decisions
+- second opinions on a plan
+
+The plugin is provider-agnostic. It only depends on the configured Xpert model selection and does not assume Anthropic or any other vendor-specific protocol.
+
+## Key Behavior
+
+- injects an `advisor` tool into the runtime
+- appends a short executor prompt explaining when to use it
+- enforces per-run and optional per-session usage limits
+- forwards a curated slice of conversation history to the advisor model
+- returns the advisor result as a normal `ToolMessage`
+
+## Configuration
+
+- `advisorModel`: model selected with `ai-model-select`
+- `maxUsesPerRun`: per-run quota, default `3`
+- `maxUsesPerSession`: optional session quota
+- `appendSystemPrompt`: whether to guide the executor on advisor usage
+- `maxTokens` / `temperature`: internal advisor call settings
+- `context.*`: controls how much prior conversation is forwarded
+
+## Validation
+
+Run:
+
+```bash
+npx nx build @xpert-ai/plugin-advisor
+npx nx test @xpert-ai/plugin-advisor
+fnm exec --using=20 -- node ../plugin-dev-harness/dist/index.js --workspace . --plugin ./middlewares/advisor/dist/index.js
+```

--- a/xpertai/middlewares/advisor/jest.config.ts
+++ b/xpertai/middlewares/advisor/jest.config.ts
@@ -1,0 +1,19 @@
+/* eslint-disable */
+import { readFileSync } from 'fs'
+
+// Reading the SWC compilation config for the spec files
+const swcJestConfig = JSON.parse(readFileSync(`${__dirname}/.spec.swcrc`, 'utf-8'))
+
+// Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
+swcJestConfig.swcrc = false
+
+export default {
+  displayName: '@xpert-ai/plugin-advisor',
+  preset: '../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig]
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: 'test-output/jest/coverage'
+}

--- a/xpertai/middlewares/advisor/package.json
+++ b/xpertai/middlewares/advisor/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@xpert-ai/plugin-advisor",
+  "version": "0.0.1",
+  "author": {
+    "name": "XpertAI",
+    "url": "https://xpertai.cn"
+  },
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xpert-ai/xpert-plugins.git"
+  },
+  "bugs": {
+    "url": "https://github.com/xpert-ai/xpert-plugins/issues"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@xpert-plugins-starter/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "!**/*.tsbuildinfo"
+  ],
+  "dependencies": {
+    "tslib": "^2.3.0"
+  },
+  "peerDependencies": {
+    "@metad/contracts": "^3.8.3",
+    "@xpert-ai/plugin-sdk": "^3.8.3"
+  }
+}

--- a/xpertai/middlewares/advisor/src/index.ts
+++ b/xpertai/middlewares/advisor/src/index.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { XpertPlugin } from '@xpert-ai/plugin-sdk'
+import { AdvisorPluginModule } from './lib/advisor.module.js'
+import {
+  AdvisorPluginConfigFormSchema,
+  AdvisorPluginConfigSchema,
+  AdvisorPluginIcon
+} from './lib/advisor.types.js'
+
+const moduleDir = dirname(fileURLToPath(import.meta.url))
+
+const packageJson = JSON.parse(readFileSync(join(moduleDir, '../package.json'), 'utf8')) as {
+  name: string
+  version: string
+}
+
+const plugin: XpertPlugin = {
+  meta: {
+    name: packageJson.name,
+    version: packageJson.version,
+    level: 'organization',
+    category: 'middleware',
+    icon: {
+      type: 'svg',
+      value: AdvisorPluginIcon
+    },
+    displayName: 'Advisor Middleware',
+    description:
+      'Adds a configurable `advisor` tool that lets the executor consult a secondary model for hard debugging, tradeoffs, and planning decisions.',
+    keywords: ['advisor', 'middleware', 'agent', 'reasoning', 'model'],
+    author: 'XpertAI Team'
+  },
+  config: {
+    schema: AdvisorPluginConfigSchema,
+    formSchema: AdvisorPluginConfigFormSchema
+  },
+  register(ctx) {
+    ctx.logger.log('register advisor middleware plugin')
+    return { module: AdvisorPluginModule, global: true }
+  },
+  async onStart(ctx) {
+    ctx.logger.log('advisor middleware plugin started')
+  },
+  async onStop(ctx) {
+    ctx.logger.log('advisor middleware plugin stopped')
+  }
+}
+
+export * from './lib/advisor.middleware.js'
+export * from './lib/advisor.module.js'
+export * from './lib/advisor.types.js'
+export default plugin

--- a/xpertai/middlewares/advisor/src/lib/advisor.middleware.ts
+++ b/xpertai/middlewares/advisor/src/lib/advisor.middleware.ts
@@ -1,0 +1,479 @@
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models'
+import {
+  AIMessage,
+  HumanMessage,
+  SystemMessage,
+  ToolMessage,
+  type BaseMessage,
+  isAIMessage,
+  isSystemMessage,
+  isToolMessage
+} from '@langchain/core/messages'
+import { tool } from '@langchain/core/tools'
+import { Command } from '@langchain/langgraph'
+import { type ICopilotModel, type TAgentMiddlewareMeta } from '@metad/contracts'
+import { Injectable } from '@nestjs/common'
+import { CommandBus } from '@nestjs/cqrs'
+import {
+  AgentMiddleware,
+  AgentMiddlewareStrategy,
+  CreateModelClientCommand,
+  IAgentMiddlewareContext,
+  IAgentMiddlewareStrategy
+} from '@xpert-ai/plugin-sdk'
+import { z } from 'zod'
+import {
+  ADVISOR_METADATA_KEY,
+  ADVISOR_MIDDLEWARE_NAME,
+  ADVISOR_TOOL_NAME,
+  AdvisorContextConfigSchema,
+  type AdvisorPluginConfig,
+  AdvisorPluginConfigFormSchema,
+  AdvisorPluginConfigSchema,
+  type AdvisorState,
+  AdvisorStateSchema,
+  AdvisorToolInputSchema,
+  type ResolvedAdvisorPluginConfig
+} from './advisor.types.js'
+
+const INVALID_ADVISOR_INPUT =
+  'Invalid `advisor` input. Provide a non-empty `question` field before calling the advisor.'
+const ADVISOR_NO_TEXT_RESPONSE = 'Advisor returned no textual guidance.'
+
+const EXECUTOR_ADVISOR_PROMPT = [
+  '<advisor>',
+  'Use `advisor` sparingly for hard debugging, architecture tradeoffs, risky decisions, or when you need a second opinion.',
+  'Do not call `advisor` for routine execution, simple lookups, or obvious next steps.',
+  'When you call `advisor`, ask one concrete question that clearly states the blocker, tradeoff, or decision.',
+  '</advisor>'
+].join('\n')
+
+const DEFAULT_ADVISOR_SYSTEM_PROMPT = [
+  'You are an internal advisor tool helping another AI executor.',
+  'Provide concise, high-signal guidance that helps the executor decide what to do next.',
+  'Prioritize diagnosis, tradeoffs, hidden risks, and concrete next steps.',
+  'Do not answer as the end-user assistant and do not call tools.',
+  'If context is incomplete, make the best recommendation you can from the available information.'
+].join('\n')
+
+@Injectable()
+@AgentMiddlewareStrategy(ADVISOR_MIDDLEWARE_NAME)
+export class AdvisorMiddleware implements IAgentMiddlewareStrategy<Partial<AdvisorPluginConfig>> {
+  constructor(private readonly commandBus: CommandBus) {}
+
+  readonly meta: TAgentMiddlewareMeta = {
+    name: ADVISOR_MIDDLEWARE_NAME,
+    label: {
+      en_US: 'Advisor Middleware',
+      zh_Hans: '顾问中间件'
+    },
+    description: {
+      en_US:
+        'Adds a configurable `advisor` tool that lets the executor consult a secondary model for hard debugging, tradeoffs, and planning.',
+      zh_Hans:
+        '提供可配置的 `advisor` 工具，让执行器在复杂调试、权衡决策和规划场景下咨询一个辅助模型。'
+    },
+    icon: {
+      type: 'svg',
+      value:
+        '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none"><rect x="6" y="8" width="52" height="40" rx="12" fill="currentColor" opacity="0.12"/><path d="M19 22c0-5.523 4.477-10 10-10h6c5.523 0 10 4.477 10 10v7c0 5.523-4.477 10-10 10h-6l-8 8v-8c-3.314 0-6-2.686-6-6V22Z" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/><path d="M27 25h10M27 32h16" stroke="currentColor" stroke-width="4" stroke-linecap="round"/><circle cx="45" cy="47" r="9" fill="currentColor" opacity="0.18"/><path d="m41 47 3 3 6-6" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+    },
+    configSchema: AdvisorPluginConfigFormSchema
+  }
+
+  createMiddleware(
+    options: Partial<AdvisorPluginConfig>,
+    _context: IAgentMiddlewareContext
+  ): AgentMiddleware {
+    const config = resolveConfig(options)
+
+    if (!config.enabled) {
+      return {
+        name: ADVISOR_MIDDLEWARE_NAME
+      }
+    }
+
+    let advisorModelPromise: Promise<BaseChatModel> | null = null
+
+    const getAdvisorModel = async () => {
+      if (!advisorModelPromise) {
+        advisorModelPromise = this.commandBus.execute(
+          new CreateModelClientCommand<BaseChatModel>(buildInternalModelConfig(config.advisorModel, config), {
+            usageCallback: () => undefined
+          })
+        )
+      }
+      return advisorModelPromise
+    }
+
+    const advisorTool = createAdvisorTool()
+
+    return {
+      name: ADVISOR_MIDDLEWARE_NAME,
+      stateSchema: AdvisorStateSchema,
+      tools: [advisorTool],
+      beforeAgent: () => ({
+        advisorRunUses: 0
+      }),
+      wrapModelCall: async (request, handler) => {
+        const quota = evaluateQuota(config, request.state)
+        let nextRequest = request
+
+        if (quota.exhausted) {
+          const filteredTools = request.tools.filter((toolCandidate) => getToolName(toolCandidate) !== ADVISOR_TOOL_NAME)
+          if (filteredTools.length !== request.tools.length) {
+            nextRequest = {
+              ...nextRequest,
+              tools: filteredTools
+            }
+          }
+        } else if (config.appendSystemPrompt) {
+          nextRequest = {
+            ...nextRequest,
+            systemMessage: appendSystemPrompt(request.systemMessage?.content, EXECUTOR_ADVISOR_PROMPT)
+          }
+        }
+
+        return handler(nextRequest)
+      },
+      wrapToolCall: async (request, handler) => {
+        if (request.toolCall?.name !== ADVISOR_TOOL_NAME) {
+          return handler(request)
+        }
+
+        const parsedInput = AdvisorToolInputSchema.safeParse(normalizeToolArgs(request.toolCall?.args))
+        if (!parsedInput.success) {
+          return buildErrorToolMessage(request.toolCall?.id, INVALID_ADVISOR_INPUT)
+        }
+
+        const quota = evaluateQuota(config, request.state)
+        if (quota.exhausted) {
+          return buildErrorToolMessage(request.toolCall?.id, quota.reason)
+        }
+
+        try {
+          const advisorModel = await getAdvisorModel()
+          const advisorMessages = buildAdvisorMessages(parsedInput.data.question, request.state.messages, config)
+          const advisorResponse = await advisorModel.invoke(advisorMessages as BaseMessage[])
+          const content = extractTextContent(advisorResponse?.content).trim() || ADVISOR_NO_TEXT_RESPONSE
+          const nextRunUses = quota.runUses + 1
+          const nextSessionUses = quota.sessionUses + 1
+          const toolMessage = new ToolMessage({
+            name: ADVISOR_TOOL_NAME,
+            tool_call_id: normalizeToolCallId(request.toolCall?.id),
+            status: 'success',
+            content,
+            metadata: {
+              [ADVISOR_METADATA_KEY]: {
+                question: parsedInput.data.question,
+                advisorRunUses: nextRunUses,
+                advisorSessionUses: nextSessionUses
+              }
+            }
+          })
+
+          return new Command({
+            update: {
+              messages: [toolMessage],
+              advisorRunUses: nextRunUses,
+              advisorSessionUses: nextSessionUses
+            }
+          })
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error)
+          return buildErrorToolMessage(request.toolCall?.id, `Advisor model call failed: ${reason}`)
+        }
+      }
+    }
+  }
+}
+
+function resolveConfig(options?: Partial<AdvisorPluginConfig>): ResolvedAdvisorPluginConfig {
+  const parsed = AdvisorPluginConfigSchema.safeParse(options ?? {})
+  if (!parsed.success) {
+    throw new Error(renderZodError(parsed.error))
+  }
+
+  const config = parsed.data
+  if (config.enabled && !config.advisorModel) {
+    throw new Error('advisorModel is required when advisor middleware is enabled')
+  }
+
+  return {
+    ...config,
+    advisorModel: config.advisorModel as ICopilotModel,
+    context: AdvisorContextConfigSchema.parse(config.context ?? {})
+  }
+}
+
+function createAdvisorTool() {
+  return tool(async () => 'Advisor middleware intercepted this tool call before ordinary execution.', {
+    name: ADVISOR_TOOL_NAME,
+    description:
+      'Ask a secondary model for help with difficult debugging, architecture tradeoffs, risky decisions, or a second opinion. Do not use this for routine execution or simple lookups.',
+    schema: AdvisorToolInputSchema
+  })
+}
+
+function evaluateQuota(config: ResolvedAdvisorPluginConfig, state: Partial<AdvisorState> | undefined) {
+  const runUses = sanitizeCounter(state?.advisorRunUses)
+  const sessionUses = sanitizeCounter(state?.advisorSessionUses)
+  const runRemaining = Math.max(config.maxUsesPerRun - runUses, 0)
+  const sessionRemaining =
+    config.maxUsesPerSession === null ? null : Math.max(config.maxUsesPerSession - sessionUses, 0)
+  const exhausted = runRemaining <= 0 || (sessionRemaining !== null && sessionRemaining <= 0)
+  const reason =
+    sessionRemaining !== null && sessionRemaining <= 0
+      ? 'Advisor quota reached for this session. Continue without `advisor` until the session limit resets.'
+      : 'Advisor quota reached for this run. Continue without `advisor` until the next run starts.'
+
+  return {
+    exhausted,
+    reason,
+    runUses,
+    sessionUses
+  }
+}
+
+function sanitizeCounter(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+function buildInternalModelConfig(
+  advisorModel: ICopilotModel,
+  config: ResolvedAdvisorPluginConfig
+): ResolvedAdvisorPluginConfig['advisorModel'] {
+  const options = isRecord(advisorModel.options) ? advisorModel.options : {}
+
+  return {
+    ...advisorModel,
+    options: {
+      ...options,
+      streaming: false,
+      temperature: config.temperature,
+      max_tokens: config.maxTokens,
+      maxTokens: config.maxTokens
+    }
+  }
+}
+
+function appendSystemPrompt(existingContent: SystemMessage['content'] | undefined, prompt: string): SystemMessage {
+  if (typeof existingContent === 'string') {
+    return new SystemMessage({
+      content: [existingContent, prompt].filter(Boolean).join('\n\n')
+    })
+  }
+
+  if (Array.isArray(existingContent)) {
+    return new SystemMessage({
+      content: [...existingContent, { type: 'text', text: prompt }]
+    })
+  }
+
+  return new SystemMessage({
+    content: prompt
+  })
+}
+
+function buildAdvisorMessages(
+  question: string,
+  stateMessages: BaseMessage[] | undefined,
+  config: ResolvedAdvisorPluginConfig
+): BaseMessage[] {
+  return [
+    new SystemMessage({
+      content: [DEFAULT_ADVISOR_SYSTEM_PROMPT, config.advisorSystemPrompt].filter(Boolean).join('\n\n')
+    }),
+    ...curateContextMessages(stateMessages, config),
+    new HumanMessage({
+      content: ['The executor agent needs advice on the following question:', question].join('\n\n')
+    })
+  ]
+}
+
+function curateContextMessages(
+  stateMessages: BaseMessage[] | undefined,
+  config: ResolvedAdvisorPluginConfig
+): BaseMessage[] {
+  if (!Array.isArray(stateMessages) || stateMessages.length === 0) {
+    return []
+  }
+
+  const curated = stateMessages
+    .map((message) => sanitizeMessage(message, config))
+    .filter((message): message is BaseMessage => Boolean(message))
+
+  const limitedByCount =
+    config.context.maxContextMessages === null
+      ? curated
+      : curated.slice(-config.context.maxContextMessages)
+
+  if (config.context.maxContextChars === null) {
+    return limitedByCount
+  }
+
+  const result: BaseMessage[] = []
+  let totalChars = 0
+
+  for (let index = limitedByCount.length - 1; index >= 0; index--) {
+    const message = limitedByCount[index]
+    const size = estimateMessageChars(message)
+    if (result.length > 0 && totalChars + size > config.context.maxContextChars) {
+      break
+    }
+    totalChars += size
+    result.unshift(message)
+  }
+
+  return result
+}
+
+function sanitizeMessage(
+  message: BaseMessage,
+  config: ResolvedAdvisorPluginConfig
+): BaseMessage | null {
+  if (isSystemMessage(message) && !config.context.includeSystemPrompt) {
+    return null
+  }
+
+  if (isToolMessage(message) && !config.context.includeToolResults) {
+    return null
+  }
+
+  if (isAIMessage(message)) {
+    return stripAdvisorToolCall(message)
+  }
+
+  return message
+}
+
+function stripAdvisorToolCall(message: AIMessage): AIMessage | null {
+  if (!Array.isArray(message.tool_calls) || message.tool_calls.length === 0) {
+    return message
+  }
+
+  const toolCalls = message.tool_calls.filter((toolCall) => toolCall?.name !== ADVISOR_TOOL_NAME)
+  if (toolCalls.length === message.tool_calls.length) {
+    return message
+  }
+
+  if (toolCalls.length === 0 && !extractTextContent(message.content).trim()) {
+    return null
+  }
+
+  const filteredEntries = Object.fromEntries(
+    Object.entries(message as unknown as Record<string, unknown>).filter(([key]) => !key.startsWith('lc_'))
+  )
+  const additionalKwargs = isRecord(filteredEntries['additional_kwargs'])
+    ? {
+        ...filteredEntries['additional_kwargs']
+      }
+    : undefined
+
+  if (additionalKwargs && 'tool_calls' in additionalKwargs) {
+    delete additionalKwargs['tool_calls']
+  }
+
+  return new AIMessage({
+    ...(filteredEntries as Record<string, unknown>),
+    ...(additionalKwargs ? { additional_kwargs: additionalKwargs } : {}),
+    tool_calls: toolCalls
+  } as ConstructorParameters<typeof AIMessage>[0])
+}
+
+function estimateMessageChars(message: BaseMessage) {
+  const base = extractTextContent((message as { content?: unknown }).content).length
+
+  if (isToolMessage(message)) {
+    return base + (message.name?.length ?? 0)
+  }
+
+  if (isAIMessage(message) && Array.isArray(message.tool_calls)) {
+    return (
+      base +
+      message.tool_calls
+        .map((toolCall) => toolCall?.name?.length ?? 0)
+        .reduce((sum, value) => sum + value, 0)
+    )
+  }
+
+  return base
+}
+
+function buildErrorToolMessage(toolCallId: string | undefined, content: string) {
+  return new ToolMessage({
+    name: ADVISOR_TOOL_NAME,
+    tool_call_id: normalizeToolCallId(toolCallId),
+    status: 'error',
+    content
+  })
+}
+
+function normalizeToolArgs(rawArgs: unknown) {
+  if (!rawArgs || typeof rawArgs !== 'object' || Array.isArray(rawArgs)) {
+    return {}
+  }
+
+  const raw = rawArgs as Record<string, unknown>
+  const question = typeof raw['question'] === 'string' ? raw['question'].trim() : undefined
+
+  return question ? { question } : {}
+}
+
+function normalizeToolCallId(toolCallId: string | null | undefined) {
+  if (typeof toolCallId !== 'string') {
+    return ''
+  }
+
+  return toolCallId.trim()
+}
+
+function extractTextContent(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (typeof item === 'string') {
+          return item
+        }
+        if (isRecord(item) && typeof item['text'] === 'string') {
+          return item['text']
+        }
+        return ''
+      })
+      .filter(Boolean)
+      .join('\n')
+  }
+
+  if (isRecord(value)) {
+    return JSON.stringify(value)
+  }
+
+  return ''
+}
+
+function getToolName(toolCandidate: unknown) {
+  if (!toolCandidate || typeof toolCandidate !== 'object') {
+    return null
+  }
+
+  const name = (toolCandidate as { name?: unknown }).name
+  return typeof name === 'string' ? name : null
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null
+}
+
+function renderZodError(error: z.ZodError) {
+  return `Invalid advisor middleware options: ${error.issues
+    .map((issue) => `${issue.path.join('.') || 'root'}: ${issue.message}`)
+    .join('; ')}`
+}

--- a/xpertai/middlewares/advisor/src/lib/advisor.module.ts
+++ b/xpertai/middlewares/advisor/src/lib/advisor.module.ts
@@ -1,0 +1,23 @@
+import { CqrsModule } from '@nestjs/cqrs'
+import { IOnPluginBootstrap, IOnPluginDestroy, XpertServerPlugin } from '@xpert-ai/plugin-sdk'
+import { AdvisorMiddleware } from './advisor.middleware.js'
+
+@XpertServerPlugin({
+  imports: [CqrsModule],
+  providers: [AdvisorMiddleware]
+})
+export class AdvisorPluginModule implements IOnPluginBootstrap, IOnPluginDestroy {
+  private logEnabled = true
+
+  onPluginBootstrap(): void | Promise<void> {
+    if (this.logEnabled) {
+      console.log(`${AdvisorPluginModule.name} is being bootstrapped...`)
+    }
+  }
+
+  onPluginDestroy(): void | Promise<void> {
+    if (this.logEnabled) {
+      console.log(`${AdvisorPluginModule.name} is being destroyed...`)
+    }
+  }
+}

--- a/xpertai/middlewares/advisor/src/lib/advisor.spec.ts
+++ b/xpertai/middlewares/advisor/src/lib/advisor.spec.ts
@@ -1,0 +1,314 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  AgentMiddlewareStrategy: () => () => undefined,
+  CreateModelClientCommand: class CreateModelClientCommand<T = unknown> {
+    constructor(
+      public readonly modelConfig: unknown,
+      public readonly options?: unknown
+    ) {}
+  }
+}))
+
+jest.mock('@metad/contracts', () => ({
+  AiModelTypeEnum: {
+    LLM: 'LLM'
+  }
+}))
+
+import { AIMessage, HumanMessage, SystemMessage, ToolMessage } from '@langchain/core/messages'
+import { Command } from '@langchain/langgraph'
+import { AdvisorMiddleware } from './advisor.middleware.js'
+import { AdvisorPluginConfigFormSchema } from './advisor.types.js'
+
+describe('AdvisorMiddleware', () => {
+  function createSubject(options: Record<string, unknown> = {}) {
+    const commandBus = {
+      execute: jest.fn()
+    }
+    const strategy = new AdvisorMiddleware(commandBus as any)
+    const middleware = strategy.createMiddleware(
+      {
+        advisorModel: {
+          model: 'advisor-model'
+        },
+        ...options
+      },
+      {} as any
+    )
+
+    return {
+      commandBus,
+      strategy,
+      middleware
+    }
+  }
+
+  it('exposes the advisor config schema on middleware meta', () => {
+    const { strategy } = createSubject()
+
+    expect(strategy.meta.configSchema).toEqual(AdvisorPluginConfigFormSchema)
+  })
+
+  it('validates advisorModel when enabled', () => {
+    const commandBus = {
+      execute: jest.fn()
+    }
+    const strategy = new AdvisorMiddleware(commandBus as any)
+
+    expect(() => strategy.createMiddleware({}, {} as any)).toThrow(
+      'advisorModel is required when advisor middleware is enabled'
+    )
+  })
+
+  it('resets the run counter in beforeAgent', async () => {
+    const { middleware } = createSubject()
+
+    const result = await middleware.beforeAgent?.({ advisorRunUses: 9, advisorSessionUses: 4 } as any, {} as any)
+
+    expect(result).toEqual({
+      advisorRunUses: 0
+    })
+  })
+
+  it('appends the advisor executor prompt to the model call', async () => {
+    const { middleware } = createSubject()
+    const handler = jest.fn().mockResolvedValue(new AIMessage('ok'))
+
+    await middleware.wrapModelCall?.(
+      {
+        model: {} as any,
+        messages: [],
+        tools: [{ name: 'advisor' }],
+        state: {
+          advisorRunUses: 0,
+          advisorSessionUses: 0
+        },
+        runtime: {} as any,
+        systemMessage: new SystemMessage('base prompt')
+      } as any,
+      handler
+    )
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].systemMessage).toEqual(
+      new SystemMessage({
+        content: expect.stringContaining('Use `advisor` sparingly for hard debugging')
+      })
+    )
+  })
+
+  it('removes the advisor tool when quota is exhausted', async () => {
+    const { middleware } = createSubject({ maxUsesPerRun: 1 })
+    const handler = jest.fn().mockResolvedValue(new AIMessage('ok'))
+
+    await middleware.wrapModelCall?.(
+      {
+        model: {} as any,
+        messages: [],
+        tools: [{ name: 'advisor' }, { name: 'search' }],
+        state: {
+          advisorRunUses: 1,
+          advisorSessionUses: 0
+        },
+        runtime: {} as any
+      } as any,
+      handler
+    )
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler.mock.calls[0][0].tools).toEqual([{ name: 'search' }])
+  })
+
+  it('passes through non-advisor tools untouched', async () => {
+    const { middleware } = createSubject()
+    const handler = jest.fn().mockResolvedValue({ ok: true })
+    const request = {
+      tool: { name: 'search' },
+      toolCall: {
+        id: 'tool-call-1',
+        name: 'search',
+        args: {
+          query: 'latest logs'
+        }
+      },
+      state: {},
+      runtime: {} as any
+    }
+
+    const result = await middleware.wrapToolCall?.(request as any, handler as any)
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith(request)
+    expect(result).toEqual({ ok: true })
+  })
+
+  it('returns an error tool message for invalid advisor input', async () => {
+    const { middleware } = createSubject()
+    const handler = jest.fn()
+
+    const result = await middleware.wrapToolCall?.(
+      {
+        tool: { name: 'advisor' },
+        toolCall: {
+          id: 'tool-call-2',
+          name: 'advisor',
+          args: {
+            question: '   '
+          }
+        },
+        state: {},
+        runtime: {} as any
+      } as any,
+      handler as any
+    )
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(result).toBeInstanceOf(ToolMessage)
+    expect((result as ToolMessage).status).toBe('error')
+    expect((result as ToolMessage).content).toBe(
+      'Invalid `advisor` input. Provide a non-empty `question` field before calling the advisor.'
+    )
+  })
+
+  it('returns an error tool message when quota is exhausted at tool time', async () => {
+    const { middleware } = createSubject({ maxUsesPerSession: 2 })
+    const handler = jest.fn()
+
+    const result = await middleware.wrapToolCall?.(
+      {
+        tool: { name: 'advisor' },
+        toolCall: {
+          id: 'tool-call-3',
+          name: 'advisor',
+          args: {
+            question: 'Should I fallback to another parser?'
+          }
+        },
+        state: {
+          advisorRunUses: 0,
+          advisorSessionUses: 2
+        },
+        runtime: {} as any
+      } as any,
+      handler as any
+    )
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(result).toBeInstanceOf(ToolMessage)
+    expect((result as ToolMessage).status).toBe('error')
+    expect((result as ToolMessage).content).toContain('Advisor quota reached for this session')
+  })
+
+  it('returns a command with updated usage counters after advisor execution', async () => {
+    const { commandBus, middleware } = createSubject()
+    const invoke = jest.fn().mockResolvedValue(
+      new AIMessage({
+        content: 'Check the parser branch first, then add a fallback.'
+      })
+    )
+    commandBus.execute.mockResolvedValue({
+      invoke
+    })
+
+    const result = await middleware.wrapToolCall?.(
+      {
+        tool: { name: 'advisor' },
+        toolCall: {
+          id: 'tool-call-4',
+          name: 'advisor',
+          args: {
+            question: 'What is the safest fix path?'
+          }
+        },
+        state: {
+          advisorRunUses: 1,
+          advisorSessionUses: 5,
+          messages: [new HumanMessage('The plugin crashes after tool execution.')]
+        },
+        runtime: {} as any
+      } as any,
+      jest.fn() as any
+    )
+
+    expect(commandBus.execute).toHaveBeenCalledTimes(1)
+    expect(result).toBeInstanceOf(Command)
+    expect((result as any).update.advisorRunUses).toBe(2)
+    expect((result as any).update.advisorSessionUses).toBe(6)
+    expect((result as any).update.messages[0]).toBeInstanceOf(ToolMessage)
+    expect((result as any).update.messages[0].content).toContain('Check the parser branch first')
+  })
+
+  it('curates forwarded context and strips advisor tool calls and tool results when configured', async () => {
+    const { commandBus, middleware } = createSubject({
+      context: {
+        includeSystemPrompt: false,
+        includeToolResults: false,
+        maxContextMessages: 5,
+        maxContextChars: 1000
+      }
+    })
+    const invoke = jest.fn().mockResolvedValue(new AIMessage('Use the generic adapter boundary.'))
+    commandBus.execute.mockResolvedValue({
+      invoke
+    })
+
+    await middleware.wrapToolCall?.(
+      {
+        tool: { name: 'advisor' },
+        toolCall: {
+          id: 'tool-call-5',
+          name: 'advisor',
+          args: {
+            question: 'Should I keep provider logic outside the middleware core?'
+          }
+        },
+        state: {
+          advisorRunUses: 0,
+          advisorSessionUses: 0,
+          messages: [
+            new SystemMessage('executor system prompt'),
+            new HumanMessage('We need a generic middleware.'),
+            new ToolMessage({
+              name: 'search',
+              tool_call_id: 'search-1',
+              content: 'anthropic docs'
+            }),
+            new AIMessage({
+              content: 'I think we need an adapter layer.',
+              tool_calls: [
+                {
+                  id: 'call-advisor-1',
+                  name: 'advisor',
+                  args: {
+                    question: 'Help'
+                  },
+                  type: 'tool_call'
+                }
+              ]
+            })
+          ]
+        },
+        runtime: {} as any
+      } as any,
+      jest.fn() as any
+    )
+
+    expect(invoke).toHaveBeenCalledTimes(1)
+    const forwardedMessages = invoke.mock.calls[0][0]
+    expect(forwardedMessages[0]).toBeInstanceOf(SystemMessage)
+    expect(forwardedMessages.some((message: unknown) => message instanceof ToolMessage)).toBe(false)
+    expect(
+      forwardedMessages.some(
+        (message: unknown) => message instanceof HumanMessage && message.content === 'We need a generic middleware.'
+      )
+    ).toBe(true)
+    const sanitizedAiMessage = forwardedMessages.find((message: unknown) => message instanceof AIMessage) as AIMessage
+    expect(sanitizedAiMessage.tool_calls).toEqual([])
+    expect(sanitizedAiMessage.content).toBe('I think we need an adapter layer.')
+    expect(forwardedMessages[forwardedMessages.length - 1]).toEqual(
+      new HumanMessage({
+        content:
+          'The executor agent needs advice on the following question:\n\nShould I keep provider logic outside the middleware core?'
+      })
+    )
+  })
+})

--- a/xpertai/middlewares/advisor/src/lib/advisor.types.ts
+++ b/xpertai/middlewares/advisor/src/lib/advisor.types.ts
@@ -1,0 +1,224 @@
+import { AiModelTypeEnum, JsonSchemaObjectType, type ICopilotModel } from '@metad/contracts'
+import { z } from 'zod'
+
+export const ADVISOR_MIDDLEWARE_NAME = 'AdvisorMiddleware'
+export const ADVISOR_TOOL_NAME = 'advisor'
+export const ADVISOR_METADATA_KEY = 'advisor'
+
+export const AdvisorToolInputSchema = z.object({
+  question: z
+    .string()
+    .trim()
+    .min(1, 'question is required')
+    .describe(
+      'A focused question for the advisor model. Use this for debugging, architecture tradeoffs, risky decisions, or when you need a second opinion.'
+    )
+})
+
+export type AdvisorToolInput = z.input<typeof AdvisorToolInputSchema>
+export type ResolvedAdvisorToolInput = z.infer<typeof AdvisorToolInputSchema>
+
+export const AdvisorContextConfigSchema = z.object({
+  includeSystemPrompt: z.boolean().optional().default(true),
+  includeToolResults: z.boolean().optional().default(true),
+  maxContextMessages: z.number().int().positive().optional().nullable().default(12),
+  maxContextChars: z.number().int().positive().optional().nullable().default(12000)
+})
+
+export type AdvisorContextConfig = z.infer<typeof AdvisorContextConfigSchema>
+
+export const AdvisorPluginConfigSchema = z.object({
+  enabled: z.boolean().optional().default(true),
+  advisorModel: z.custom<ICopilotModel>((value) => Boolean(value)).optional(),
+  maxUsesPerRun: z.number().int().nonnegative().optional().default(3),
+  maxUsesPerSession: z.number().int().nonnegative().optional().nullable().default(null),
+  appendSystemPrompt: z.boolean().optional().default(true),
+  maxTokens: z.number().int().positive().optional().default(1024),
+  temperature: z.number().min(0).max(2).optional().default(0.7),
+  advisorSystemPrompt: z.string().trim().min(1).optional().nullable().default(null),
+  context: AdvisorContextConfigSchema.optional()
+})
+
+export type AdvisorPluginConfig = z.infer<typeof AdvisorPluginConfigSchema>
+
+export type ResolvedAdvisorPluginConfig = Omit<AdvisorPluginConfig, 'advisorModel' | 'context'> & {
+  advisorModel: ICopilotModel
+  context: AdvisorContextConfig
+}
+
+export const AdvisorStateSchema = z.object({
+  advisorSessionUses: z.number().int().nonnegative().default(0),
+  advisorRunUses: z.number().int().nonnegative().default(0)
+})
+
+export type AdvisorState = z.infer<typeof AdvisorStateSchema>
+
+export const AdvisorPluginConfigFormSchema: JsonSchemaObjectType = {
+  type: 'object',
+  properties: {
+    enabled: {
+      type: 'boolean',
+      title: {
+        en_US: 'Enabled',
+        zh_Hans: '启用'
+      },
+      description: {
+        en_US: 'Enable the advisor tool and middleware interception.',
+        zh_Hans: '启用 advisor 工具和中间件拦截。'
+      },
+      default: true
+    },
+    advisorModel: {
+      type: 'object',
+      title: {
+        en_US: 'Advisor Model',
+        zh_Hans: '顾问模型'
+      },
+      description: {
+        en_US: 'The secondary model used when the executor calls `advisor`.',
+        zh_Hans: '执行器调用 `advisor` 时使用的辅助模型。'
+      },
+      'x-ui': {
+        component: 'ai-model-select',
+        span: 2,
+        inputs: {
+          modelType: AiModelTypeEnum.LLM,
+          hiddenLabel: true
+        }
+      }
+    } as unknown as JsonSchemaObjectType['properties'][string],
+    maxUsesPerRun: {
+      type: 'number',
+      title: {
+        en_US: 'Max Uses Per Run',
+        zh_Hans: '单轮最大调用次数'
+      },
+      description: {
+        en_US: 'How many times the current run can call `advisor`.',
+        zh_Hans: '当前一轮执行最多可调用 `advisor` 的次数。'
+      },
+      default: 3
+    },
+    maxUsesPerSession: {
+      type: 'number',
+      title: {
+        en_US: 'Max Uses Per Session',
+        zh_Hans: '会话最大调用次数'
+      },
+      description: {
+        en_US: 'Optional session-wide limit. Leave empty for unlimited.',
+        zh_Hans: '可选的会话总限额，留空表示不限制。'
+      }
+    },
+    appendSystemPrompt: {
+      type: 'boolean',
+      title: {
+        en_US: 'Append Executor Prompt',
+        zh_Hans: '追加执行器提示'
+      },
+      description: {
+        en_US: 'Append a short instruction telling the executor when to use `advisor`.',
+        zh_Hans: '向执行器追加一段关于何时使用 `advisor` 的提示。'
+      },
+      default: true
+    },
+    maxTokens: {
+      type: 'number',
+      title: {
+        en_US: 'Advisor Max Tokens',
+        zh_Hans: '顾问最大输出令牌'
+      },
+      description: {
+        en_US: 'Maximum output tokens for the advisor model.',
+        zh_Hans: 'advisor 模型的最大输出令牌数。'
+      },
+      default: 1024
+    },
+    temperature: {
+      type: 'number',
+      title: {
+        en_US: 'Advisor Temperature',
+        zh_Hans: '顾问温度'
+      },
+      description: {
+        en_US: 'Sampling temperature for the advisor model.',
+        zh_Hans: 'advisor 模型采样温度。'
+      },
+      default: 0.7
+    },
+    advisorSystemPrompt: {
+      type: 'string',
+      title: {
+        en_US: 'Advisor System Prompt',
+        zh_Hans: '顾问系统提示词'
+      },
+      description: {
+        en_US: 'Optional extra system prompt appended before the advisor model call.',
+        zh_Hans: '调用 advisor 模型前追加的可选系统提示词。'
+      },
+      'x-ui': {
+        component: 'textarea',
+        span: 2
+      }
+    },
+    context: {
+      type: 'object',
+      title: {
+        en_US: 'Context',
+        zh_Hans: '上下文'
+      },
+      properties: {
+        includeSystemPrompt: {
+          type: 'boolean',
+          title: {
+            en_US: 'Include System Prompt',
+            zh_Hans: '包含系统提示词'
+          },
+          default: true
+        },
+        includeToolResults: {
+          type: 'boolean',
+          title: {
+            en_US: 'Include Tool Results',
+            zh_Hans: '包含工具结果'
+          },
+          default: true
+        },
+        maxContextMessages: {
+          type: 'number',
+          title: {
+            en_US: 'Max Context Messages',
+            zh_Hans: '最大上下文消息数'
+          },
+          description: {
+            en_US: 'Tail limit for forwarded conversation messages.',
+            zh_Hans: '转发给 advisor 的历史消息尾部数量限制。'
+          },
+          default: 12
+        },
+        maxContextChars: {
+          type: 'number',
+          title: {
+            en_US: 'Max Context Characters',
+            zh_Hans: '最大上下文字符数'
+          },
+          description: {
+            en_US: 'Tail character budget for forwarded conversation content.',
+            zh_Hans: '转发给 advisor 的历史内容字符预算。'
+          },
+          default: 12000
+        }
+      }
+    }
+  }
+}
+
+export const AdvisorPluginIcon = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect x="6" y="8" width="52" height="40" rx="12" fill="currentColor" opacity="0.12"/>
+  <path d="M19 22c0-5.523 4.477-10 10-10h6c5.523 0 10 4.477 10 10v7c0 5.523-4.477 10-10 10h-6l-8 8v-8c-3.314 0-6-2.686-6-6V22Z" stroke="currentColor" stroke-width="4" stroke-linejoin="round"/>
+  <path d="M27 25h10M27 32h16" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="45" cy="47" r="9" fill="currentColor" opacity="0.18"/>
+  <path d="m41 47 3 3 6-6" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
+`

--- a/xpertai/middlewares/advisor/tsconfig.json
+++ b/xpertai/middlewares/advisor/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/xpertai/middlewares/advisor/tsconfig.lib.json
+++ b/xpertai/middlewares/advisor/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [],
+  "exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/xpertai/middlewares/advisor/tsconfig.spec.json
+++ b/xpertai/middlewares/advisor/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/jest",
+    "types": ["jest", "node"],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/xpertai/pnpm-lock.yaml
+++ b/xpertai/pnpm-lock.yaml
@@ -672,6 +672,18 @@ importers:
         specifier: ^1.0.17
         version: 1.0.17
 
+  middlewares/advisor:
+    dependencies:
+      '@metad/contracts':
+        specifier: ^3.8.3
+        version: 3.8.3(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.19.0)(zod@3.25.67)))(signal-polyfill@0.2.2)
+      '@xpert-ai/plugin-sdk':
+        specifier: ^3.8.3
+        version: 3.8.4(1c71fb6577ea7c83c275767fc5cae2fc)
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+
   middlewares/agent-behavior-monitor:
     dependencies:
       '@langchain/core':

--- a/xpertai/tsconfig.json
+++ b/xpertai/tsconfig.json
@@ -155,6 +155,9 @@
     },
     {
       "path": "./models/hunyuan"
+    },
+    {
+      "path": "./middlewares/advisor"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a generic `@xpert-ai/plugin-advisor` middleware plugin in `xpertai/middlewares/advisor`
- expose configurable advisor model selection, quotas, context curation, and executor prompt injection
- add unit coverage and wire the new middleware project into the workspace

## Validation
- `NX_DAEMON=false npx nx build @xpert-ai/plugin-advisor`
- `NX_DAEMON=false npx nx test @xpert-ai/plugin-advisor`
- `fnm exec --using=20 -- node /Users/pony/Code/compony/unify/xpert-plugins/plugin-dev-harness/dist/index.js --workspace . --plugin ./middlewares/advisor/dist/index.js`