### PR TITLE
fix: break WeCom long-connection init cycle

### DIFF
--- a/xpertai/.changeset/five-points-shine.md
+++ b/xpertai/.changeset/five-points-shine.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-wecom': patch
+---
+
+Fix WeCom plugin installation hanging by marking the long-connection sender cycle for NestJS forwardRef injection, while preserving the long-connection callback reply fix.

--- a/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
-import { Inject, Injectable, Logger } from '@nestjs/common'
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common'
 import {
   CHAT_CHANNEL_TEXT_LIMITS,
   ChatChannel,
@@ -74,7 +74,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
   constructor(
     @Inject(WECOM_PLUGIN_CONTEXT)
     private readonly pluginContext: PluginContext,
-    @Inject(WECOM_LONG_CONNECTION_SERVICE)
+    @Inject(forwardRef(() => WECOM_LONG_CONNECTION_SERVICE))
     private readonly longConnectionService: WeComLongConnectionClient
   ) {}
 

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto'
 import { createRequire } from 'module'
-import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
+import { forwardRef, Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
 import express from 'express'
 import { IIntegration, IUser } from '@metad/contracts'
 import {
@@ -83,6 +83,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
   constructor(
     @Inject(WECOM_PLUGIN_CONTEXT)
     private readonly pluginContext: PluginContext,
+    @Inject(forwardRef(() => WeComChannelStrategy))
     private readonly wecomChannel: WeComChannelStrategy,
     private readonly conversationService: WeComConversationService
   ) {}


### PR DESCRIPTION
## Summary
- mark the WeCom channel and long-connection dependency cycle with Nest `forwardRef` injection
- keep the callback reply path on the injected long-connection sender instead of runtime `resolve`
- add a patch changeset for `@xpert-ai/plugin-wecom`

## Validation
- `pnpm -C xpertai exec tsc -p integrations/wecom/tsconfig.lib.json`
- `node plugin-dev-harness/dist/index.js --workspace /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/integrations/wecom --plugin @xpert-ai/plugin-wecom --verbose`
- local runtime script covering the long-connection `respond`, `update`, and `active` send paths without `resolve(WECOM_LONG_CONNECTION_SERVICE)`
