### PR TITLE
[codex] fix(wecom): mark plugin as system-level plugin

### DIFF
--- a/xpertai/.changeset/wecom-system-level-plugin.md
+++ b/xpertai/.changeset/wecom-system-level-plugin.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-wecom': patch
+---
+
+Mark the WeCom plugin as a system-level plugin.

--- a/xpertai/integrations/wecom/package.json
+++ b/xpertai/integrations/wecom/package.json
@@ -48,5 +48,10 @@
     "express": "4.21.2",
     "passport": "^0.6.0",
     "rxjs": "^7.8.1"
+  },
+  "xpert": {
+    "plugin": {
+      "level": "system"
+    }
   }
 }


### PR DESCRIPTION
## Summary
This PR marks `@xpert-ai/plugin-wecom` as a system-level plugin so the host can recognize it the same way it already recognizes the Lark/Feishu integration. It also adds a patch changeset so the metadata update is released with the plugin package.

## Problem
The WeCom integration was configured as a normal plugin package instead of a system-level plugin. In practice, that means the host would not treat it like the built-in system integrations even though that is the intended setup for this plugin.

## Root Cause
The host reads the plugin level from package metadata. The Lark/Feishu plugin already declares `xpert.plugin.level = "system"`, but `xpertai/integrations/wecom/package.json` did not include the same metadata block.

## Fix
This PR adds the missing `xpert.plugin.level` declaration with the value `system` to the WeCom plugin package metadata and adds a patch changeset entry for `@xpert-ai/plugin-wecom` so the release flow captures the change.

## Validation
I validated the change locally by:
- building the plugin-dev-harness with `pnpm -C plugin-dev-harness build`
- building the WeCom plugin with `pnpm -C xpertai exec nx build @xpert-ai/plugin-wecom`
- running the plugin lifecycle load through `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-wecom --verbose`

The lifecycle load passed against the built plugin entry during validation. The harness resolves plugins by package name from the workspace root, so I used a temporary local symlink only for that check and removed it afterward. No repository files were changed as part of that validation setup.