### PR TITLE
fix(wecom): inject long reply sender

### DIFF
--- a/xpertai/.changeset/wecom-long-reply-injection.md
+++ b/xpertai/.changeset/wecom-long-reply-injection.md
@@ -1,0 +1,4 @@
+"@xpert-ai/plugin-wecom": patch
+---
+
+Fix WeCom long-connection replies to use injected sender service during callback processing.

--- a/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
@@ -65,7 +65,6 @@ type WeComLongConnectionClient = {
 @ChatChannel('wecom')
 export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptions, TWeComEvent> {
   private readonly logger = new Logger(WeComChannelStrategy.name)
-  private _longConnection!: WeComLongConnectionClient
 
   @Inject(CACHE_MANAGER)
   private readonly cacheManager: Cache
@@ -74,7 +73,9 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
 
   constructor(
     @Inject(WECOM_PLUGIN_CONTEXT)
-    private readonly pluginContext: PluginContext
+    private readonly pluginContext: PluginContext,
+    @Inject(WECOM_LONG_CONNECTION_SERVICE)
+    private readonly longConnectionService: WeComLongConnectionClient
   ) {}
 
   private get integrationPermissionService(): IntegrationPermissionService {
@@ -85,10 +86,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
   }
 
   private get longConnection(): WeComLongConnectionClient {
-    if (!this._longConnection) {
-      this._longConnection = this.pluginContext.resolve(WECOM_LONG_CONNECTION_SERVICE) as WeComLongConnectionClient
-    }
-    return this._longConnection
+    return this.longConnectionService
   }
 
   meta: TChatChannelMeta = {


### PR DESCRIPTION
## Summary
- inject the WeCom long-connection sender into the channel strategy instead of resolving it at callback runtime
- add a patch changeset for the long-reply callback fix

## Validation
- `pnpm -C xpertai exec tsc -p integrations/wecom/tsconfig.lib.json`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-wecom --verbose`
- local Node 20 runtime check covering long-connection `respond`, `update`, and `active` send paths