### PR TITLE
feat(tongyi): add glm-5.1 support

### DIFF
--- a/xpertai/.changeset/tongyi-glm-5-1.md
+++ b/xpertai/.changeset/tongyi-glm-5-1.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-tongyi': patch
+---
+
+Add `glm-5.1` support and package build assets for the Tongyi plugin.

--- a/xpertai/models/tongyi/project.json
+++ b/xpertai/models/tongyi/project.json
@@ -1,0 +1,32 @@
+{
+  "name": "@xpert-ai/plugin-tongyi",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "models/tongyi/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "models/tongyi/dist",
+        "main": "models/tongyi/src/index.ts",
+        "rootDir": "models/tongyi/src",
+        "tsConfig": "models/tongyi/tsconfig.lib.json",
+        "generatePackageJson": false,
+        "assets": [
+          {
+            "glob": "**/*.yaml",
+            "input": "models/tongyi/src",
+            "output": "./"
+          },
+          {
+            "glob": "**/*.svg",
+            "input": "models/tongyi/src/_assets",
+            "output": "./_assets"
+          }
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/xpertai/models/tongyi/src/llm/_position.yaml
+++ b/xpertai/models/tongyi/src/llm/_position.yaml
@@ -13,6 +13,7 @@
 - deepseek-r1-distill-qwen-32b
 - deepseek-v3.1
 - deepseek-v3
+- glm-5.1
 - glm-5
 - glm-4.7
 - glm-4.6

--- a/xpertai/models/tongyi/src/llm/glm-4.5-air.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-4.5-air.yaml
@@ -34,7 +34,7 @@ parameter_rules:
     type: float
     default: 0.95
     min: 0.1
-    max: 0.9
+    max: 1.0
   - name: top_k
     type: int
     default: 20

--- a/xpertai/models/tongyi/src/llm/glm-4.5.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-4.5.yaml
@@ -34,7 +34,7 @@ parameter_rules:
     type: float
     default: 0.95
     min: 0.1
-    max: 0.9
+    max: 1.0
   - name: top_k
     type: int
     default: 20

--- a/xpertai/models/tongyi/src/llm/glm-4.6.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-4.6.yaml
@@ -34,7 +34,7 @@ parameter_rules:
     type: float
     default: 0.95
     min: 0.1
-    max: 0.9
+    max: 1.0
   - name: top_k
     type: int
     default: 20

--- a/xpertai/models/tongyi/src/llm/glm-4.7.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-4.7.yaml
@@ -34,7 +34,7 @@ parameter_rules:
     type: float
     default: 0.95
     min: 0.1
-    max: 0.9
+    max: 1.0
   - name: top_k
     type: int
     default: 20

--- a/xpertai/models/tongyi/src/llm/glm-5.1.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-5.1.yaml
@@ -34,7 +34,7 @@ parameter_rules:
     type: float
     default: 0.95
     min: 0.1
-    max: 0.9
+    max: 1.0
     help:
       zh_Hans: 生成过程中核采样方法概率阈值。
       en_US: The probability threshold of the nucleus sampling method during generation.

--- a/xpertai/models/tongyi/src/llm/glm-5.1.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-5.1.yaml
@@ -1,0 +1,103 @@
+# for more details, please refer to https://help.aliyun.com/zh/model-studio/glm
+model: glm-5.1
+label:
+  en_US: glm-5.1
+model_type: llm
+features:
+  - multi-tool-call
+  - agent-thought
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 202752
+parameter_rules:
+  - name: temperature
+    use_template: temperature
+    type: float
+    default: 1.0
+    min: 0.0
+    max: 2.0
+    help:
+      zh_Hans: 用于控制随机性和多样性的程度。
+      en_US: Used to control the degree of randomness and diversity.
+  - name: max_tokens
+    use_template: max_tokens
+    type: int
+    default: 8192
+    min: 1
+    max: 131072
+    help:
+      zh_Hans: 用于指定模型在生成内容时 token 的最大数量。
+      en_US: It is used to specify the maximum number of tokens when the model generates content.
+  - name: top_p
+    use_template: top_p
+    type: float
+    default: 0.95
+    min: 0.1
+    max: 0.9
+    help:
+      zh_Hans: 生成过程中核采样方法概率阈值。
+      en_US: The probability threshold of the nucleus sampling method during generation.
+  - name: top_k
+    type: int
+    default: 20
+    min: 0
+    max: 99
+    label:
+      zh_Hans: 取样数量
+      en_US: Top k
+    help:
+      zh_Hans: 生成时采样候选集的大小。
+      en_US: The size of the sampled candidate set during generation.
+  - name: seed
+    required: false
+    type: int
+    default: 1234
+    label:
+      zh_Hans: 随机种子
+      en_US: Random seed
+    help:
+      zh_Hans: 生成时使用的随机数种子。
+      en_US: The random number seed used during generation.
+  - name: repetition_penalty
+    required: false
+    type: float
+    default: 1.0
+    label:
+      zh_Hans: 重复惩罚
+      en_US: Repetition penalty
+    help:
+      zh_Hans: 用于控制模型生成时的重复度。1.0 表示不做惩罚。
+      en_US: Used to control repetition in model output. A value of 1.0 means no penalty.
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: true
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。GLM-5.1 默认开启思考。
+      en_US: Whether to enable thinking mode. GLM-5.1 enables thinking by default.
+  - name: tool_stream
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 流式工具调用
+      en_US: Stream Tool Calls
+    help:
+      zh_Hans: 以增量方式返回工具调用参数，适合长参数或多工具调用场景。
+      en_US: Stream tool call arguments incrementally for long arguments or multi-tool-call scenarios.
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式（仅在非思考模式下支持）
+      en_US: Specifying the format that the model must output (only supported in non-thinking mode)
+    required: false
+    options:
+      - text
+      - json_object

--- a/xpertai/models/tongyi/src/llm/glm-5.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-5.yaml
@@ -34,7 +34,7 @@ parameter_rules:
     type: float
     default: 0.95
     min: 0.1
-    max: 0.9
+    max: 1.0
     help:
       zh_Hans: 生成过程中核采样方法概率阈值，例如，取值为0.8时，仅保留概率加起来大于等于0.8的最可能token的最小集合作为候选集。取值范围为（0,1.0)，取值越大，生成的随机性越高；取值越低，生成的确定性越高。
       en_US: The probability threshold of the kernel sampling method during the generation process. For example, when the value is 0.8, only the smallest set of the most likely tokens with a sum of probabilities greater than or equal to 0.8 is retained as the candidate set. The value range is (0,1.0). The larger the value, the higher the randomness generated; the lower the value, the higher the certainty generated.

--- a/xpertai/models/tongyi/src/llm/llm.ts
+++ b/xpertai/models/tongyi/src/llm/llm.ts
@@ -50,7 +50,11 @@ export class TongyiLargeLanguageModel extends LargeLanguageModel {
           {
             enable_thinking: modelCredentials?.enable_thinking,
             thinking_budget: modelCredentials?.thinking_budget,
-            enable_search: modelCredentials?.enable_search
+            tool_stream: modelCredentials?.tool_stream,
+            enable_search: modelCredentials?.enable_search,
+            response_format: modelCredentials?.response_format
+              ? { type: modelCredentials.response_format }
+              : undefined
           },
           isNil
         ),

--- a/xpertai/models/tongyi/src/tongyi.yaml
+++ b/xpertai/models/tongyi/src/tongyi.yaml
@@ -2,6 +2,9 @@ provider: tongyi
 label:
   zh_Hans: 通义千问
   en_US: TONGYI
+description:
+  zh_Hans: 阿里云百炼提供的对话、文本嵌入、语音识别、重排和语音合成模型。
+  en_US: Models from Alibaba Cloud DashScope for chat, text embedding, speech-to-text, rerank, and text-to-speech.
 icon_small:
   en_US: icon_s_en.svg
 icon_large:

--- a/xpertai/models/tongyi/src/types.ts
+++ b/xpertai/models/tongyi/src/types.ts
@@ -22,7 +22,9 @@ export interface TongyiModelCredentials extends CommonChatModelParameters {
     frequency_penalty?: number
     enable_thinking?: boolean
     thinking_budget?: number
+    tool_stream?: boolean
     enable_search?: boolean
+    response_format?: 'text' | 'json_object'
 }
 
 export interface TongyiTextEmbeddingModelOptions {


### PR DESCRIPTION
## Summary
- add `glm-5.1` model metadata to the Tongyi plugin
- expose `tool_stream` for the new GLM model line and pass through `response_format`
- add `project.json` so `nx build` copies YAML and SVG assets into `dist`
- add a changeset for `@xpert-ai/plugin-tongyi`

## Validation
- `pnpm -C plugin-dev-harness build`
- `cd xpertai && pnpm install --lockfile-only`
- `cd xpertai && CI=true pnpm install --frozen-lockfile`
- `cd xpertai && pnpm exec nx build @xpert-ai/plugin-tongyi`
- `cd xpertai && npx -y node@20 ../plugin-dev-harness/dist/index.js --workspace . --plugin ./models/tongyi --verbose`

## Notes
- PR intentionally includes only Tongyi plugin files and its changeset.
- `xpertai/pnpm-lock.yaml` did not change after lockfile sync.
