### PR TITLE
[codex] Fix OpenAI max_output_tokens validation

### DIFF
--- a/xpertai/models/openai/jest.config.ts
+++ b/xpertai/models/openai/jest.config.ts
@@ -1,9 +1,18 @@
+/**
+ * adds a docblock pointing Jest's loader at the dedicated ts config for this file.
+ *
+ * @jest-config-loader-options {"project":"tsconfig.jest.json"}
+ */
 /* eslint-disable */
 import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const configDir = dirname(fileURLToPath(import.meta.url));
 
 // Reading the SWC compilation config for the spec files
 const swcJestConfig = JSON.parse(
-  readFileSync(`${__dirname}/.spec.swcrc`, 'utf-8')
+  readFileSync(join(configDir, '.spec.swcrc'), 'utf-8')
 );
 
 // Disable .swcrc look-up by SWC core because we're passing in swcJestConfig ourselves
@@ -16,7 +25,10 @@ export default {
   transform: {
     '^.+\\.[tj]s$': ['@swc/jest', swcJestConfig],
   },
-  transformIgnorePatterns: ['/node_modules/'],
+  transformIgnorePatterns: ['/node_modules/(?!(lodash-es)/)'],
+  moduleNameMapper: {
+    '^lodash-es$': '<rootDir>/../../test-utils/lodashEsMock.ts'
+  },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: 'test-output/jest/coverage',
   testTimeout: 30000,

--- a/xpertai/models/openai/src/llm/gpt-5.2-chat.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2-chat.yaml
@@ -26,7 +26,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 4096
-    min: 1
+    min: 16
     max: 16384
     help:
       zh_Hans: 最大输出 token 数量。

--- a/xpertai/models/openai/src/llm/gpt-5.2-codex.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2-codex.yaml
@@ -26,7 +26,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 32768
-    min: 1
+    min: 16
     max: 128000
     help:
       zh_Hans: 最大输出 token 数量。

--- a/xpertai/models/openai/src/llm/gpt-5.2-pro.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2-pro.yaml
@@ -17,7 +17,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 32768
-    min: 1
+    min: 16
     max: 128000
     help:
       zh_Hans: 最大输出 token 数量。

--- a/xpertai/models/openai/src/llm/gpt-5.2.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.2.yaml
@@ -26,7 +26,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 32768
-    min: 1
+    min: 16
     max: 128000
     help:
       zh_Hans: 最大输出 token 数量。GPT-5.2 支持最大 128K 输出。

--- a/xpertai/models/openai/src/llm/gpt-5.3-codex.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.3-codex.yaml
@@ -26,7 +26,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 16384
-    min: 1
+    min: 16
     max: 65536
     help:
       zh_Hans: 最大输出 token 数量。

--- a/xpertai/models/openai/src/llm/gpt-5.4-pro.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.4-pro.yaml
@@ -17,7 +17,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 32768
-    min: 1
+    min: 16
     max: 128000
     help:
       zh_Hans: 最大输出 token 数量。

--- a/xpertai/models/openai/src/llm/gpt-5.4.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.4.yaml
@@ -26,7 +26,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 32768
-    min: 1
+    min: 16
     max: 128000
     help:
       zh_Hans: 最大输出 token 数量。GPT-5.4 支持最大 128K 输出。

--- a/xpertai/models/openai/src/llm/gpt-5.yaml
+++ b/xpertai/models/openai/src/llm/gpt-5.yaml
@@ -26,7 +26,7 @@ parameter_rules:
   - name: max_tokens
     use_template: max_tokens
     default: 32768
-    min: 1
+    min: 16
     max: 128000
     help:
       zh_Hans: 最大输出 token 数量。GPT-5 支持最大 128K 输出。

--- a/xpertai/models/openai/src/llm/llm.spec.ts
+++ b/xpertai/models/openai/src/llm/llm.spec.ts
@@ -1,3 +1,95 @@
+jest.mock('@metad/contracts', () => ({
+  AiModelTypeEnum: {
+    LLM: 'llm'
+  }
+}))
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  AIModelProviderStrategy: () => () => undefined,
+  CredentialsValidateFailedError: class extends Error {},
+  getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+  ModelProvider: class {},
+  LargeLanguageModel: class {
+    constructor(readonly modelProvider: unknown, readonly modelType: unknown) {}
+
+    createHandleUsageCallbacks() {
+      return []
+    }
+
+    createHandleLLMErrorCallbacks() {
+      return {}
+    }
+
+    getModelProfile() {
+      return {}
+    }
+  }
+}))
+
+jest.mock('@langchain/openai', () => {
+  class MockChatOpenAI {
+    private params: Record<string, any>
+
+    constructor(params: Record<string, any>) {
+      this.params = { ...params }
+    }
+
+    invocationParams() {
+      const params = { ...this.params }
+
+      if (params.maxTokens !== undefined) {
+        params.max_output_tokens = params.maxTokens
+        delete params.maxTokens
+      }
+
+      if (params.topP !== undefined) {
+        params.top_p = params.topP
+        delete params.topP
+      }
+
+      if (params.frequencyPenalty !== undefined) {
+        params.frequency_penalty = params.frequencyPenalty
+        delete params.frequencyPenalty
+      }
+
+      if (params.presencePenalty !== undefined) {
+        params.presence_penalty = params.presencePenalty
+        delete params.presencePenalty
+      }
+
+      return params
+    }
+
+    withConfig(config: Record<string, any>) {
+      if (config.response_format) {
+        return new MockChatOpenAI({
+          ...this.params,
+          text: {
+            format: config.response_format
+          }
+        })
+      }
+
+      return new MockChatOpenAI(this.params)
+    }
+
+    invoke = jest.fn().mockResolvedValue({
+      content: 'Test response',
+      role: 'assistant'
+    })
+  }
+
+  class MockChatOpenAIResponses {
+    constructor(_params: Record<string, any>) {}
+  }
+
+  return {
+    ChatOpenAI: MockChatOpenAI,
+    ChatOpenAIResponses: MockChatOpenAIResponses,
+    OpenAIClient: {}
+  }
+})
+
 import { ICopilotModel } from '@metad/contracts'
 import { OpenAIProviderStrategy } from '../provider.strategy.js'
 import { OpenAILargeLanguageModel } from './llm.js'
@@ -46,6 +138,18 @@ describe('OpenAILargeLanguageModel', () => {
     expect(params.max_output_tokens).toBe(1024)
     expect(params.reasoning).toEqual({ effort: 'high', summary: 'auto' })
     expect(params.text?.format).toEqual({ type: 'json_object' })
+  })
+
+  it('clamps official OpenAI max_tokens below the Responses API minimum', () => {
+    const model = llm.getChatModel(
+      createCopilotModel('gpt-5.4', {
+        max_tokens: 5,
+      })
+    )
+
+    const params = (model as any).invocationParams()
+
+    expect(params.max_output_tokens).toBe(16)
   })
 
   it('normalizes legacy GPT-5.4 reasoning values to the official enum', () => {

--- a/xpertai/models/openai/src/llm/llm.ts
+++ b/xpertai/models/openai/src/llm/llm.ts
@@ -11,9 +11,11 @@ import {
 import { isNil, omitBy } from 'lodash-es'
 import {
   getSupportedOpenAIReasoningEfforts,
+  normalizeOpenAIMaxTokens,
   normalizeOpenAIReasoningEffort,
   OpenAICredentials,
   OpenAIModelOptions,
+  OpenAIResponsesMinOutputTokens,
   shouldEnableResponseFormat,
   shouldEnableSamplingParameters,
   toCredentialKwargs
@@ -39,7 +41,7 @@ export class OpenAILargeLanguageModel extends LargeLanguageModel {
       const chatModel = new ChatOpenAI({
         ...params,
         model,
-        maxTokens: 5,
+        maxTokens: OpenAIResponsesMinOutputTokens,
         useResponsesApi: true,
       })
       const messages = [new HumanMessage('Hello')]
@@ -94,7 +96,7 @@ export class OpenAILargeLanguageModel extends LargeLanguageModel {
         model,
         streaming,
         temperature: supportsSamplingParams ? (modelOptions?.temperature ?? 1) : undefined,
-        maxTokens: modelOptions?.max_tokens,
+        maxTokens: normalizeOpenAIMaxTokens(modelOptions?.max_tokens, params.configuration?.baseURL),
         topP: supportsSamplingParams ? modelOptions?.top_p : undefined,
         frequencyPenalty: modelOptions?.frequency_penalty,
         presencePenalty: modelOptions?.presence_penalty,

--- a/xpertai/models/openai/src/provider.strategy.spec.ts
+++ b/xpertai/models/openai/src/provider.strategy.spec.ts
@@ -1,5 +1,11 @@
 const validateCredentials = jest.fn()
 
+jest.mock('@metad/contracts', () => ({
+  AiModelTypeEnum: {
+    LLM: 'llm'
+  }
+}))
+
 jest.mock('@xpert-ai/plugin-sdk', () => ({
   AIModelProviderStrategy: () => () => undefined,
   ModelProvider: class {

--- a/xpertai/models/openai/src/types.spec.ts
+++ b/xpertai/models/openai/src/types.spec.ts
@@ -2,9 +2,11 @@ import { OpenAIBaseInput } from '@langchain/openai'
 import {
   isOpenAIOfficialBaseUrl,
   isOpenAIGPT5ProModel,
+  normalizeOpenAIMaxTokens,
   normalizeOpenAIBaseUrl,
   OpenAICredentials,
   OpenAIDefaultBaseUrl,
+  OpenAIResponsesMinOutputTokens,
   shouldEnableResponseFormat,
   shouldEnableSamplingParameters,
   toCredentialKwargs
@@ -66,5 +68,14 @@ describe('OpenAI credential kwargs', () => {
     expect(shouldEnableResponseFormat('https://api.openai.com/v1', 'gpt-5.4')).toBe(true)
     expect(shouldEnableResponseFormat('https://api.openai.com/v1', 'gpt-5.4-pro')).toBe(false)
     expect(shouldEnableResponseFormat('https://gateway.example.com/v1', 'gpt-5.4-pro')).toBe(true)
+  })
+
+  it('clamps official OpenAI max_tokens to the Responses API minimum', () => {
+    expect(normalizeOpenAIMaxTokens(5, 'https://api.openai.com/v1')).toBe(OpenAIResponsesMinOutputTokens)
+    expect(normalizeOpenAIMaxTokens(64, 'https://api.openai.com/v1')).toBe(64)
+  })
+
+  it('keeps custom-endpoint max_tokens unchanged', () => {
+    expect(normalizeOpenAIMaxTokens(5, 'https://gateway.example.com/v1')).toBe(5)
   })
 })

--- a/xpertai/models/openai/src/types.ts
+++ b/xpertai/models/openai/src/types.ts
@@ -8,6 +8,7 @@ const moduleDir = dirname(fileURLToPath(import.meta.url))
 
 export const OpenAIProvider = 'openai'
 export const OpenAIDefaultBaseUrl = 'https://api.openai.com/v1'
+export const OpenAIResponsesMinOutputTokens = 16
 const OpenAIApiVersionPath = '/v1'
 const OpenAIOfficialHost = 'api.openai.com'
 
@@ -174,6 +175,18 @@ export function shouldEnableResponseFormat(
 	}
 
 	return !isOpenAIGPT5ProModel(model)
+}
+
+export function normalizeOpenAIMaxTokens(maxTokens?: number, baseURL?: string): number | undefined {
+	if (maxTokens == null) {
+		return undefined
+	}
+
+	if (!isOpenAIOfficialBaseUrl(baseURL)) {
+		return maxTokens
+	}
+
+	return Math.max(maxTokens, OpenAIResponsesMinOutputTokens)
 }
 
 export function toCredentialKwargs(credentials: OpenAICredentials) {

--- a/xpertai/models/openai/tsconfig.jest.json
+++ b/xpertai/models/openai/tsconfig.jest.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2020",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["jest.config.ts"]
+}

--- a/xpertai/test-utils/lodashEsMock.ts
+++ b/xpertai/test-utils/lodashEsMock.ts
@@ -9,3 +9,19 @@ export function pick<T extends Record<string, unknown>, K extends keyof T>(
     return result;
   }, {} as Pick<T, K>);
 }
+
+export function isNil(value: unknown): value is null | undefined {
+  return value == null;
+}
+
+export function omitBy<T extends Record<string, unknown>>(
+  object: T,
+  predicate: (value: T[keyof T], key: keyof T) => boolean
+): Partial<T> {
+  return Object.entries(object).reduce((result, [key, value]) => {
+    if (!predicate(value as T[keyof T], key as keyof T)) {
+      result[key as keyof T] = value as T[keyof T];
+    }
+    return result;
+  }, {} as Partial<T>);
+}


### PR DESCRIPTION
## What changed
- clamp OpenAI Responses API `max_output_tokens` usage in `models/openai` to the minimum supported value of `16`
- stop provider credential validation from sending `max_output_tokens=5`
- raise the GPT-5 family model schema minimum for `max_tokens` from `1` to `16`
- restore `@xpert-ai/plugin-openai` Jest execution by fixing the package Jest config and tightening unit-test mocks around the OpenAI integration

## Why
Users were hitting `400 Invalid 'max_output_tokens'` when the OpenAI plugin validated credentials against the Responses API. The plugin was issuing a validation request with `maxTokens: 5`, which LangChain maps to `max_output_tokens=5`, below OpenAI's accepted minimum.

## Impact
- official OpenAI validation no longer fails on the plugin's own request payload
- existing saved configs with `max_tokens < 16` are normalized at runtime for official OpenAI endpoints
- newly configured GPT-5 family models cannot save invalid sub-16 output token limits through the plugin schema
- `@xpert-ai/plugin-openai` tests now run successfully in this workspace again

## Root cause
`models/openai/src/llm/llm.ts` hard-coded `maxTokens: 5` during credential validation while using the Responses API. The plugin schema also allowed `max_tokens` values below the minimum accepted by OpenAI.

## Validation
- `node ./node_modules/nx/bin/nx.js test @xpert-ai/plugin-openai`
- `node ./node_modules/nx/bin/nx.js build @xpert-ai/plugin-openai`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai/models/openai --plugin @xpert-ai/plugin-openai`
