### PR TITLE
[codex] fix minimax reasoning output

### DIFF
--- a/xpertai/.changeset/minimax-reasoning-output.md
+++ b/xpertai/.changeset/minimax-reasoning-output.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-minimax": patch
+---
+
+Improve MiniMax reasoning output handling so streamed reasoning chunks preserve answer text, and add regression coverage for mixed reasoning and content deltas.

--- a/xpertai/models/minimax/src/llm/llm.spec.ts
+++ b/xpertai/models/minimax/src/llm/llm.spec.ts
@@ -172,6 +172,59 @@ describe('MiniMaxLargeLanguageModel', () => {
     );
   });
 
+  it('preserves answer text when a stream chunk contains both reasoning_details and content', async () => {
+    const model = llm.getChatModel(
+      createCopilotModel('MiniMax-M2.7-highspeed', {
+        streaming: true,
+        max_tokens: 256
+      })
+    ) as PatchedChatModel;
+
+    model.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: 'assistant',
+                reasoning_details: [
+                  {
+                    id: 'reasoning-text-1',
+                    type: 'reasoning.text',
+                    text: '先分析'
+                  }
+                ],
+                content: '最终'
+              }
+            }
+          ]
+        };
+
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '回答'
+              },
+              finish_reason: 'stop'
+            }
+          ],
+          model: 'MiniMax-M2.7-highspeed'
+        };
+      })();
+
+    model._getEstimatedTokenCountFromPrompt = async () => 0;
+    model._getNumTokensFromGenerations = async () => 0;
+
+    const result = await model._generate([new HumanMessage('你好')]);
+
+    expect(result.generations[0]?.text).toBe('最终回答');
+    expect(result.generations[0]?.message.content).toBe('最终回答');
+    expect(result.generations[0]?.message.additional_kwargs?.reasoning_content).toBe('先分析');
+  });
+
   it('falls back to extracting mixed think tags when reasoning_split is absent', async () => {
     const model = llm.getChatModel(
       createCopilotModel('MiniMax-M2.7-highspeed', {

--- a/xpertai/models/minimax/src/llm/llm.spec.ts
+++ b/xpertai/models/minimax/src/llm/llm.spec.ts
@@ -1,0 +1,220 @@
+import { HumanMessage } from '@langchain/core/messages';
+import { ICopilotModel } from '@metad/contracts';
+import { MiniMaxProviderStrategy } from '../provider.strategy.js';
+import { MiniMaxLargeLanguageModel } from './llm.js';
+
+type PatchedChatModel = ReturnType<MiniMaxLargeLanguageModel['getChatModel']> & {
+  completionWithRetry: (...args: unknown[]) => unknown;
+  invocationParams: (...args: unknown[]) => Record<string, unknown>;
+  _generate: (...args: unknown[]) => Promise<{
+    generations: Array<{
+      text: string;
+      message: {
+        content: string;
+        additional_kwargs?: Record<string, unknown>;
+      };
+    }>;
+  }>;
+  _getEstimatedTokenCountFromPrompt: (...args: unknown[]) => Promise<number>;
+  _getNumTokensFromGenerations: (...args: unknown[]) => Promise<number>;
+};
+
+function createCopilotModel(
+  model: string,
+  options: Record<string, unknown>,
+  credentials: Record<string, unknown> = {
+    api_key: 'test-key',
+    group_id: 'test-group'
+  }
+): ICopilotModel {
+  return {
+    model,
+    options,
+    copilot: {
+      modelProvider: {
+        credentials
+      }
+    }
+  } as unknown as ICopilotModel;
+}
+
+describe('MiniMaxLargeLanguageModel', () => {
+  let provider: MiniMaxProviderStrategy;
+  let llm: MiniMaxLargeLanguageModel;
+
+  beforeEach(() => {
+    provider = new MiniMaxProviderStrategy();
+    llm = new MiniMaxLargeLanguageModel(provider);
+  });
+
+  it('enables reasoning_split for MiniMax chat requests', () => {
+    const model = llm.getChatModel(
+      createCopilotModel('MiniMax-M2.7-highspeed', {
+        streaming: true,
+        max_tokens: 256
+      })
+    ) as PatchedChatModel;
+
+    const params = model.invocationParams();
+
+    expect(params.reasoning_split).toBe(true);
+  });
+
+  it('maps reasoning_details into reasoning_content for non-streaming responses', async () => {
+    const model = llm.getChatModel(
+      createCopilotModel('MiniMax-M2.7-highspeed', {
+        streaming: false,
+        max_tokens: 256
+      })
+    ) as PatchedChatModel;
+
+    const reasoningDetails = [
+      {
+        id: 'reasoning-text-1',
+        type: 'reasoning.text',
+        text: '内部思考'
+      }
+    ];
+
+    model.completionWithRetry = async () => ({
+      choices: [
+        {
+          message: {
+            role: 'assistant',
+            content: '最终回答',
+            reasoning_details: reasoningDetails
+          },
+          finish_reason: 'stop'
+        }
+      ],
+      usage: {}
+    });
+
+    const result = await model._generate([new HumanMessage('你好')]);
+
+    expect(result.generations[0]?.text).toBe('最终回答');
+    expect(result.generations[0]?.message.content).toBe('最终回答');
+    expect(result.generations[0]?.message.additional_kwargs?.reasoning_content).toBe('内部思考');
+    expect(result.generations[0]?.message.additional_kwargs?.reasoning_details).toEqual(reasoningDetails);
+  });
+
+  it('accumulates streamed reasoning_details without leaking them into content', async () => {
+    const model = llm.getChatModel(
+      createCopilotModel('MiniMax-M2.7-highspeed', {
+        streaming: true,
+        max_tokens: 256
+      })
+    ) as PatchedChatModel;
+
+    const finalReasoningDetails = [
+      {
+        id: 'reasoning-text-1',
+        type: 'reasoning.text',
+        text: '先分析，再收束'
+      }
+    ];
+
+    model.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: 'assistant',
+                reasoning_details: [
+                  {
+                    id: 'reasoning-text-1',
+                    type: 'reasoning.text',
+                    text: '先分析'
+                  }
+                ]
+              }
+            }
+          ]
+        };
+
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                reasoning_details: finalReasoningDetails
+              }
+            }
+          ]
+        };
+
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '最终回答'
+              },
+              finish_reason: 'stop'
+            }
+          ],
+          model: 'MiniMax-M2.7-highspeed'
+        };
+      })();
+
+    model._getEstimatedTokenCountFromPrompt = async () => 0;
+    model._getNumTokensFromGenerations = async () => 0;
+
+    const result = await model._generate([new HumanMessage('你好')]);
+
+    expect(result.generations[0]?.text).toBe('最终回答');
+    expect(result.generations[0]?.message.content).toBe('最终回答');
+    expect(result.generations[0]?.message.additional_kwargs?.reasoning_content).toBe('先分析，再收束');
+    expect(result.generations[0]?.message.additional_kwargs?.reasoning_details).toEqual(
+      finalReasoningDetails
+    );
+  });
+
+  it('falls back to extracting mixed think tags when reasoning_split is absent', async () => {
+    const model = llm.getChatModel(
+      createCopilotModel('MiniMax-M2.7-highspeed', {
+        streaming: true,
+        max_tokens: 256
+      })
+    ) as PatchedChatModel;
+
+    model.completionWithRetry = async () =>
+      (async function* () {
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: 'assistant',
+                content: '<think>先分析'
+              }
+            }
+          ]
+        };
+
+        yield {
+          choices: [
+            {
+              index: 0,
+              delta: {
+                content: '，再收束</think>最终回答'
+              },
+              finish_reason: 'stop'
+            }
+          ],
+          model: 'MiniMax-M2.7-highspeed'
+        };
+      })();
+
+    model._getEstimatedTokenCountFromPrompt = async () => 0;
+    model._getNumTokensFromGenerations = async () => 0;
+
+    const result = await model._generate([new HumanMessage('你好')]);
+
+    expect(result.generations[0]?.text).toBe('最终回答');
+    expect(result.generations[0]?.message.content).toBe('最终回答');
+    expect(result.generations[0]?.message.additional_kwargs?.reasoning_content).toBe('先分析，再收束');
+  });
+});

--- a/xpertai/models/minimax/src/llm/llm.ts
+++ b/xpertai/models/minimax/src/llm/llm.ts
@@ -206,6 +206,7 @@ class MiniMaxChatOAICompatReasoningModel extends ChatOAICompatReasoningModel {
     messageChunk.additional_kwargs ??= {};
 
     const choiceIndex = rawResponse.choices?.[0]?.index ?? 0;
+    let reasoningContent = '';
 
     if ('reasoning_details' in delta) {
       const reasoningText = extractReasoningText(delta.reasoning_details);
@@ -225,28 +226,34 @@ class MiniMaxChatOAICompatReasoningModel extends ChatOAICompatReasoningModel {
       messageChunk.additional_kwargs['reasoning_details'] = delta.reasoning_details;
 
       if (incrementalReasoning) {
-        messageChunk.additional_kwargs['reasoning_content'] = incrementalReasoning;
-      } else {
-        delete messageChunk.additional_kwargs['reasoning_content'];
+        reasoningContent += incrementalReasoning;
       }
-
-      messageChunk.content = '';
-      return messageChunk;
     }
 
     const rawContent = typeof delta.content === 'string' ? delta.content : '';
     if (!rawContent) {
+      if (reasoningContent) {
+        messageChunk.additional_kwargs['reasoning_content'] = reasoningContent;
+      } else {
+        delete messageChunk.additional_kwargs['reasoning_content'];
+      }
       return messageChunk;
     }
 
     const tagged = extractTaggedReasoning(rawContent, this.tagReasoningState.get(choiceIndex) ?? false);
     if (!tagged.handled) {
+      if (reasoningContent) {
+        messageChunk.additional_kwargs['reasoning_content'] = reasoningContent;
+      }
       return messageChunk;
     }
 
     this.tagReasoningState.set(choiceIndex, tagged.inReasoningMode);
     if (tagged.reasoning) {
-      messageChunk.additional_kwargs['reasoning_content'] = tagged.reasoning;
+      reasoningContent += tagged.reasoning;
+    }
+    if (reasoningContent) {
+      messageChunk.additional_kwargs['reasoning_content'] = reasoningContent;
     } else {
       delete messageChunk.additional_kwargs['reasoning_content'];
     }

--- a/xpertai/models/minimax/src/llm/llm.ts
+++ b/xpertai/models/minimax/src/llm/llm.ts
@@ -1,3 +1,6 @@
+import { AIMessage, AIMessageChunk, BaseMessage } from '@langchain/core/messages';
+import { ChatGenerationChunk } from '@langchain/core/outputs';
+import { OpenAIClient } from '@langchain/openai';
 import { Injectable } from '@nestjs/common';
 import { AiModelTypeEnum, ICopilotModel } from '@metad/contracts';
 import {
@@ -10,6 +13,286 @@ import {
 import { MiniMaxProviderStrategy } from '../provider.strategy.js';
 import { MiniMaxModelCredentials, SUPPORTED_LLM_MODELS, toCredentialKwargs } from '../types.js';
 
+const THINK_START_TAG = '<think>';
+const THINK_END_TAG = '</think>';
+
+type MiniMaxReasoningDetail = {
+  id?: string;
+  text?: string;
+  type?: string;
+  [key: string]: unknown;
+};
+
+function extractReasoningText(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const text = value
+      .map((item) => extractReasoningText(item))
+      .filter((item): item is string => typeof item === 'string' && item.length > 0)
+      .join('');
+
+    return text || undefined;
+  }
+
+  if (value && typeof value === 'object' && typeof (value as MiniMaxReasoningDetail).text === 'string') {
+    return (value as MiniMaxReasoningDetail).text;
+  }
+
+  return undefined;
+}
+
+function extractTaggedReasoning(
+  content: string,
+  isInReasoningMode: boolean
+): { handled: boolean; reasoning: string; text: string; inReasoningMode: boolean } {
+  if (!isInReasoningMode && !content.includes(THINK_START_TAG) && !content.includes(THINK_END_TAG)) {
+    return {
+      handled: false,
+      reasoning: '',
+      text: content,
+      inReasoningMode: false
+    };
+  }
+
+  let remaining = content;
+  let reasoning = '';
+  let text = '';
+  let inReasoningMode = isInReasoningMode;
+
+  while (remaining.length) {
+    if (inReasoningMode) {
+      const endIndex = remaining.indexOf(THINK_END_TAG);
+      if (endIndex === -1) {
+        reasoning += remaining;
+        remaining = '';
+        break;
+      }
+
+      reasoning += remaining.slice(0, endIndex);
+      remaining = remaining.slice(endIndex + THINK_END_TAG.length);
+      inReasoningMode = false;
+      continue;
+    }
+
+    const startIndex = remaining.indexOf(THINK_START_TAG);
+    if (startIndex === -1) {
+      text += remaining;
+      remaining = '';
+      break;
+    }
+
+    text += remaining.slice(0, startIndex);
+    remaining = remaining.slice(startIndex + THINK_START_TAG.length);
+    inReasoningMode = true;
+  }
+
+  return {
+    handled: true,
+    reasoning,
+    text,
+    inReasoningMode
+  };
+}
+
+class MiniMaxChatOAICompatReasoningModel extends ChatOAICompatReasoningModel {
+  private streamedReasoning = new Map<number, string>();
+  private streamedReasoningDetails = new Map<number, unknown>();
+  private tagReasoningState = new Map<number, boolean>();
+
+  override async _generate(
+    messages: BaseMessage[],
+    options?: Parameters<ChatOAICompatReasoningModel['_generate']>[1],
+    runManager?: Parameters<ChatOAICompatReasoningModel['_generate']>[2]
+  ) {
+    this.resetReasoningState();
+    const callOptions = options ?? {};
+
+    const params = this.invocationParams(callOptions);
+    if (!params.stream) {
+      return super._generate(messages, callOptions, runManager);
+    }
+
+    const stream = super._streamResponseChunks(messages, callOptions, runManager);
+    const finalChunks: Record<number, ChatGenerationChunk> = {};
+    const accumulatedReasoningContent: Record<number, string> = {};
+    const latestReasoningDetails: Record<number, unknown> = {};
+
+    for await (const chunk of stream) {
+      const message = chunk.message as AIMessageChunk & {
+        response_metadata?: Record<string, unknown>;
+      };
+      message.response_metadata = {
+        ...(chunk.generationInfo ?? {}),
+        ...message.response_metadata
+      };
+
+      const index = chunk.generationInfo?.completion ?? 0;
+      const chunkReasoning = message.additional_kwargs?.reasoning_content;
+      if (typeof chunkReasoning === 'string' && chunkReasoning.length > 0) {
+        accumulatedReasoningContent[index] = (accumulatedReasoningContent[index] ?? '') + chunkReasoning;
+      }
+
+      if ('reasoning_details' in (message.additional_kwargs ?? {})) {
+        latestReasoningDetails[index] = message.additional_kwargs?.reasoning_details;
+      }
+
+      if (finalChunks[index] === undefined) {
+        finalChunks[index] = chunk;
+      } else {
+        finalChunks[index] = finalChunks[index].concat(chunk);
+      }
+    }
+
+    const generations = Object.entries(finalChunks)
+      .sort(([aKey], [bKey]) => parseInt(aKey, 10) - parseInt(bKey, 10))
+      .map(([key, value]) => {
+        const index = parseInt(key, 10);
+        const message = value.message as AIMessageChunk;
+        message.additional_kwargs = {
+          ...message.additional_kwargs,
+          ...(index in accumulatedReasoningContent
+            ? { reasoning_content: accumulatedReasoningContent[index] ?? '' }
+            : {}),
+          ...(index in latestReasoningDetails
+            ? { reasoning_details: latestReasoningDetails[index] }
+            : {})
+        };
+
+        return value;
+      });
+
+    const { functions, function_call } = this.invocationParams(callOptions);
+    const promptTokenUsage = await this._getEstimatedTokenCountFromPrompt(
+      messages,
+      functions,
+      function_call
+    );
+    const completionTokenUsage = await this._getNumTokensFromGenerations(generations);
+
+    return {
+      generations,
+      llmOutput: {
+        estimatedTokenUsage: {
+          promptTokens: promptTokenUsage,
+          completionTokens: completionTokenUsage,
+          totalTokens: promptTokenUsage + completionTokenUsage
+        }
+      }
+    };
+  }
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options?: Parameters<ChatOAICompatReasoningModel['_streamResponseChunks']>[1],
+    runManager?: Parameters<ChatOAICompatReasoningModel['_streamResponseChunks']>[2]
+  ) {
+    this.resetReasoningState();
+    const callOptions = options ?? {};
+
+    for await (const chunk of super._streamResponseChunks(messages, callOptions, runManager)) {
+      yield chunk;
+    }
+  }
+
+  protected override _convertCompletionsDeltaToBaseMessageChunk(
+    delta: Record<string, any>,
+    rawResponse: OpenAIClient.ChatCompletionChunk,
+    defaultRole?: 'function' | 'user' | 'system' | 'developer' | 'assistant' | 'tool'
+  ) {
+    const messageChunk = super._convertCompletionsDeltaToBaseMessageChunk(delta, rawResponse, defaultRole);
+    messageChunk.additional_kwargs ??= {};
+
+    const choiceIndex = rawResponse.choices?.[0]?.index ?? 0;
+
+    if ('reasoning_details' in delta) {
+      const reasoningText = extractReasoningText(delta.reasoning_details);
+      const previousReasoning = this.streamedReasoning.get(choiceIndex) ?? '';
+      const nextReasoning = reasoningText
+        ? reasoningText.startsWith(previousReasoning)
+          ? reasoningText
+          : `${previousReasoning}${reasoningText}`
+        : previousReasoning;
+      const incrementalReasoning =
+        reasoningText && reasoningText.startsWith(previousReasoning)
+          ? reasoningText.slice(previousReasoning.length)
+          : reasoningText;
+
+      this.streamedReasoning.set(choiceIndex, nextReasoning);
+      this.streamedReasoningDetails.set(choiceIndex, delta.reasoning_details);
+      messageChunk.additional_kwargs['reasoning_details'] = delta.reasoning_details;
+
+      if (incrementalReasoning) {
+        messageChunk.additional_kwargs['reasoning_content'] = incrementalReasoning;
+      } else {
+        delete messageChunk.additional_kwargs['reasoning_content'];
+      }
+
+      messageChunk.content = '';
+      return messageChunk;
+    }
+
+    const rawContent = typeof delta.content === 'string' ? delta.content : '';
+    if (!rawContent) {
+      return messageChunk;
+    }
+
+    const tagged = extractTaggedReasoning(rawContent, this.tagReasoningState.get(choiceIndex) ?? false);
+    if (!tagged.handled) {
+      return messageChunk;
+    }
+
+    this.tagReasoningState.set(choiceIndex, tagged.inReasoningMode);
+    if (tagged.reasoning) {
+      messageChunk.additional_kwargs['reasoning_content'] = tagged.reasoning;
+    } else {
+      delete messageChunk.additional_kwargs['reasoning_content'];
+    }
+    messageChunk.content = tagged.text;
+
+    return messageChunk;
+  }
+
+  protected override _convertCompletionsMessageToBaseMessage(
+    message: OpenAIClient.ChatCompletionMessage & {
+      reasoning_details?: unknown;
+    },
+    rawResponse: OpenAIClient.ChatCompletion
+  ) {
+    const langChainMessage = super._convertCompletionsMessageToBaseMessage(message, rawResponse) as AIMessage;
+    langChainMessage.additional_kwargs ??= {};
+
+    if ('reasoning_details' in message) {
+      langChainMessage.additional_kwargs['reasoning_details'] = message.reasoning_details;
+      const reasoningText = extractReasoningText(message.reasoning_details);
+      if (reasoningText) {
+        langChainMessage.additional_kwargs['reasoning_content'] = reasoningText;
+      }
+      return langChainMessage;
+    }
+
+    if (typeof langChainMessage.content !== 'string') {
+      return langChainMessage;
+    }
+
+    const tagged = extractTaggedReasoning(langChainMessage.content, false);
+    if (tagged.handled && tagged.reasoning) {
+      langChainMessage.additional_kwargs['reasoning_content'] = tagged.reasoning;
+      langChainMessage.content = tagged.text;
+    }
+
+    return langChainMessage;
+  }
+
+  private resetReasoningState() {
+    this.streamedReasoning.clear();
+    this.streamedReasoningDetails.clear();
+    this.tagReasoningState.clear();
+  }
+}
+
 @Injectable()
 export class MiniMaxLargeLanguageModel extends LargeLanguageModel {
   constructor(modelProvider: MiniMaxProviderStrategy) {
@@ -17,7 +300,7 @@ export class MiniMaxLargeLanguageModel extends LargeLanguageModel {
   }
 
   protected createChatModel(params: object) {
-    return new ChatOAICompatReasoningModel(params);
+    return new MiniMaxChatOAICompatReasoningModel(params);
   }
 
   override getChatModel(copilotModel: ICopilotModel, options?: TChatModelOptions) {
@@ -31,6 +314,9 @@ export class MiniMaxLargeLanguageModel extends LargeLanguageModel {
     return this.createChatModel({
       ...params,
       model,
+      modelKwargs: {
+        reasoning_split: true
+      },
       streaming: copilotModel.options?.['streaming'] ?? true,
       temperature: copilotModel.options?.['temperature'] ?? 0,
       maxTokens: copilotModel.options?.['max_tokens'],


### PR DESCRIPTION
## Summary
- improve MiniMax reasoning separation so streamed `reasoning_details` chunks no longer swallow answer text when `content` arrives in the same delta
- add regression coverage for mixed `reasoning_details + content` streaming chunks
- add `xpertai/.changeset/minimax-reasoning-output.md` so the PR is release-ready for the xpertai workspace

## Validation
- `cd xpertai && pnpm install --lockfile-only`
- `cd xpertai && CI=true pnpm install --frozen-lockfile`
- `cd xpertai && ./node_modules/.bin/nx build @xpert-ai/plugin-minimax`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-minimax`

## Notes
- PR intentionally includes only MiniMax plugin files plus the xpertai changeset.
- Root `.gitignore` remains uncommitted and is not part of this PR.
