### PR TITLE
[codex] fix(wecom): align handoff dispatch with current chat request contract

### DIFF
--- a/xpertai/.changeset/wecom-handoff-contract.md
+++ b/xpertai/.changeset/wecom-handoff-contract.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-wecom': patch
+---
+
+Align WeCom handoff dispatch with the current chat request contract.

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.spec.ts
@@ -1,0 +1,137 @@
+import {
+  HANDOFF_PERMISSION_SERVICE_TOKEN,
+  RequestContext
+} from '@xpert-ai/plugin-sdk'
+import { ChatWeComMessage } from '../message.js'
+import { WeComChatDispatchService } from './wecom-chat-dispatch.service.js'
+
+function createWeComMessage(
+  overrides: Partial<{
+    id: string
+    messageId: string
+    status: string
+    language: string
+    integrationId: string
+    chatId: string
+    senderId: string
+    responseUrl: string
+  }> = {}
+) {
+  return new ChatWeComMessage(
+    {
+      integrationId: overrides.integrationId ?? 'integration-1',
+      chatId: overrides.chatId ?? 'chat-1',
+      senderId: overrides.senderId ?? 'sender-1',
+      responseUrl: overrides.responseUrl ?? 'https://example.com/wecom/respond',
+      wecomChannel: {
+        sendTextByIntegrationId: jest.fn().mockResolvedValue({
+          success: true,
+          messageId: 'reply-message-id'
+        })
+      }
+    },
+    {
+      id: overrides.id ?? 'wecom-message-id',
+      messageId: overrides.messageId ?? 'wecom-chat-message-id',
+      status: (overrides.status as any) ?? 'thinking',
+      language: overrides.language ?? 'zh-Hans'
+    }
+  )
+}
+
+function mockRequestContext(params?: {
+  userId?: string
+  language?: string
+}) {
+  jest.spyOn(RequestContext, 'currentUserId').mockReturnValue((params?.userId ?? 'request-user-id') as any)
+  jest.spyOn(RequestContext, 'getLanguageCode').mockReturnValue((params?.language ?? 'zh-Hans') as any)
+}
+
+describe('WeComChatDispatchService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  function createFixture() {
+    const runStateService = {
+      save: jest.fn().mockResolvedValue(undefined)
+    }
+    const handoffPermissionService = {
+      enqueue: jest.fn().mockResolvedValue(undefined)
+    }
+    const pluginContext = {
+      resolve: jest.fn((token: unknown) => {
+        if (token === HANDOFF_PERMISSION_SERVICE_TOKEN) {
+          return handoffPermissionService
+        }
+        throw new Error(`Unexpected token: ${String(token)}`)
+      })
+    }
+    const service = new WeComChatDispatchService(
+      runStateService as any,
+      pluginContext as any
+    )
+
+    return {
+      service,
+      runStateService,
+      handoffPermissionService
+    }
+  }
+
+  it('buildDispatchMessage uses the current send request shape', async () => {
+    mockRequestContext({
+      userId: 'request-user-id',
+      language: 'zh-Hans'
+    })
+    const { service, runStateService } = createFixture()
+    const wecomMessage = createWeComMessage()
+
+    const message = await service.buildDispatchMessage({
+      xpertId: 'xpert-1',
+      input: 'hello from wecom',
+      wecomMessage,
+      conversationId: 'conversation-1',
+      conversationUserKey: 'wecom:user-key-1',
+      tenantId: 'tenant-1',
+      organizationId: 'organization-1',
+      executorUserId: 'executor-user-id',
+      endUserId: 'end-user-id'
+    })
+
+    expect((message.payload as any).request).toEqual({
+      action: 'send',
+      conversationId: 'conversation-1',
+      message: {
+        input: {
+          input: 'hello from wecom'
+        }
+      }
+    })
+    expect((message.payload as any).options).toEqual(
+      expect.objectContaining({
+        xpertId: 'xpert-1',
+        from: 'wecom',
+        fromEndUserId: 'end-user-id',
+        tenantId: 'tenant-1',
+        organizationId: 'organization-1',
+        language: 'zh-Hans',
+        integrationId: 'integration-1',
+        chatId: 'chat-1',
+        senderId: 'sender-1',
+        channelUserId: 'sender-1',
+        responseUrl: 'https://example.com/wecom/respond',
+        response_url: 'https://example.com/wecom/respond'
+      })
+    )
+    expect(message.headers).toEqual(
+      expect.objectContaining({
+        organizationId: 'organization-1',
+        userId: 'executor-user-id',
+        language: 'zh-Hans',
+        conversationId: 'conversation-1'
+      })
+    )
+    expect(runStateService.save).toHaveBeenCalledTimes(1)
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.ts
@@ -119,10 +119,13 @@ export class WeComChatDispatchService {
       traceId: runId,
       payload: {
         request: {
-          input: {
-            input: textInput
-          },
-          conversationId
+          action: 'send',
+          ...(conversationId ? { conversationId } : {}),
+          message: {
+            input: {
+              input: textInput ?? ''
+            }
+          }
         },
         options: {
           xpertId,

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.ts
@@ -1,4 +1,4 @@
-import { LanguagesEnum } from '@metad/contracts'
+import { LanguagesEnum, TChatRequest } from '@metad/contracts'
 import { Inject, Injectable, Logger } from '@nestjs/common'
 import {
   AGENT_CHAT_DISPATCH_MESSAGE_TYPE,
@@ -105,6 +105,10 @@ export class WeComChatDispatchService {
     this.logger.debug(
       `Build WeCom dispatch message runId=${runId} xpertId=${xpertId} sessionKey=${sessionKey} integration=${wecomMessage.integrationId}`
     )
+    const request = this.buildChatRequest({
+      conversationId,
+      input: textInput
+    })
 
     return {
       id: runId,
@@ -118,15 +122,7 @@ export class WeComChatDispatchService {
       enqueuedAt: Date.now(),
       traceId: runId,
       payload: {
-        request: {
-          action: 'send',
-          ...(conversationId ? { conversationId } : {}),
-          message: {
-            input: {
-              input: textInput ?? ''
-            }
-          }
-        },
+        request,
         options: {
           xpertId,
           from: 'wecom',
@@ -186,5 +182,20 @@ export class WeComChatDispatchService {
     }
     const text = value.trim()
     return text || undefined
+  }
+
+  private buildChatRequest(params: {
+    conversationId?: string
+    input?: string
+  }): TChatRequest {
+    return {
+      action: 'send',
+      ...(params.conversationId ? { conversationId: params.conversationId } : {}),
+      message: {
+        input: {
+          input: params.input ?? ''
+        }
+      }
+    } as unknown as TChatRequest
   }
 }

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat.types.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat.types.ts
@@ -1,4 +1,4 @@
-import { LanguagesEnum, TChatOptions } from '@metad/contracts'
+import { LanguagesEnum, TChatOptions, TChatRequest } from '@metad/contracts'
 import { AgentChatCallbackEnvelopePayload, defineChannelMessageType } from '@xpert-ai/plugin-sdk'
 
 export const WECOM_CHAT_STREAM_CALLBACK_MESSAGE_TYPE = defineChannelMessageType(
@@ -43,13 +43,7 @@ export interface WeComChatStreamCallbackPayload extends AgentChatCallbackEnvelop
 }
 
 export interface WeComChatHandoffPayload extends Record<string, unknown> {
-  request: {
-    input: {
-      input: string
-    }
-    conversationId?: string
-    confirm?: boolean
-  }
+  request: TChatRequest
   options: TChatOptions & {
     xpertId: string
     from: string


### PR DESCRIPTION
## Summary
This PR brings the WeCom handoff dispatch changes onto a clean branch based on `main`, and includes the missing `xpertai` workspace changeset so the release workflow can pick up `@xpert-ai/plugin-wecom`.

## Problem
The WeCom handoff payload was still being emitted in the older request shape on `main`, while the current chat flow expects the newer request contract. The earlier code had already been pushed through `develop`, but opening a PR from that branch to `main` would have pulled in unrelated `develop` commits.

## Root Cause
The dispatch builder in the WeCom integration was still constructing the legacy request payload directly inside `buildDispatchMessage`. That left the emitted payload out of sync with the current chat request contract used by downstream chat handling.

There was also no `xpertai/.changeset/*.md` entry for this plugin change, so the `xpertai` release workflow would not prepare a version bump for `@xpert-ai/plugin-wecom`.

## Fix
This PR:
- updates the WeCom handoff request payload to match the current chat request shape
- centralizes request construction through a dedicated helper to keep the emitted payload consistent
- updates the handoff payload typing to use `TChatRequest`
- adds a focused spec for the current dispatch request shape
- adds `xpertai/.changeset/wecom-handoff-contract.md` so the `xpertai` release flow can version `@xpert-ai/plugin-wecom`

## Validation
I ran the following checks locally on this branch:
- `pnpm -C xpertai exec changeset status --verbose`
- `pnpm -C xpertai exec tsc -p integrations/wecom/tsconfig.lib.json`
- `pnpm -C xpertai exec tsc -p integrations/wecom/tsconfig.spec.json --noEmit`

I also attempted the plugin lifecycle validation required by the workspace guidance:
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-wecom`

That harness step is currently blocked in this workspace because `@xpert-ai/plugin-wecom` is not resolvable from `xpertai/package.json` via Node module resolution (`Cannot find module '@xpert-ai/plugin-wecom'`). The failure is at plugin resolution time rather than in the updated WeCom code path itself.

## Notes
This branch is based directly on `origin/main` so the PR stays scoped to the WeCom handoff fix and the accompanying changeset only.