### PR TITLE
Fix WeCom trigger strategy resolution

### DIFF
--- a/xpertai/.changeset/wecom-nx-jest-config.md
+++ b/xpertai/.changeset/wecom-nx-jest-config.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-wecom': patch
+---
+
+Fix the WeCom Jest config so Nx release builds can process the plugin project graph reliably.

--- a/xpertai/integrations/wecom/jest.config.ts
+++ b/xpertai/integrations/wecom/jest.config.ts
@@ -1,12 +1,11 @@
+/**
+ * adds a docblock pointing Jest's loader at the new ts config, keeping the rest of the file untouched.
+ *
+ * @jest-config-loader-options {"project":"tsconfig.jest.json"}
+ */
 /* eslint-disable */
 import { readFileSync } from 'fs'
-import { dirname, join } from 'path'
-import { fileURLToPath } from 'url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const swcJestConfig = JSON.parse(readFileSync(join(__dirname, '.spec.swcrc'), 'utf-8'))
+const swcJestConfig = JSON.parse(readFileSync(`${__dirname}/.spec.swcrc`, 'utf-8'))
 
 swcJestConfig.swcrc = false
 

--- a/xpertai/integrations/wecom/tsconfig.jest.json
+++ b/xpertai/integrations/wecom/tsconfig.jest.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node10",
+    "target": "ES2019",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["jest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- fix WeCom trigger strategy resolution by injecting the strategy directly in the conversation service
- add a focused regression test for the conversation service
- make the WeCom Jest config Nx release-build compatible
- add patch changesets for the WeCom fixes

## Testing
- `JEST_DISABLE_V8_COMPILE_CACHE=1 pnpm exec jest --config integrations/wecom/jest.config.ts integrations/wecom/src/lib/conversation.service.spec.ts --runInBand --coverage=false --cache=false`
- `pnpm exec nx run @xpert-ai/plugin-wecom:build`