### PR TITLE
[codex] Add missing changeset for OpenAI plugin fix

### DIFF
--- a/xpertai/.changeset/openai-max-output-tokens-fix.md
+++ b/xpertai/.changeset/openai-max-output-tokens-fix.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-openai": patch
+---
+
+Fix OpenAI Responses API max_output_tokens validation and enforce the minimum supported output token limit.


### PR DESCRIPTION
## Summary
- add the missing `xpertai/.changeset` entry for the merged OpenAI plugin fix in #209
- mark `@xpert-ai/plugin-openai` for a patch release so the fix can flow into the next `changeset-release/main` PR
- keep this PR code-free aside from the release note file

## Validation
- `cd xpertai && pnpm dlx @changesets/cli status --verbose`
- confirmed the workspace would bump `@xpert-ai/plugin-openai` to `0.0.5`

## Notes
- no plugin source files are changed in this PR
- merging this PR should allow the release workflow to open the next release PR with the OpenAI fix included