### PR TITLE
fix(changeset): add missing frontmatter fence

### DIFF
--- a/xpertai/.changeset/wecom-long-reply-injection.md
+++ b/xpertai/.changeset/wecom-long-reply-injection.md
@@ -1,3 +1,4 @@
+---
 "@xpert-ai/plugin-wecom": patch
 ---
 


### PR DESCRIPTION
## Summary
- add the missing opening `---` fence to the WeCom long-reply changeset
- unblock the Changesets release workflow after `#215` merged without the follow-up formatting fix

## Validation
- `pnpm -C xpertai exec changeset status`
- verified only `xpertai/.changeset/wecom-long-reply-injection.md` differs from `main`