### PR TITLE
feat(openai): align GPT-5 reasoning and validation

### DIFF
--- a/xpertai/.changeset/openai-gpt5-refresh.md
+++ b/xpertai/.changeset/openai-gpt5-refresh.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-openai": patch
+---
+
+Align GPT-5 reasoning options with the latest OpenAI model support, improve provider validation fallback for custom OpenAI-compatible endpoints, and preserve reasoning summaries from Responses API output.

--- a/xpertai/models/openai/package.json
+++ b/xpertai/models/openai/package.json
@@ -32,6 +32,7 @@
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
+    "build": "tsc --build tsconfig.lib.json && node ./scripts/copy-assets.mjs",
     "test": "jest",
     "prepack": "node ./scripts/copy-assets.mjs"
   },

--- a/xpertai/models/openai/project.json
+++ b/xpertai/models/openai/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "@xpert-ai/plugin-openai",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "models/openai/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "models/openai/dist",
+        "main": "models/openai/src/index.ts",
+        "rootDir": "models/openai/src",
+        "tsConfig": "models/openai/tsconfig.lib.json",
+        "generatePackageJson": false,
+        "assets": [
+          {
+            "glob": "**/*.yaml",
+            "input": "models/openai/src",
+            "output": "./"
+          },
+          {
+            "glob": "**/*.svg",
+            "input": "models/openai/src/_assets",
+            "output": "./_assets"
+          }
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/xpertai/models/openai/src/llm/gpt-5.2-codex.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2-codex.yaml
@@ -47,13 +47,13 @@ parameter_rules:
     required: false
     default: medium
     options:
-      - minimal
       - low
       - medium
       - high
+      - xhigh
     help:
-      zh_Hans: 控制模型推理的深度。high 提供最深度的推理，minimal 适合更快的响应。
-      en_US: Controls how much reasoning effort the model uses. high provides the deepest reasoning, while minimal favors faster responses.
+      zh_Hans: 控制模型推理的深度。xhigh 提供最深推理，适合更复杂的编码任务。
+      en_US: Controls how much reasoning effort the model uses. xhigh provides the deepest reasoning for more complex coding tasks.
   - name: frequency_penalty
     use_template: frequency_penalty
     default: 0

--- a/xpertai/models/openai/src/llm/gpt-5.2-pro.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2-pro.yaml
@@ -30,13 +30,12 @@ parameter_rules:
     required: false
     default: medium
     options:
-      - minimal
-      - low
       - medium
       - high
+      - xhigh
     help:
-      zh_Hans: 控制模型推理的深度。high 提供最深度的推理，minimal 适合更快的响应。
-      en_US: Controls how much reasoning effort the model uses. high provides the deepest reasoning, while minimal favors faster responses.
+      zh_Hans: 控制模型推理的深度。Pro 模型从 medium 起步，xhigh 适合最复杂的问题。
+      en_US: Controls how much reasoning effort the model uses. Pro models start at medium, while xhigh is best for the hardest problems.
   - name: frequency_penalty
     use_template: frequency_penalty
     default: 0

--- a/xpertai/models/openai/src/llm/gpt-5.2.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2.yaml
@@ -45,15 +45,16 @@ parameter_rules:
       en_US: Reasoning Effort
     type: string
     required: false
-    default: medium
+    default: none
     options:
-      - minimal
+      - none
       - low
       - medium
       - high
+      - xhigh
     help:
-      zh_Hans: 控制模型推理的深度。high 提供最深度的推理，minimal 适合更快的响应。
-      en_US: Controls how much reasoning effort the model uses. high provides the deepest reasoning, while minimal favors faster responses.
+      zh_Hans: 控制模型推理的深度。none 为默认值，xhigh 提供最深推理但通常延迟更高。
+      en_US: Controls how much reasoning effort the model uses. none is the default, while xhigh provides the deepest reasoning at higher latency.
   - name: frequency_penalty
     use_template: frequency_penalty
     default: 0

--- a/xpertai/models/openai/src/llm/gpt-5.3-codex.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.3-codex.yaml
@@ -47,13 +47,13 @@ parameter_rules:
     required: false
     default: medium
     options:
-      - minimal
       - low
       - medium
       - high
+      - xhigh
     help:
-      zh_Hans: 控制模型推理的深度。high 提供最深度的推理，minimal 适合更快的响应。
-      en_US: Controls how much reasoning effort the model uses. high provides the deepest reasoning, while minimal favors faster responses.
+      zh_Hans: 控制模型推理的深度。xhigh 提供最深推理，适合更复杂的编码任务。
+      en_US: Controls how much reasoning effort the model uses. xhigh provides the deepest reasoning for more complex coding tasks.
   - name: frequency_penalty
     use_template: frequency_penalty
     default: 0

--- a/xpertai/models/openai/src/llm/gpt-5.4-pro.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.4-pro.yaml
@@ -30,13 +30,12 @@ parameter_rules:
     required: false
     default: medium
     options:
-      - minimal
-      - low
       - medium
       - high
+      - xhigh
     help:
-      zh_Hans: 控制模型推理的深度。high 提供最深度的推理，minimal 适合更快的响应。
-      en_US: Controls how much reasoning effort the model uses. high provides the deepest reasoning, while minimal favors faster responses.
+      zh_Hans: 控制模型推理的深度。Pro 模型从 medium 起步，xhigh 适合最复杂的问题。
+      en_US: Controls how much reasoning effort the model uses. Pro models start at medium, while xhigh is best for the hardest problems.
   - name: frequency_penalty
     use_template: frequency_penalty
     default: 0

--- a/xpertai/models/openai/src/llm/gpt-5.4.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.4.yaml
@@ -45,15 +45,16 @@ parameter_rules:
       en_US: Reasoning Effort
     type: string
     required: false
-    default: medium
+    default: none
     options:
-      - minimal
+      - none
       - low
       - medium
       - high
+      - xhigh
     help:
-      zh_Hans: 控制模型推理的深度。high 提供最深度的推理，minimal 适合更快的响应。
-      en_US: Controls how much reasoning effort the model uses. high provides the deepest reasoning, while minimal favors faster responses.
+      zh_Hans: 控制模型推理的深度。none 为默认值，xhigh 提供最深推理但通常延迟更高。
+      en_US: Controls how much reasoning effort the model uses. none is the default, while xhigh provides the deepest reasoning at higher latency.
   - name: frequency_penalty
     use_template: frequency_penalty
     default: 0

--- a/xpertai/models/openai/src/llm/llm.spec.ts
+++ b/xpertai/models/openai/src/llm/llm.spec.ts
@@ -44,8 +44,20 @@ describe('OpenAILargeLanguageModel', () => {
     expect(params.temperature).toBe(0.4)
     expect(params.top_p).toBe(0.7)
     expect(params.max_output_tokens).toBe(1024)
-    expect(params.reasoning).toEqual({ effort: 'high' })
+    expect(params.reasoning).toEqual({ effort: 'high', summary: 'auto' })
     expect(params.text?.format).toEqual({ type: 'json_object' })
+  })
+
+  it('normalizes legacy GPT-5.4 reasoning values to the official enum', () => {
+    const model = llm.getChatModel(
+      createCopilotModel('gpt-5.4', {
+        reasoning_effort: 'minimal',
+      })
+    )
+
+    const params = (model as any).invocationParams()
+
+    expect(params.reasoning).toEqual({ effort: 'none', summary: 'auto' })
   })
 
   it('suppresses unsupported GPT-5 Pro parameters on the official endpoint', () => {
@@ -54,7 +66,7 @@ describe('OpenAILargeLanguageModel', () => {
         temperature: 0.4,
         top_p: 0.7,
         response_format: 'json_object',
-        reasoning_effort: 'minimal',
+        reasoning_effort: 'low',
       })
     )
 
@@ -62,8 +74,20 @@ describe('OpenAILargeLanguageModel', () => {
 
     expect(params.temperature).toBeUndefined()
     expect(params.top_p).toBeUndefined()
-    expect(params.reasoning).toEqual({ effort: 'minimal' })
+    expect(params.reasoning).toEqual({ effort: 'medium', summary: 'auto' })
     expect(params.text?.format).toBeUndefined()
+  })
+
+  it('normalizes legacy Codex reasoning values to the supported enum', () => {
+    const model = llm.getChatModel(
+      createCopilotModel('gpt-5.3-codex', {
+        reasoning_effort: 'minimal',
+      })
+    )
+
+    const params = (model as any).invocationParams()
+
+    expect(params.reasoning).toEqual({ effort: 'low', summary: 'auto' })
   })
 
   it('keeps auto sampling disabled for custom endpoints', () => {

--- a/xpertai/models/openai/src/llm/llm.ts
+++ b/xpertai/models/openai/src/llm/llm.ts
@@ -1,5 +1,5 @@
 import { HumanMessage } from '@langchain/core/messages'
-import { ChatOpenAI } from '@langchain/openai'
+import { ChatOpenAI, OpenAIClient } from '@langchain/openai'
 import { AiModelTypeEnum, ICopilotModel } from '@metad/contracts'
 import { Injectable, Logger } from '@nestjs/common'
 import {
@@ -10,6 +10,8 @@ import {
 } from '@xpert-ai/plugin-sdk'
 import { isNil, omitBy } from 'lodash-es'
 import {
+  getSupportedOpenAIReasoningEfforts,
+  normalizeOpenAIReasoningEffort,
   OpenAICredentials,
   OpenAIModelOptions,
   shouldEnableResponseFormat,
@@ -17,6 +19,11 @@ import {
   toCredentialKwargs
 } from '../types.js'
 import { OpenAIProviderStrategy } from '../provider.strategy.js'
+import { OpenAIReasoningResponsesModel } from './reasoning.js'
+
+type OpenAIReasoningRequest = Omit<OpenAIClient.Reasoning, 'effort'> & {
+  effort?: OpenAIModelOptions['reasoning_effort']
+}
 
 @Injectable()
 export class OpenAILargeLanguageModel extends LargeLanguageModel {
@@ -42,6 +49,21 @@ export class OpenAILargeLanguageModel extends LargeLanguageModel {
     }
   }
 
+  private getReasoningOptions(model: string, reasoningEffort?: OpenAIModelOptions['reasoning_effort']) {
+    if (!getSupportedOpenAIReasoningEfforts(model)) {
+      return undefined
+    }
+
+    return {
+      ...(reasoningEffort ? { effort: reasoningEffort } : {}),
+      summary: 'auto' as const
+    }
+  }
+
+  private toLangChainReasoning(reasoning?: OpenAIReasoningRequest) {
+    return reasoning as OpenAIClient.Reasoning | undefined
+  }
+
   override getChatModel(copilotModel: ICopilotModel, options?: TChatModelOptions) {
     const { handleLLMTokens } = options ?? {}
     const { copilot } = copilotModel
@@ -57,6 +79,9 @@ export class OpenAILargeLanguageModel extends LargeLanguageModel {
       params.configuration?.baseURL,
       model
     )
+    const reasoningEffort = normalizeOpenAIReasoningEffort(model, modelOptions?.reasoning_effort)
+    const reasoning = this.getReasoningOptions(model, reasoningEffort)
+    const langChainReasoning = this.toLangChainReasoning(reasoning)
     const supportsResponseFormat = shouldEnableResponseFormat(params.configuration?.baseURL, model)
     const responseFormat =
       supportsResponseFormat && modelOptions?.response_format
@@ -75,9 +100,12 @@ export class OpenAILargeLanguageModel extends LargeLanguageModel {
         presencePenalty: modelOptions?.presence_penalty,
         maxRetries: modelOptions?.maxRetries,
         useResponsesApi: true,
-        reasoning: modelOptions?.reasoning_effort
-          ? { effort: modelOptions.reasoning_effort }
-          : undefined,
+        reasoning: langChainReasoning,
+        responses: new OpenAIReasoningResponsesModel({
+          ...params,
+          model,
+          reasoning: langChainReasoning
+        }),
         streamUsage: streaming,
       },
       isNil

--- a/xpertai/models/openai/src/llm/reasoning.ts
+++ b/xpertai/models/openai/src/llm/reasoning.ts
@@ -1,0 +1,83 @@
+import { AIMessage, AIMessageChunk } from '@langchain/core/messages'
+import { ChatGenerationChunk } from '@langchain/core/outputs'
+import { ChatOpenAIResponses, OpenAIClient } from '@langchain/openai'
+
+type OpenAIReasoningSummaryPart = {
+  text?: string
+}
+
+type OpenAIReasoningSummary = {
+  summary?: OpenAIReasoningSummaryPart[]
+}
+
+function extractReasoningSummaryText(reasoning: unknown): string | undefined {
+  if (!reasoning || typeof reasoning !== 'object') {
+    return undefined
+  }
+
+  const summary = (reasoning as OpenAIReasoningSummary).summary
+  if (!Array.isArray(summary)) {
+    return undefined
+  }
+
+  const text = summary
+    .map((item) => (typeof item?.text === 'string' ? item.text : ''))
+    .join('')
+    .trim()
+
+  return text || undefined
+}
+
+function extractReasoningDeltaText(chunk: OpenAIClient.Responses.ResponseStreamEvent): string | undefined {
+  if (chunk.type === 'response.reasoning_summary_text.delta') {
+    return chunk.delta || undefined
+  }
+
+  if (chunk.type === 'response.reasoning_summary_part.added' && typeof chunk.part?.text === 'string') {
+    return chunk.part.text || undefined
+  }
+
+  return undefined
+}
+
+export class OpenAIReasoningResponsesModel extends ChatOpenAIResponses {
+  protected override _convertResponsesMessageToBaseMessage(
+    response: OpenAIClient.Responses.Response
+  ) {
+    const message = super._convertResponsesMessageToBaseMessage(response) as AIMessage
+    const reasoningContent = extractReasoningSummaryText(message.additional_kwargs?.reasoning)
+
+    if (reasoningContent) {
+      message.additional_kwargs = {
+        ...message.additional_kwargs,
+        reasoning_content: reasoningContent
+      }
+    }
+
+    return message
+  }
+
+  protected override _convertResponsesDeltaToBaseMessageChunk(
+    chunk: OpenAIClient.Responses.ResponseStreamEvent
+  ): ChatGenerationChunk | null {
+    const generationChunk = super._convertResponsesDeltaToBaseMessageChunk(chunk)
+    if (!generationChunk) {
+      return null
+    }
+
+    const message = generationChunk.message as AIMessageChunk
+    const reasoningContent =
+      extractReasoningDeltaText(chunk) ?? extractReasoningSummaryText(message.additional_kwargs?.reasoning)
+
+    if (reasoningContent) {
+      message.additional_kwargs = {
+        ...message.additional_kwargs,
+        reasoning_content: reasoningContent
+      }
+      message.content = ''
+      generationChunk.text = ''
+    }
+
+    return generationChunk
+  }
+}

--- a/xpertai/models/openai/src/provider.strategy.spec.ts
+++ b/xpertai/models/openai/src/provider.strategy.spec.ts
@@ -1,0 +1,61 @@
+const validateCredentials = jest.fn()
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  AIModelProviderStrategy: () => () => undefined,
+  ModelProvider: class {
+    getModelManager() {
+      return {
+        validateCredentials
+      }
+    }
+
+    getProviderSchema() {
+      return { provider: 'openai' }
+    }
+  },
+  CredentialsValidateFailedError: class extends Error {}
+}))
+
+import { CredentialsValidateFailedError } from '@xpert-ai/plugin-sdk'
+import { OpenAIProviderStrategy } from './provider.strategy.js'
+import { OpenAICredentials } from './types.js'
+
+describe('OpenAIProviderStrategy', () => {
+  let strategy: OpenAIProviderStrategy
+  let credentials: OpenAICredentials
+
+  beforeEach(() => {
+    validateCredentials.mockReset()
+    strategy = new OpenAIProviderStrategy()
+    credentials = {
+      api_key: 'test-api-key'
+    }
+  })
+
+  it('prefers GPT-5.4 for provider credential validation', async () => {
+    validateCredentials.mockResolvedValue(undefined)
+
+    await expect(strategy.validateProviderCredentials(credentials)).resolves.toBeUndefined()
+    expect(validateCredentials).toHaveBeenCalledTimes(1)
+    expect(validateCredentials).toHaveBeenCalledWith('gpt-5.4', credentials)
+  })
+
+  it('falls back to older GPT-5 models when the first candidate is unsupported', async () => {
+    validateCredentials
+      .mockRejectedValueOnce(new CredentialsValidateFailedError("The 'gpt-5.4' model is not supported"))
+      .mockResolvedValueOnce(undefined)
+
+    await expect(strategy.validateProviderCredentials(credentials)).resolves.toBeUndefined()
+    expect(validateCredentials).toHaveBeenNthCalledWith(1, 'gpt-5.4', credentials)
+    expect(validateCredentials).toHaveBeenNthCalledWith(2, 'gpt-5', credentials)
+  })
+
+  it('does not retry when the failure is unrelated to model availability', async () => {
+    const error = new CredentialsValidateFailedError('Incorrect API key provided')
+    validateCredentials.mockRejectedValue(error)
+
+    await expect(strategy.validateProviderCredentials(credentials)).rejects.toBe(error)
+    expect(validateCredentials).toHaveBeenCalledTimes(1)
+    expect(validateCredentials).toHaveBeenCalledWith('gpt-5.4', credentials)
+  })
+})

--- a/xpertai/models/openai/src/provider.strategy.ts
+++ b/xpertai/models/openai/src/provider.strategy.ts
@@ -11,6 +11,29 @@ import {
   toCredentialKwargs,
 } from './types.js'
 
+const OpenAIValidationModels = ['gpt-5.4', 'gpt-5', 'gpt-5.2'] as const
+
+const OpenAIValidationFallbackPatterns = [
+  'model is not supported',
+  'unsupported model',
+  'does not exist',
+  'unknown model',
+  'invalid model',
+  'unrecognized model',
+  'no such model',
+  'not found',
+  'not available',
+] as const
+
+function shouldRetryWithNextValidationModel(error: unknown): boolean {
+  if (!(error instanceof CredentialsValidateFailedError)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return OpenAIValidationFallbackPatterns.some((pattern) => message.includes(pattern))
+}
+
 @Injectable()
 @AIModelProviderStrategy(OpenAIProvider)
 export class OpenAIProviderStrategy extends ModelProvider {
@@ -26,16 +49,39 @@ export class OpenAIProviderStrategy extends ModelProvider {
   }
 
   async validateProviderCredentials(credentials: OpenAICredentials): Promise<void> {
-    try {
-      const modelInstance = this.getModelManager(AiModelTypeEnum.LLM)
-      await modelInstance.validateCredentials('gpt-5', credentials)
-    } catch (ex: any) {
-      if (ex instanceof CredentialsValidateFailedError) {
-        throw ex
-      } else {
-        this.logger.error(`${this.getProviderSchema().provider}: credentials verification failed`, ex.stack)
-        throw ex
+    const modelInstance = this.getModelManager(AiModelTypeEnum.LLM)
+    let lastError: unknown
+
+    for (const model of OpenAIValidationModels) {
+      try {
+        await modelInstance.validateCredentials(model, credentials)
+        return
+      } catch (ex: unknown) {
+        lastError = ex
+
+        if (!shouldRetryWithNextValidationModel(ex)) {
+          if (ex instanceof CredentialsValidateFailedError) {
+            throw ex
+          } else {
+            this.logger.error(`${this.getProviderSchema().provider}: credentials verification failed`, (ex as any)?.stack)
+            throw ex
+          }
+        }
+
+        this.logger.warn(
+          `${this.getProviderSchema().provider}: validation model '${model}' unavailable, trying next candidate`
+        )
       }
+    }
+
+    if (lastError instanceof CredentialsValidateFailedError) {
+      throw lastError
+    } else {
+      this.logger.error(
+        `${this.getProviderSchema().provider}: credentials verification failed`,
+        (lastError as any)?.stack
+      )
+      throw lastError
     }
   }
 }

--- a/xpertai/models/openai/src/types.ts
+++ b/xpertai/models/openai/src/types.ts
@@ -19,7 +19,35 @@ export interface OpenAICredentials {
 	sampling_parameters?: 'auto' | 'enabled' | 'disabled'
 }
 
-export type OpenAIReasoningEffort = 'minimal' | 'low' | 'medium' | 'high'
+export type OpenAIReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh'
+
+const OpenAIReasoningEffortScale: readonly OpenAIReasoningEffort[] = [
+	'none',
+	'minimal',
+	'low',
+	'medium',
+	'high',
+	'xhigh',
+]
+
+const OpenAIReasoningEffortProfiles = [
+	{
+		pattern: /^gpt-5$/,
+		supported: ['minimal', 'low', 'medium', 'high'] as const,
+	},
+	{
+		pattern: /^gpt-5\.(2|4)$/,
+		supported: ['none', 'low', 'medium', 'high', 'xhigh'] as const,
+	},
+	{
+		pattern: /^gpt-5\.[23]-codex$/,
+		supported: ['low', 'medium', 'high', 'xhigh'] as const,
+	},
+	{
+		pattern: /^gpt-5\.(2|4)-pro$/,
+		supported: ['medium', 'high', 'xhigh'] as const,
+	},
+] as const
 
 export interface OpenAIModelOptions extends CommonChatModelParameters {
 	streaming?: boolean
@@ -73,6 +101,48 @@ export function isOpenAIOfficialBaseUrl(baseURL?: string): boolean {
 
 export function isOpenAIGPT5ProModel(model?: string): boolean {
 	return !!model?.trim() && OpenAIGPT5ProModelPattern.test(model.trim())
+}
+
+export function getSupportedOpenAIReasoningEfforts(
+	model?: string
+): readonly OpenAIReasoningEffort[] | undefined {
+	if (!model?.trim()) {
+		return undefined
+	}
+
+	return OpenAIReasoningEffortProfiles.find(({ pattern }) => pattern.test(model.trim()))?.supported
+}
+
+export function normalizeOpenAIReasoningEffort(
+	model?: string,
+	effort?: OpenAIReasoningEffort
+): OpenAIReasoningEffort | undefined {
+	if (!effort) {
+		return undefined
+	}
+
+	const supported = getSupportedOpenAIReasoningEfforts(model)
+	if (!supported?.length) {
+		return undefined
+	}
+
+	if (supported.includes(effort)) {
+		return effort
+	}
+
+	const requestedIndex = OpenAIReasoningEffortScale.indexOf(effort)
+	if (requestedIndex === -1) {
+		return supported[0]
+	}
+
+	return supported.reduce((closest, candidate) => {
+		const candidateIndex = OpenAIReasoningEffortScale.indexOf(candidate)
+		const closestIndex = OpenAIReasoningEffortScale.indexOf(closest)
+		const candidateDistance = Math.abs(candidateIndex - requestedIndex)
+		const closestDistance = Math.abs(closestIndex - requestedIndex)
+
+		return candidateDistance < closestDistance ? candidate : closest
+	})
 }
 
 export function shouldEnableSamplingParameters(


### PR DESCRIPTION
## Summary
- align `@xpert-ai/plugin-openai` GPT-5 reasoning effort options with current OpenAI model support across GPT-5.2, GPT-5.4, Pro, and Codex variants
- add provider credential validation fallback for OpenAI-compatible endpoints that reject a specific validation model
- preserve Responses API reasoning summaries in the OpenAI plugin and add release metadata with `xpertai/.changeset/openai-gpt5-refresh.md`

## Validation
- `pnpm -C xpertai install --lockfile-only`
- `CI=true pnpm -C xpertai install --frozen-lockfile`
- `pnpm -C xpertai exec nx build @xpert-ai/plugin-openai`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-openai`

## Notes
- PR intentionally includes only OpenAI plugin files plus the `xpertai` changeset.
- Root `.gitignore` remains uncommitted and is not part of this PR.
