### PR TITLE
Improve WeCom long connection runtime

### DIFF
--- a/.changeset/calm-rabbits-wink.md
+++ b/.changeset/calm-rabbits-wink.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-wecom": minor
+---
+
+Improve WeCom long-connection runtime management with a status view, Redis-backed recovery flow, and safer callback reply handling.

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-callback.processor.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-callback.processor.spec.ts
@@ -1,0 +1,224 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  __esModule: true,
+  HandoffProcessorStrategy: () => (target: unknown) => target,
+  defineChannelMessageType: (...parts: Array<string | number>) => parts.join('.')
+}))
+
+jest.mock('@xpert-ai/chatkit-types', () => ({
+  ChatMessageEventTypeEnum: {
+    ON_CONVERSATION_START: 'on_conversation_start'
+  },
+  ChatMessageTypeEnum: {
+    MESSAGE: 'message',
+    EVENT: 'event'
+  }
+}))
+
+jest.mock('@metad/contracts', () => ({
+  filterMessageText: (value: unknown) => {
+    if (typeof value === 'string') {
+      return value
+    }
+    if (value && typeof value === 'object' && (value as { type?: unknown }).type === 'text') {
+      return (value as { text?: unknown }).text ?? ''
+    }
+    return ''
+  }
+}))
+
+jest.mock('../conversation.service.js', () => ({
+  WeComConversationService: class WeComConversationService {}
+}))
+
+jest.mock('../wecom-channel.strategy.js', () => ({
+  WeComChannelStrategy: class WeComChannelStrategy {}
+}))
+
+import { ChatMessageTypeEnum } from '@xpert-ai/chatkit-types'
+import { WeComChatStreamCallbackProcessor } from './wecom-chat-callback.processor.js'
+
+describe('WeComChatStreamCallbackProcessor', () => {
+  function createFixture() {
+    let storedState: any = null
+
+    const wecomChannel = {
+      sendTextByIntegrationId: jest.fn().mockResolvedValue({
+        success: true,
+        messageId: 'reply-message-id'
+      })
+    }
+    const conversationService = {
+      setConversation: jest.fn().mockResolvedValue(undefined)
+    }
+    const runStateService = {
+      get: jest.fn(async () => storedState),
+      save: jest.fn(async (state: unknown) => {
+        storedState = state
+      }),
+      clear: jest.fn(async () => {
+        storedState = null
+      })
+    }
+
+    const processor = new WeComChatStreamCallbackProcessor(
+      wecomChannel as any,
+      conversationService as any,
+      runStateService as any,
+      {} as any
+    )
+
+    return {
+      processor,
+      wecomChannel,
+      runStateService
+    }
+  }
+
+  function createContext() {
+    return {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+      xpertId: 'xpert-1',
+      integrationId: 'integration-1',
+      chatId: 'chat-1',
+      senderId: 'sender-1',
+      responseUrl: 'https://example.com/respond',
+      message: {
+        id: 'wecom-message-id',
+        messageId: 'chat-message-id',
+        status: 'thinking',
+        language: 'zh-Hans'
+      }
+    }
+  }
+
+  it('preserves markdown chunk boundaries before sending the final reply', async () => {
+    const { processor, wecomChannel, runStateService } = createFixture()
+    const context = createContext()
+
+    await processor.process(
+      {
+        payload: {
+          sourceMessageId: 'source-message-id',
+          sequence: 1,
+          kind: 'stream',
+          context,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: '\n根据知识库信息，装备评估按照成熟度等级分为一级至五级，具体评估方法如下：\n\n---\n'
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+
+    await processor.process(
+      {
+        payload: {
+          sourceMessageId: 'source-message-id',
+          sequence: 2,
+          kind: 'stream',
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: '\n## 一级评估要点\n\n**要求1：** 应在关键工序应用自动化设备\n'
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+
+    await processor.process(
+      {
+        payload: {
+          sourceMessageId: 'source-message-id',
+          sequence: 3,
+          kind: 'complete'
+        }
+      } as any,
+      {} as any
+    )
+
+    expect(wecomChannel.sendTextByIntegrationId).toHaveBeenCalledWith(
+      'integration-1',
+      expect.objectContaining({
+        chatId: 'chat-1',
+        senderId: 'sender-1',
+        responseUrl: 'https://example.com/respond',
+        preferResponseUrl: true,
+        content:
+          '根据知识库信息，装备评估按照成熟度等级分为一级至五级，具体评估方法如下：\n\n---\n\n## 一级评估要点\n\n**要求1：** 应在关键工序应用自动化设备'
+      })
+    )
+    expect(runStateService.save).toHaveBeenCalledTimes(2)
+    expect(runStateService.clear).toHaveBeenCalledWith('source-message-id')
+  })
+
+  it('does not include reasoning chunks in the final WeCom reply', async () => {
+    const { processor, wecomChannel } = createFixture()
+    const context = createContext()
+
+    await processor.process(
+      {
+        payload: {
+          sourceMessageId: 'source-message-id',
+          sequence: 1,
+          kind: 'stream',
+          context,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: {
+                type: 'reasoning',
+                text: '这是不该发给企微的推理'
+              }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+
+    await processor.process(
+      {
+        payload: {
+          sourceMessageId: 'source-message-id',
+          sequence: 2,
+          kind: 'stream',
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: {
+                type: 'text',
+                text: '这是最终答案'
+              }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+
+    await processor.process(
+      {
+        payload: {
+          sourceMessageId: 'source-message-id',
+          sequence: 3,
+          kind: 'complete'
+        }
+      } as any,
+      {} as any
+    )
+
+    expect(wecomChannel.sendTextByIntegrationId).toHaveBeenCalledWith(
+      'integration-1',
+      expect.objectContaining({
+        content: '这是最终答案'
+      })
+    )
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-callback.processor.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-callback.processor.ts
@@ -8,7 +8,7 @@ import {
   ProcessResult
 } from '@xpert-ai/plugin-sdk'
 import { ChatMessageEventTypeEnum, ChatMessageTypeEnum } from '@xpert-ai/chatkit-types'
-import { messageContentText } from '@metad/contracts'
+import { filterMessageText } from '@metad/contracts'
 import { ChatWeComMessage } from '../message.js'
 import { WeComConversationService } from '../conversation.service.js'
 import { WeComChannelStrategy } from '../wecom-channel.strategy.js'
@@ -166,7 +166,7 @@ export class WeComChatStreamCallbackProcessor implements IHandoffProcessor<WeCom
     }
 
     if (eventPayload.type === ChatMessageTypeEnum.MESSAGE) {
-      const textDelta = this.normalizeStreamText(messageContentText(eventPayload.data))
+      const textDelta = this.normalizeStreamTextDelta(filterMessageText(eventPayload.data) ?? '')
       if (textDelta) {
         state.responseMessageContent += textDelta
       }
@@ -192,7 +192,7 @@ export class WeComChatStreamCallbackProcessor implements IHandoffProcessor<WeCom
 
   private async completeRun(state: WeComChatRunState): Promise<void> {
     const message = this.createWeComMessage(state.context)
-    const streamText = this.normalizeStreamText(state.responseMessageContent)
+    const streamText = this.normalizeFinalStreamText(state.responseMessageContent)
     const finalText = streamText || `[企业微信回复]\n${state.context?.conversationId ? `会话ID: ${state.context.conversationId}` : '已处理完成。'}`
 
     await message.reply(finalText)
@@ -222,11 +222,15 @@ export class WeComChatStreamCallbackProcessor implements IHandoffProcessor<WeCom
     )
   }
 
-  private normalizeStreamText(value: unknown): string {
+  private normalizeStreamTextDelta(value: unknown): string {
     if (typeof value !== 'string') {
       return ''
     }
-    return value.replace(/\r/g, '').trim()
+    return value.replace(/\r/g, '')
+  }
+
+  private normalizeFinalStreamText(value: unknown): string {
+    return this.normalizeStreamTextDelta(value).trim()
   }
 
   private extractConversationId(data: unknown): string | undefined {

--- a/xpertai/integrations/wecom/src/lib/types.ts
+++ b/xpertai/integrations/wecom/src/lib/types.ts
@@ -46,6 +46,51 @@ export type TIntegrationWeComOptions = {
   agentId?: number
 }
 
+export type TWeComConnectionMode = 'webhook' | 'long_connection'
+
+export type TWeComLongRuntimeState = 'idle' | 'connecting' | 'connected' | 'retrying' | 'unhealthy'
+
+export type TWeComLongDisabledReason =
+  | 'manual_disconnect'
+  | 'integration_disabled'
+  | 'xpert_unbound'
+  | 'config_invalid'
+  | 'lease_conflict'
+  | 'runtime_error'
+  | 'restore_skipped'
+
+export type TWeComRuntimeStatus = {
+  integrationId: string
+  connectionMode: TWeComConnectionMode
+  connected: boolean
+  state: TWeComLongRuntimeState
+  shouldRun?: boolean
+  ownerInstanceId?: string | null
+  lastConnectedAt?: number | null
+  lastDisconnectedAt?: number | null
+  lastError?: string | null
+  failureCount?: number
+  reconnectAttempts?: number
+  nextReconnectAt?: number | null
+  disabledReason?: TWeComLongDisabledReason | null
+  lastCallbackAt?: number | null
+  lastPingAt?: number | null
+}
+
+export type TWeComLegacyLongConnectionState = 'disconnected' | 'connecting' | 'connected' | 'error'
+
+export type TWeComLegacyLongConnectionStatus = {
+  integrationId: string
+  state: TWeComLegacyLongConnectionState
+  connected: boolean
+  shouldRun: boolean
+  connectedAt?: number
+  disconnectedAt?: number
+  reconnectAttempts: number
+  lastError?: string
+  disabledReason?: TWeComLongDisabledReason | null
+}
+
 export type TWeComEvent = {
   msgType?: string
   eventType?: string

--- a/xpertai/integrations/wecom/src/lib/views/index.ts
+++ b/xpertai/integrations/wecom/src/lib/views/index.ts
@@ -1,0 +1,1 @@
+export * from './wecom-integration-view.provider.js'

--- a/xpertai/integrations/wecom/src/lib/views/wecom-integration-view.provider.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/views/wecom-integration-view.provider.spec.ts
@@ -1,0 +1,169 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  __esModule: true,
+  CHAT_CHANNEL_TEXT_LIMITS: { wecom: 1000 },
+  ChatChannel: () => (target: unknown) => target,
+  INTEGRATION_PERMISSION_SERVICE_TOKEN: 'INTEGRATION_PERMISSION_SERVICE_TOKEN',
+  RequestContext: {
+    currentUser: jest.fn(),
+    currentTenantId: jest.fn(),
+    currentUserId: jest.fn(),
+    getOrganizationId: jest.fn(),
+    getLanguageCode: jest.fn()
+  },
+  ViewExtensionProvider: () => (target: unknown) => target,
+  WorkflowTriggerStrategy: () => (target: unknown) => target,
+  XpertServerPlugin: () => (target: unknown) => target,
+  defineChannelMessageType: (...parts: Array<string | number>) => parts.join('.'),
+  getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+  runWithRequestContext: async (_context: unknown, _store: unknown, callback: () => unknown) => await callback()
+}))
+
+import type { IIntegration } from '@metad/contracts'
+import { WeComChannelStrategy } from '../wecom-channel.strategy.js'
+import { WeComLongConnectionService } from '../wecom-long-connection.service.js'
+import { TIntegrationWeComLongOptions } from '../types.js'
+import { WeComIntegrationViewProvider } from './wecom-integration-view.provider.js'
+
+type WeComViewHostContext = {
+  tenantId: string
+  organizationId: string
+  userId: string
+  hostType: string
+  hostId: string
+  locale: string
+  slots: Array<{ key: string; mode: string; order: number }>
+  hostSnapshot: Record<string, unknown>
+}
+
+describe('WeComIntegrationViewProvider', () => {
+  function createContext(provider = 'wecom_long'): WeComViewHostContext {
+    return {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+      hostType: 'integration',
+      hostId: 'integration-1',
+      locale: 'zh-Hans',
+      slots: [{ key: 'detail.main_tabs', mode: 'tabs', order: 0 }],
+      hostSnapshot: {
+        id: 'integration-1',
+        provider,
+        type: provider,
+        name: '企微机器人',
+        status: 'connected'
+      }
+    }
+  }
+
+  function createIntegration() {
+    return {
+      id: 'integration-1',
+      provider: 'wecom_long',
+      name: '企微机器人',
+      options: {
+        botId: 'bot-1',
+        secret: 'secret-1',
+        xpertId: 'xpert-1',
+        preferLanguage: 'zh-Hans'
+      }
+    } as IIntegration<TIntegrationWeComLongOptions>
+  }
+
+  function createFixture() {
+    const integration = createIntegration()
+    const longConnectionService = {
+      status: jest.fn().mockResolvedValue({
+        integrationId: 'integration-1',
+        connectionMode: 'long_connection',
+        connected: true,
+        state: 'connected',
+        ownerInstanceId: 'instance-1',
+        lastConnectedAt: Date.parse('2026-04-01T00:00:00.000Z'),
+        lastDisconnectedAt: Date.parse('2026-04-01T01:00:00.000Z'),
+        lastCallbackAt: Date.parse('2026-04-01T02:00:00.000Z'),
+        lastPingAt: Date.parse('2026-04-01T03:00:00.000Z'),
+        lastError: null,
+        reconnectAttempts: 2,
+        disabledReason: null
+      }),
+      reconnect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined)
+    }
+    const wecomChannel = {
+      readIntegrationById: jest.fn().mockResolvedValue(integration)
+    }
+
+    return {
+      longConnectionService,
+      wecomChannel,
+      provider: new WeComIntegrationViewProvider(
+        longConnectionService as unknown as WeComLongConnectionService,
+        wecomChannel as unknown as WeComChannelStrategy
+      )
+    }
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('supports only wecom long integration hosts', () => {
+    const { provider } = createFixture()
+
+    expect(provider.supports(createContext('wecom_long'))).toBe(true)
+    expect(provider.supports(createContext('wecom'))).toBe(false)
+  })
+
+  it('declares only a status tab for integration detail main tabs', () => {
+    const { provider } = createFixture()
+
+    expect(provider.getViewManifests(createContext(), 'detail.main_tabs').map((manifest) => manifest.key)).toEqual([
+      'status'
+    ])
+    expect(provider.getViewManifests(createContext(), 'detail.sidebar')).toEqual([])
+  })
+
+  it('loads status data from runtime status and integration metadata', async () => {
+    const { provider } = createFixture()
+
+    await expect(provider.getViewData(createContext(), 'status', {})).resolves.toEqual({
+      summary: {
+        connectionMode: 'long_connection',
+        state: 'connected',
+        botUser: '企微机器人',
+        ownerInstanceId: 'instance-1',
+        lastConnectedAt: '2026-04-01T00:00:00.000Z',
+        lastDisconnectedAt: '2026-04-01T01:00:00.000Z',
+        lastCallbackAt: '2026-04-01T02:00:00.000Z',
+        lastPingAt: '2026-04-01T03:00:00.000Z',
+        lastError: null,
+        reconnectAttempts: 2,
+        disabledReason: null
+      }
+    })
+  })
+
+  it('refreshes and invokes reconnect or disconnect actions', async () => {
+    const { provider, longConnectionService } = createFixture()
+
+    await expect(provider.executeViewAction(createContext(), 'status', 'refresh', {})).resolves.toEqual({
+      success: true,
+      message: { en_US: 'WeCom view refreshed', zh_Hans: 'WeCom 视图已刷新' },
+      refresh: true
+    })
+
+    await expect(provider.executeViewAction(createContext(), 'status', 'reconnect', {})).resolves.toEqual({
+      success: true,
+      message: { en_US: 'WeCom long connection reconnected', zh_Hans: 'WeCom 长连接已重连' },
+      refresh: true
+    })
+    expect(longConnectionService.reconnect).toHaveBeenCalledWith('integration-1')
+
+    await expect(provider.executeViewAction(createContext(), 'status', 'disconnect', {})).resolves.toEqual({
+      success: true,
+      message: { en_US: 'WeCom long connection disconnected', zh_Hans: 'WeCom 长连接已断开' },
+      refresh: true
+    })
+    expect(longConnectionService.disconnect).toHaveBeenCalledWith('integration-1')
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/views/wecom-integration-view.provider.ts
+++ b/xpertai/integrations/wecom/src/lib/views/wecom-integration-view.provider.ts
@@ -1,0 +1,315 @@
+import type { I18nObject } from '@metad/contracts'
+import { applyDecorators, Injectable, SetMetadata } from '@nestjs/common'
+import { getErrorMessage } from '@xpert-ai/plugin-sdk'
+import { WeComChannelStrategy } from '../wecom-channel.strategy.js'
+import { WeComLongConnectionService } from '../wecom-long-connection.service.js'
+import {
+  INTEGRATION_WECOM_LONG,
+  TIntegrationWeComLongOptions,
+  TWeComRuntimeStatus
+} from '../types.js'
+
+const WECOM_PLUGIN_NAME = '@xpert-ai/plugin-wecom'
+const WECOM_PROVIDER_KEY = 'wecom_long_integration'
+const STRATEGY_META_KEY = 'XPERT_STRATEGY_META_KEY'
+const VIEW_EXTENSION_PROVIDER = 'VIEW_EXTENSION_PROVIDER'
+
+const text = (en_US: string, zh_Hans: string): I18nObject => ({ en_US, zh_Hans })
+const ViewExtensionProvider = (providerKey: string) =>
+  applyDecorators(
+    SetMetadata(VIEW_EXTENSION_PROVIDER, providerKey),
+    SetMetadata(STRATEGY_META_KEY, VIEW_EXTENSION_PROVIDER)
+  )
+
+type WeComStatusSummary = {
+  connectionMode: string
+  state: string
+  botUser: string | null
+  ownerInstanceId: string | null
+  lastConnectedAt: string | null
+  lastDisconnectedAt: string | null
+  lastCallbackAt: string | null
+  lastPingAt: string | null
+  lastError: string | null
+  reconnectAttempts: number
+  disabledReason: string | null
+}
+
+type WeComViewHostContext = {
+  hostType: string
+  hostId: string
+  hostSnapshot?: Record<string, unknown>
+}
+
+type WeComViewManifest = {
+  key: string
+  title: I18nObject
+  hostType: string
+  slot: string
+  order: number
+  refreshable?: boolean
+  source: {
+    provider: string
+    plugin: string
+  }
+  view: {
+    type: string
+    items: Array<Record<string, unknown>>
+  }
+  dataSource: Record<string, unknown>
+  actions?: Array<Record<string, unknown>>
+}
+
+type WeComViewQuery = Record<string, unknown>
+
+type WeComViewDataResult = {
+  summary?: WeComStatusSummary
+}
+
+type WeComViewActionRequest = Record<string, unknown>
+
+type WeComViewActionResult = {
+  success: boolean
+  message?: I18nObject
+  refresh?: boolean
+}
+
+@Injectable()
+@ViewExtensionProvider(WECOM_PROVIDER_KEY)
+export class WeComIntegrationViewProvider {
+  constructor(
+    private readonly longConnectionService: WeComLongConnectionService,
+    private readonly wecomChannel: WeComChannelStrategy
+  ) {}
+
+  supports(context: WeComViewHostContext) {
+    if (context.hostType !== 'integration') {
+      return false
+    }
+
+    return [getStringProperty(context.hostSnapshot, 'provider'), getStringProperty(context.hostSnapshot, 'type')].some(
+      (value) => value === INTEGRATION_WECOM_LONG
+    )
+  }
+
+  getViewManifests(context: WeComViewHostContext, slot: string): WeComViewManifest[] {
+    if (slot !== 'detail.main_tabs') {
+      return []
+    }
+
+    return [
+      {
+        key: 'status',
+        title: text('Status', '状态'),
+        hostType: context.hostType,
+        slot,
+        order: 10,
+        refreshable: true,
+        source: {
+          provider: WECOM_PROVIDER_KEY,
+          plugin: WECOM_PLUGIN_NAME
+        },
+        view: {
+          type: 'stats',
+          items: [
+            { key: 'connectionMode', label: text('Connection Mode', '连接方式'), valueType: 'text' },
+            { key: 'state', label: text('State', '状态'), valueType: 'status' },
+            { key: 'botUser', label: text('Bot User / Bot ID', '机器人用户 / Bot ID'), valueType: 'text' },
+            { key: 'ownerInstanceId', label: text('Owner Instance', '持有实例'), valueType: 'text' },
+            { key: 'lastConnectedAt', label: text('Last Connected', '最近连接'), valueType: 'datetime' },
+            { key: 'lastDisconnectedAt', label: text('Last Disconnected', '最近断开'), valueType: 'datetime' },
+            { key: 'lastCallbackAt', label: text('Last Callback', '最近回调'), valueType: 'datetime' },
+            { key: 'lastPingAt', label: text('Last Ping', '最近心跳'), valueType: 'datetime' },
+            { key: 'lastError', label: text('Last Error', '最近错误'), valueType: 'text' },
+            { key: 'reconnectAttempts', label: text('Reconnect Attempts', '重连次数'), valueType: 'number' },
+            { key: 'disabledReason', label: text('Disabled Reason', '停止/禁用原因'), valueType: 'text' }
+          ]
+        },
+        dataSource: {
+          mode: 'platform',
+          cache: {
+            ttlMs: 15 * 1000
+          },
+          polling: {
+            enabled: true,
+            intervalMs: 15 * 1000
+          }
+        },
+        actions: [
+          {
+            key: 'refresh',
+            label: text('Refresh', '刷新'),
+            icon: 'ri-refresh-line',
+            placement: 'toolbar',
+            actionType: 'refresh'
+          },
+          {
+            key: 'reconnect',
+            label: text('Reconnect', '重连'),
+            icon: 'ri-restart-line',
+            placement: 'toolbar',
+            actionType: 'invoke'
+          },
+          {
+            key: 'disconnect',
+            label: text('Disconnect', '断开'),
+            icon: 'ri-plug-line',
+            placement: 'toolbar',
+            actionType: 'invoke',
+            confirm: {
+              title: text('Disconnect WeCom long connection', '断开企微长连接'),
+              message: text(
+                'Disconnect the current WeCom long connection session?',
+                '确认断开当前企微长连接会话吗？'
+              )
+            }
+          }
+        ]
+      }
+    ]
+  }
+
+  async getViewData(
+    context: WeComViewHostContext,
+    viewKey: string,
+    _query: WeComViewQuery
+  ): Promise<WeComViewDataResult> {
+    if (viewKey !== 'status') {
+      return {}
+    }
+
+    return {
+      summary: await this.getStatusSummary(context)
+    }
+  }
+
+  async executeViewAction(
+    context: WeComViewHostContext,
+    viewKey: string,
+    actionKey: string,
+    _request: WeComViewActionRequest
+  ): Promise<WeComViewActionResult> {
+    if (viewKey !== 'status') {
+      return {
+        success: false,
+        message: text('Unsupported action', '不支持的操作')
+      }
+    }
+
+    if (actionKey === 'refresh') {
+      return {
+        success: true,
+        message: text('WeCom view refreshed', 'WeCom 视图已刷新'),
+        refresh: true
+      }
+    }
+
+    const integration = await this.wecomChannel.readIntegrationById(context.hostId)
+    if (!integration || integration.provider !== INTEGRATION_WECOM_LONG) {
+      return {
+        success: false,
+        message: text('Integration not found', '未找到集成')
+      }
+    }
+
+    try {
+      if (actionKey === 'reconnect') {
+        await this.longConnectionService.reconnect(context.hostId)
+        return {
+          success: true,
+          message: text('WeCom long connection reconnected', 'WeCom 长连接已重连'),
+          refresh: true
+        }
+      }
+
+      if (actionKey === 'disconnect') {
+        await this.longConnectionService.disconnect(context.hostId)
+        return {
+          success: true,
+          message: text('WeCom long connection disconnected', 'WeCom 长连接已断开'),
+          refresh: true
+        }
+      }
+    } catch (error) {
+      const message = getErrorMessage(error)
+      return {
+        success: false,
+        message: text(message, message)
+      }
+    }
+
+    return {
+      success: false,
+      message: text('Unsupported action', '不支持的操作')
+    }
+  }
+
+  private async getStatusSummary(context: WeComViewHostContext): Promise<WeComStatusSummary> {
+    const fallback = buildFallbackStatusSummary(context.hostSnapshot)
+    const [runtimeResult, integrationResult] = await Promise.allSettled([
+      this.longConnectionService.status(context.hostId),
+      this.wecomChannel.readIntegrationById(context.hostId)
+    ])
+
+    const runtimeStatus = runtimeResult.status === 'fulfilled' ? runtimeResult.value : null
+    const integration =
+      integrationResult.status === 'fulfilled'
+        ? (integrationResult.value as { name?: string; options?: TIntegrationWeComLongOptions } | null)
+        : null
+
+    const botUser =
+      normalizeText(integration?.name) ||
+      normalizeText(integration?.options?.botId) ||
+      fallback.botUser
+
+    return {
+      connectionMode: runtimeStatus?.connectionMode ?? fallback.connectionMode,
+      state: runtimeStatus?.state ?? fallback.state,
+      botUser,
+      ownerInstanceId: runtimeStatus?.ownerInstanceId ?? null,
+      lastConnectedAt: formatDateTime(runtimeStatus?.lastConnectedAt ?? null),
+      lastDisconnectedAt: formatDateTime(runtimeStatus?.lastDisconnectedAt ?? null),
+      lastCallbackAt: formatDateTime(runtimeStatus?.lastCallbackAt ?? null),
+      lastPingAt: formatDateTime(runtimeStatus?.lastPingAt ?? null),
+      lastError: normalizeText(runtimeStatus?.lastError) ?? fallback.lastError,
+      reconnectAttempts: runtimeStatus?.reconnectAttempts ?? 0,
+      disabledReason: normalizeText(runtimeStatus?.disabledReason) ?? null
+    }
+  }
+}
+
+function buildFallbackStatusSummary(
+  snapshot: Record<string, unknown> | undefined
+): WeComStatusSummary {
+  const provider = getStringProperty(snapshot, 'provider')
+  const state = getStringProperty(snapshot, 'status') || 'idle'
+  return {
+    connectionMode: provider === INTEGRATION_WECOM_LONG ? 'long_connection' : 'webhook',
+    state,
+    botUser: getStringProperty(snapshot, 'name') || getStringProperty(snapshot, 'botId'),
+    ownerInstanceId: null,
+    lastConnectedAt: null,
+    lastDisconnectedAt: null,
+    lastCallbackAt: null,
+    lastPingAt: null,
+    lastError: null,
+    reconnectAttempts: 0,
+    disabledReason: null
+  }
+}
+
+function getStringProperty(value: unknown, key: string): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const candidate = Reflect.get(value, key)
+  return typeof candidate === 'string' && candidate.length > 0 ? candidate : null
+}
+
+function normalizeText(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function formatDateTime(value: number | null | undefined): string | null {
+  return typeof value === 'number' && Number.isFinite(value) ? new Date(value).toISOString() : null
+}

--- a/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.spec.ts
@@ -1,0 +1,78 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  __esModule: true,
+  CHAT_CHANNEL_TEXT_LIMITS: { wecom: 1000 },
+  ChatChannel: () => (target: unknown) => target,
+  INTEGRATION_PERMISSION_SERVICE_TOKEN: 'INTEGRATION_PERMISSION_SERVICE_TOKEN',
+  WorkflowTriggerStrategy: () => (target: unknown) => target,
+  defineChannelMessageType: (...parts: Array<string | number>) => parts.join('.'),
+  runWithRequestContext: async (_context: unknown, _store: unknown, callback: () => unknown) => await callback()
+}))
+
+import { WeComChannelStrategy } from './wecom-channel.strategy.js'
+
+describe('WeComChannelStrategy', () => {
+  function createFixture() {
+    const pluginContext = {
+      resolve: jest.fn()
+    }
+    const longConnection = {
+      sendRespondMessage: jest.fn(),
+      sendUpdateMessage: jest.fn(),
+      sendActiveMessage: jest.fn()
+    }
+
+    const strategy = new WeComChannelStrategy(pluginContext as any, longConnection as any)
+
+    return {
+      strategy
+    }
+  }
+
+  it('converts standard markdown into WeCom-compatible markdown before sending payloads', async () => {
+    const { strategy } = createFixture()
+
+    jest.spyOn(strategy as any, 'readIntegration').mockResolvedValue({
+      id: 'integration-1',
+      provider: 'wecom',
+      options: {
+        timeoutMs: 1200
+      }
+    })
+    jest.spyOn(strategy as any, 'resolveRobotContext').mockResolvedValue({
+      integrationId: 'integration-1',
+      provider: 'wecom',
+      senderId: 'sender-1',
+      chatId: 'chat-1',
+      responseUrl: 'https://example.com/respond',
+      reqId: null
+    })
+    const sendToResponseUrlPayload = jest.spyOn(strategy as any, 'sendToResponseUrlPayload').mockResolvedValue({
+      success: true,
+      messageId: 'message-1'
+    })
+
+    await strategy.sendRobotPayload({
+      integrationId: 'integration-1',
+      chatId: 'chat-1',
+      senderId: 'sender-1',
+      responseUrl: 'https://example.com/respond',
+      payload: {
+        msgtype: 'markdown',
+        markdown: {
+          content: ['##一级评估要点', '', '| 指标 | 说明 |', '| --- | --- |', '| 自动化 | 已覆盖 |'].join('\n')
+        }
+      }
+    })
+
+    expect(sendToResponseUrlPayload).toHaveBeenCalledWith(
+      'https://example.com/respond',
+      {
+        msgtype: 'markdown',
+        markdown: {
+          content: ['## 一级评估要点', '', '- **指标:** 自动化; **说明:** 已覆盖'].join('\n')
+        }
+      },
+      1200
+    )
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
@@ -26,6 +26,7 @@ import {
   TIntegrationWeComOptions,
   TWeComEvent
 } from './types.js'
+import { convertMarkdownToWeComMarkdown } from './wecom-markdown.js'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const RESPONSE_URL_CACHE_TTL_MS = 60 * 60 * 1000
@@ -119,6 +120,31 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
     media: false,
     textChunkLimit: CHAT_CHANNEL_TEXT_LIMITS['wecom'] || 2000,
     streamingUpdate: false
+  }
+
+  resolveConnectionMode(
+    integration: Pick<IIntegration<TIntegrationWeComOptions>, 'provider'> | TIntegrationWeComOptions | null | undefined
+  ): 'webhook' | 'long_connection' {
+    if (!integration || typeof integration !== 'object') {
+      return 'webhook'
+    }
+
+    if ('provider' in integration) {
+      return this.normalizeProvider(integration.provider) === INTEGRATION_WECOM_LONG ? 'long_connection' : 'webhook'
+    }
+
+    const options = integration as TIntegrationWeComOptions
+    return this.normalizeString(options.botId) && this.normalizeString(options.secret) ? 'long_connection' : 'webhook'
+  }
+
+  async readIntegrationById(id: string): Promise<IIntegration<TIntegrationWeComOptions> | null> {
+    if (!id) {
+      return null
+    }
+
+    return this.integrationPermissionService.read<IIntegration<TIntegrationWeComOptions>>(id, {
+      relations: ['tenant']
+    })
   }
 
   createEventHandler(
@@ -268,6 +294,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
     const integration = await this.readIntegration(params.integrationId)
     const provider = this.normalizeProvider(integration.provider)
     const timeoutMs = this.normalizeTimeout(params.timeoutMs, this.normalizeTimeout(integration.options?.timeoutMs, DEFAULT_TIMEOUT_MS))
+    const payload = this.normalizeOutboundPayload(params.payload)
 
     const context = await this.resolveRobotContext({
       integrationId: integration.id,
@@ -294,14 +321,14 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
         }
       }
 
-      return this.sendToResponseUrlPayload(context.responseUrl, params.payload, timeoutMs)
+      return this.sendToResponseUrlPayload(context.responseUrl, payload, timeoutMs)
     }
 
     if (context.reqId) {
       await this.longConnection.sendRespondMessage({
         integrationId: context.integrationId,
         reqId: context.reqId,
-        body: params.payload,
+        body: payload,
         timeoutMs
       })
       return {
@@ -321,7 +348,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
     await this.longConnection.sendActiveMessage({
       integrationId: context.integrationId,
       chatId: targetChatId,
-      body: params.payload,
+      body: payload,
       timeoutMs
     })
 
@@ -921,12 +948,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
   }
 
   private async readIntegration(integrationId: string): Promise<IIntegration<TIntegrationWeComOptions>> {
-    const integration = await this.integrationPermissionService.read<IIntegration<TIntegrationWeComOptions>>(
-      integrationId,
-      {
-        relations: ['tenant']
-      }
-    )
+    const integration = await this.readIntegrationById(integrationId)
 
     if (!integration) {
       throw new Error(`Integration ${integrationId} not found`)
@@ -1034,6 +1056,32 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
       return null
     }
     return value as Record<string, unknown>
+  }
+
+  private normalizeOutboundPayload(payload: Record<string, unknown>): Record<string, unknown> {
+    const payloadRecord = this.normalizeRecord(payload)
+    if (!payloadRecord) {
+      return payload
+    }
+
+    const msgType = typeof payloadRecord.msgtype === 'string' ? payloadRecord.msgtype.trim().toLowerCase() : ''
+    if (msgType !== 'markdown') {
+      return payload
+    }
+
+    const markdownPayload = this.normalizeRecord(payloadRecord.markdown)
+    const content = typeof markdownPayload?.content === 'string' ? markdownPayload.content : null
+    if (content == null) {
+      return payload
+    }
+
+    return {
+      ...payloadRecord,
+      markdown: {
+        ...(markdownPayload ?? {}),
+        content: convertMarkdownToWeComMarkdown(content)
+      }
+    }
   }
 
   private normalizeMentions(value: unknown): Array<{ id: string; name?: string }> | undefined {

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.spec.ts
@@ -1,0 +1,186 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  __esModule: true,
+  CHAT_CHANNEL_TEXT_LIMITS: { wecom: 1000 },
+  ChatChannel: () => (target: unknown) => target,
+  INTEGRATION_PERMISSION_SERVICE_TOKEN: 'INTEGRATION_PERMISSION_SERVICE_TOKEN',
+  RequestContext: {
+    currentUser: jest.fn()
+  },
+  defineChannelMessageType: (...parts: Array<string | number>) => parts.join('.'),
+  WorkflowTriggerStrategy: () => (target: unknown) => target,
+  runWithRequestContext: async (_context: unknown, _store: unknown, callback: () => unknown) => await callback()
+}))
+
+import { WeComConversationService } from './conversation.service.js'
+import { WeComChannelStrategy } from './wecom-channel.strategy.js'
+import { WECOM_PLUGIN_CONTEXT } from './tokens.js'
+import { TIntegrationWeComLongOptions } from './types.js'
+import { WeComLongConnectionService } from './wecom-long-connection.service.js'
+
+function createRedisMock() {
+  const store = new Map<string, string>()
+  const sets = new Map<string, Set<string>>()
+  const hashes = new Map<string, Record<string, string>>()
+
+  return {
+    set: jest.fn(async (key: string, value: string) => {
+      store.set(key, value)
+      return 'OK'
+    }),
+    get: jest.fn(async (key: string) => store.get(key) ?? null),
+    del: jest.fn(async (...keys: string[]) => {
+      keys.forEach((key) => {
+        store.delete(key)
+        sets.delete(key)
+        hashes.delete(key)
+      })
+      return 1
+    }),
+    sadd: jest.fn(async (key: string, ...members: string[]) => {
+      const current = sets.get(key) ?? new Set<string>()
+      members.forEach((member) => current.add(member))
+      sets.set(key, current)
+      return current.size
+    }),
+    srem: jest.fn(async (key: string, ...members: string[]) => {
+      const current = sets.get(key) ?? new Set<string>()
+      members.forEach((member) => current.delete(member))
+      sets.set(key, current)
+      return 1
+    }),
+    smembers: jest.fn(async (key: string) => [...(sets.get(key) ?? new Set<string>())]),
+    sismember: jest.fn(async (key: string, member: string) => Number((sets.get(key) ?? new Set<string>()).has(member))),
+    hSet: jest.fn(async (key: string, value: Record<string, string>) => {
+      hashes.set(key, { ...value })
+      return 1
+    }),
+    hGetAll: jest.fn(async (key: string) => hashes.get(key) ?? {}),
+    expire: jest.fn(async () => 1),
+    eval: jest.fn(async () => 1)
+  }
+}
+
+describe('WeComLongConnectionService', () => {
+  function createIntegration(
+    overrides?: Partial<{ enabled: boolean; options: Partial<TIntegrationWeComLongOptions> }>
+  ) {
+    return {
+      id: 'integration-1',
+      provider: 'wecom_long',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      enabled: overrides?.enabled ?? true,
+      options: {
+        botId: 'bot-1',
+        secret: 'secret-1',
+        xpertId: 'xpert-1',
+        timeoutMs: 10000,
+        ...(overrides?.options ?? {})
+      }
+    }
+  }
+
+  function createFixture(overrides?: Partial<{ integration: ReturnType<typeof createIntegration> }>) {
+    const redis = createRedisMock()
+    const integration = overrides?.integration ?? createIntegration()
+    const integrationPermissionService = {
+      read: jest.fn().mockResolvedValue(integration),
+      findAll: jest.fn().mockResolvedValue({ items: [integration] })
+    }
+    const pluginContext = {
+      resolve: jest.fn((token: string) => {
+        if (token === 'INTEGRATION_PERMISSION_SERVICE_TOKEN') {
+          return integrationPermissionService
+        }
+        if (token === 'REDIS_CLIENT') {
+          return redis
+        }
+        throw new Error(`Unknown token: ${token}`)
+      })
+    }
+
+    const service = new WeComLongConnectionService(
+      pluginContext as any,
+      {} as WeComChannelStrategy,
+      {} as WeComConversationService
+    )
+
+    return {
+      service,
+      redis,
+      integrationPermissionService,
+      integration
+    }
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('disconnect persists manual disconnect runtime status in redis', async () => {
+    const { service, integration } = createFixture()
+    ;(service as any).ensureSession(integration)
+
+    await service.disconnect('integration-1')
+
+    await expect(service.status('integration-1')).resolves.toMatchObject({
+      integrationId: 'integration-1',
+      state: 'idle',
+      connected: false,
+      shouldRun: false,
+      disabledReason: 'manual_disconnect'
+    })
+  })
+
+  it('bootstraps enabled integrations on module init', async () => {
+    const { service } = createFixture()
+    const connectSpy = jest.spyOn(service, 'connect').mockResolvedValue({
+      integrationId: 'integration-1',
+      connectionMode: 'long_connection',
+      connected: false,
+      state: 'idle'
+    } as any)
+
+    await service.onModuleInit()
+
+    expect(connectSpy).toHaveBeenCalledWith('integration-1')
+  })
+
+  it('resets unhealthy session state when connectWithConfig is called', async () => {
+    const { service, integration } = createFixture()
+    const session = (service as any).ensureSession(integration)
+    Object.assign(session, {
+      state: 'unhealthy',
+      shouldRun: false,
+      failureCount: 2,
+      reconnectAttempts: 3,
+      pingFailureCount: 1,
+      disabledReason: 'config_invalid',
+      lastError: 'invalid secret',
+      nextReconnectAt: 123
+    })
+
+    const stopSessionSpy = jest.spyOn(service as any, 'stopSession').mockResolvedValue(undefined)
+    const startSessionSpy = jest.spyOn(service as any, 'startSession').mockImplementation(async () => {
+      expect(session.state).toBe('idle')
+      expect(session.shouldRun).toBe(true)
+      expect(session.failureCount).toBe(0)
+      expect(session.reconnectAttempts).toBe(0)
+      expect(session.pingFailureCount).toBe(0)
+      expect(session.disabledReason).toBeNull()
+      expect(session.lastError).toBeNull()
+      expect(session.nextReconnectAt).toBeNull()
+    })
+
+    await service.connectWithConfig({
+      integrationId: integration.id,
+      botId: 'bot-1',
+      secret: 'secret-2',
+      timeoutMs: 10000
+    })
+
+    expect(stopSessionSpy).toHaveBeenCalledWith(session, true)
+    expect(startSessionSpy).toHaveBeenCalledWith(session)
+    expect(session.secret).toBe('secret-2')
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { createRequire } from 'module'
-import { forwardRef, Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common'
+import { hostname } from 'os'
+import { forwardRef, Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
 import express from 'express'
 import { IIntegration, IUser } from '@metad/contracts'
 import {
@@ -17,18 +18,47 @@ import { WECOM_PLUGIN_CONTEXT } from './tokens.js'
 import {
   INTEGRATION_WECOM_LONG,
   TIntegrationWeComLongOptions,
-  TIntegrationWeComOptions
+  TIntegrationWeComOptions,
+  TWeComLongDisabledReason,
+  TWeComLongRuntimeState,
+  TWeComRuntimeStatus
 } from './types.js'
 import { WeComChannelStrategy } from './wecom-channel.strategy.js'
+import {
+  classifyWeComLongConnectionError,
+  getWeComLongConnectionLockKey,
+  getWeComLongConnectionOwnerKey,
+  getWeComLongConnectionRegistryKey,
+  getWeComLongConnectionStatusKey
+} from './wecom-long-connection.utils.js'
 
 const require = createRequire(import.meta.url)
 
-type LongSessionState = 'disconnected' | 'connecting' | 'connected' | 'error'
+type RedisLike = {
+  set?: (...args: any[]) => Promise<any>
+  get?: (key: string) => Promise<string | null>
+  del?: (...keys: string[]) => Promise<any>
+  sadd?: (key: string, ...members: string[]) => Promise<any>
+  sAdd?: (key: string, members: string[] | string) => Promise<any>
+  srem?: (key: string, ...members: string[]) => Promise<any>
+  sRem?: (key: string, members: string[] | string) => Promise<any>
+  smembers?: (key: string) => Promise<string[]>
+  sMembers?: (key: string) => Promise<string[]>
+  sismember?: (key: string, member: string) => Promise<number | boolean>
+  sIsMember?: (key: string, member: string) => Promise<number | boolean>
+  hset?: (key: string, ...args: string[]) => Promise<any>
+  hSet?: (key: string, value: Record<string, string>) => Promise<any>
+  hgetall?: (key: string) => Promise<Record<string, string>>
+  hGetAll?: (key: string) => Promise<Record<string, string>>
+  expire?: (key: string, seconds: number) => Promise<any>
+  eval?: (...args: any[]) => Promise<any>
+}
 
 type PendingRequest = {
   resolve: (value: Record<string, unknown>) => void
   reject: (reason: unknown) => void
   timer: NodeJS.Timeout
+  command: string
 }
 
 type WeComLongSession = {
@@ -38,26 +68,25 @@ type WeComLongSession = {
   wsOrigin: string | null
   timeoutMs: number
   shouldRun: boolean
-  state: LongSessionState
-  connectedAt?: number
-  disconnectedAt?: number
-  lastError?: string
+  state: TWeComLongRuntimeState
+  lockId?: string | null
+  ownerInstanceId?: string | null
+  connectedAt?: number | null
+  disconnectedAt?: number | null
+  lastCallbackAt?: number | null
+  lastPingAt?: number | null
+  lastError?: string | null
   reconnectAttempts: number
+  failureCount: number
+  nextReconnectAt?: number | null
+  disabledReason?: TWeComLongDisabledReason | null
   websocket: any | null
   pingTimer: NodeJS.Timeout | null
+  watchdogTimer: NodeJS.Timeout | null
+  renewTimer: NodeJS.Timeout | null
   reconnectTimer: NodeJS.Timeout | null
   pendingRequests: Map<string, PendingRequest>
-}
-
-export type WeComLongConnectionStatus = {
-  integrationId: string
-  state: LongSessionState
-  connected: boolean
-  shouldRun: boolean
-  connectedAt?: number
-  disconnectedAt?: number
-  reconnectAttempts: number
-  lastError?: string
+  pingFailureCount: number
 }
 
 type WeComLongCommandResult = {
@@ -67,18 +96,41 @@ type WeComLongCommandResult = {
   raw: Record<string, unknown>
 }
 
+export type WeComLongConnectionStatus = {
+  integrationId: string
+  state: 'disconnected' | 'connecting' | 'connected' | 'error'
+  connected: boolean
+  shouldRun: boolean
+  connectedAt?: number
+  disconnectedAt?: number
+  reconnectAttempts: number
+  lastError?: string
+  disabledReason?: TWeComLongDisabledReason | null
+}
+
+const REDIS_CLIENT_TOKEN = 'REDIS_CLIENT'
 const WECOM_LONG_WS_URL = 'wss://openws.work.weixin.qq.com'
 const DEFAULT_TIMEOUT_MS = 10000
 const MIN_TIMEOUT_MS = 1000
 const MAX_TIMEOUT_MS = 120000
 const PING_INTERVAL_MS = 30 * 1000
-const MAX_RECONNECT_DELAY_MS = 30 * 1000
+const WATCHDOG_INTERVAL_MS = 30 * 1000
+const WATCHDOG_STALE_MS = PING_INTERVAL_MS * 3
+const LOCK_TTL_MS = 45_000
+const RENEW_INTERVAL_MS = 15_000
+const DEFAULT_RETRY_MS = 5_000
+const MAX_RETRY_MS = 30_000
+const MAX_UNRECOVERABLE_FAILURES = 3
+const MAX_PING_FAILURES = 2
+const INITIAL_CONNECT_TIMEOUT_MS = 10_000
 
 @Injectable()
-export class WeComLongConnectionService implements OnModuleDestroy {
+export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(WeComLongConnectionService.name)
+  private readonly instanceId = `${hostname()}:${process.pid}:${randomUUID().slice(0, 8)}`
   private readonly sessions = new Map<string, WeComLongSession>()
   private _integrationPermissionService: IntegrationPermissionService
+  private _redis: RedisLike | null | undefined
 
   constructor(
     @Inject(WECOM_PLUGIN_CONTEXT)
@@ -95,29 +147,66 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     return this._integrationPermissionService
   }
 
-  async onModuleDestroy(): Promise<void> {
-    const tasks = [...this.sessions.keys()].map((integrationId) => this.disconnect(integrationId))
-    await Promise.allSettled(tasks)
+  private get redis(): RedisLike | null {
+    if (this._redis === undefined) {
+      try {
+        this._redis = this.pluginContext.resolve(REDIS_CLIENT_TOKEN) as RedisLike
+      } catch {
+        this._redis = null
+      }
+    }
+    return this._redis
   }
 
-  async connect(integrationId: string): Promise<WeComLongConnectionStatus> {
-    const integration = await this.readLongIntegration(integrationId)
-    const botId = this.normalizeString(integration.options?.botId)
-    const secret = this.normalizeString(integration.options?.secret)
-    const wsOrigin = this.normalizeString(integration.options?.wsOrigin)
+  async onModuleInit(): Promise<void> {
+    const integrationIds = await this.loadBootstrapIntegrationIds()
+    this.logger.debug(`[wecom-long] bootstrapping long connection sessions for integrations: [${integrationIds.join(', ')}]`)
+    await Promise.allSettled(integrationIds.map((integrationId) => this.connect(integrationId)))
+  }
 
-    if (!botId || !secret) {
-      throw new Error(`Integration ${integrationId} missing botId/secret`)
+  async onModuleDestroy(): Promise<void> {
+    await Promise.allSettled([...this.sessions.values()].map((session) => this.stopSession(session, true)))
+  }
+
+  async connect(integrationId: string): Promise<TWeComRuntimeStatus> {
+    const integration = await this.safeReadLongIntegration(integrationId)
+    if (!integration) {
+      await this.dropMissingIntegration(integrationId)
+      return this.readStoredStatus(integrationId)
     }
 
-    const timeoutMs = this.normalizeTimeout(integration.options?.timeoutMs, DEFAULT_TIMEOUT_MS)
-    return this.connectWithConfig({
-      integrationId,
-      botId,
-      secret,
-      wsOrigin,
-      timeoutMs
-    })
+    const skipReason = this.resolveRestoreSkipReason(integration)
+    if (skipReason) {
+      await this.unregisterIntegration(integrationId)
+      await this.removeSession(integrationId)
+      await this.writeDetachedStatus(integrationId, skipReason, {
+        shouldRun: false,
+        lastError:
+          skipReason === 'integration_disabled'
+            ? 'Integration is disabled'
+            : skipReason === 'xpert_unbound'
+              ? 'Xpert is unbound'
+              : 'Restore skipped'
+      })
+      return this.readStoredStatus(integrationId)
+    }
+
+    await this.registerIntegration(integrationId)
+    const session = this.ensureSession(integration)
+
+    if (session.state === 'unhealthy') {
+      await this.writeStatus(session)
+      return this.buildStatus(session)
+    }
+
+    if (session.state === 'connected' && this.isSocketOpen(session.websocket)) {
+      this.refreshSessionState(session)
+      await this.writeStatus(session)
+      return this.buildStatus(session)
+    }
+
+    await this.startSession(session)
+    return this.buildStatus(session)
   }
 
   async connectWithConfig(params: {
@@ -126,7 +215,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     secret: string
     wsOrigin?: string | null
     timeoutMs?: number
-  }): Promise<WeComLongConnectionStatus> {
+  }): Promise<TWeComRuntimeStatus> {
     const integrationId = this.normalizeString(params.integrationId)
     const botId = this.normalizeString(params.botId)
     const secret = this.normalizeString(params.secret)
@@ -140,6 +229,8 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     }
 
     const timeoutMs = this.normalizeTimeout(params.timeoutMs, DEFAULT_TIMEOUT_MS)
+    await this.registerIntegration(integrationId)
+
     const existing = this.sessions.get(integrationId)
     const shouldRestart =
       !!existing &&
@@ -147,80 +238,142 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       (existing.botId !== botId || existing.secret !== secret || existing.wsOrigin !== wsOrigin)
 
     if (shouldRestart) {
-      await this.disconnect(integrationId)
+      await this.disconnect(integrationId, {
+        reason: 'runtime_error',
+        unregister: false
+      })
     }
 
     const session = this.ensureSession({
-      integrationId,
-      botId,
-      secret,
-      wsOrigin,
-      timeoutMs
-    })
-
-    if (session.state === 'connected') {
-      session.shouldRun = true
-      return this.buildStatus(session)
-    }
+      id: integrationId,
+      tenantId: '',
+      organizationId: '',
+      provider: INTEGRATION_WECOM_LONG,
+      options: {
+        botId,
+        secret,
+        wsOrigin: wsOrigin || undefined,
+        timeoutMs
+      }
+    } as IIntegration<TIntegrationWeComLongOptions>)
 
     session.shouldRun = true
 
-    await this.connectSession(session)
+    if (session.state === 'unhealthy') {
+      this.resetSessionForReconnect(session)
+      await this.writeStatus(session)
+      await this.stopSession(session, true)
+      await this.startSession(session)
+      return this.buildStatus(session)
+    }
+
+    if (session.state === 'connected' && this.isSocketOpen(session.websocket)) {
+      await this.writeStatus(session)
+      return this.buildStatus(session)
+    }
+
+    await this.startSession(session)
     return this.buildStatus(session)
   }
 
-  async disconnect(integrationId: string): Promise<WeComLongConnectionStatus> {
-    const session = this.sessions.get(integrationId)
-    if (!session) {
-      return {
-        integrationId,
-        state: 'disconnected',
-        connected: false,
-        shouldRun: false,
-        reconnectAttempts: 0
-      }
+  async reconnect(integrationId: string): Promise<TWeComRuntimeStatus> {
+    const integration = await this.safeReadLongIntegration(integrationId)
+    if (!integration) {
+      await this.dropMissingIntegration(integrationId)
+      return this.readStoredStatus(integrationId)
     }
 
-    session.shouldRun = false
-    this.clearPingTimer(session)
-    this.clearReconnectTimer(session)
-
-    for (const [reqId, pending] of session.pendingRequests.entries()) {
-      clearTimeout(pending.timer)
-      pending.reject(new Error(`Long connection is closing (integration=${integrationId}, reqId=${reqId})`))
-    }
-    session.pendingRequests.clear()
-
-    if (session.websocket) {
-      try {
-        session.websocket.close()
-      } catch (error) {
-        this.logger.warn(
-          `[wecom-long] close socket failed integration=${integrationId}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        )
-      }
-      session.websocket = null
+    const skipReason = this.resolveRestoreSkipReason(integration)
+    if (skipReason) {
+      await this.disconnect(integrationId, {
+        reason: skipReason,
+        unregister: true
+      })
+      return this.readStoredStatus(integrationId)
     }
 
-    session.state = 'disconnected'
-    session.disconnectedAt = Date.now()
-
+    await this.registerIntegration(integrationId)
+    const session = this.ensureSession(integration)
+    this.resetSessionForReconnect(session)
+    await this.writeStatus(session)
+    await this.stopSession(session, true)
+    await this.startSession(session)
     return this.buildStatus(session)
   }
 
-  async status(integrationId: string): Promise<WeComLongConnectionStatus> {
+  async disconnect(
+    integrationId: string,
+    options?: {
+      reason?: TWeComLongDisabledReason | null
+      unregister?: boolean
+      clearStatus?: boolean
+    }
+  ): Promise<TWeComRuntimeStatus> {
+    const reason = options?.reason ?? 'manual_disconnect'
+    const unregister = options?.unregister !== false
+    const clearStatus = options?.clearStatus === true
+
+    if (unregister) {
+      await this.unregisterIntegration(integrationId)
+    }
+
+    const session = this.sessions.get(integrationId)
+    if (session) {
+      session.shouldRun = false
+      session.disabledReason = reason
+      session.nextReconnectAt = null
+      session.ownerInstanceId = null
+      session.disconnectedAt = Date.now()
+      session.state = 'idle'
+      session.lastError = session.lastError ?? this.describeDisabledReason(reason)
+      await this.stopSession(session, true)
+      this.sessions.delete(integrationId)
+    }
+
+    if (clearStatus) {
+      await this.clearStatus(integrationId)
+      return this.buildDetachedStatus(integrationId)
+    }
+
+    await this.writeDetachedStatus(integrationId, reason, {
+      shouldRun: false,
+      lastError: reason ? this.describeDisabledReason(reason) : null,
+      lastDisconnectedAt: Date.now()
+    })
+
+    return this.readStoredStatus(integrationId)
+  }
+
+  async status(integrationId: string): Promise<TWeComRuntimeStatus> {
+    const integration = await this.safeReadLongIntegration(integrationId)
+    if (!integration) {
+      await this.dropMissingIntegration(integrationId)
+      return this.readStoredStatus(integrationId)
+    }
+
+    const skipReason = this.resolveRestoreSkipReason(integration)
+    if (skipReason) {
+      await this.unregisterIntegration(integrationId)
+      await this.removeSession(integrationId)
+      await this.writeDetachedStatus(integrationId, skipReason, {
+        shouldRun: false,
+        lastError: this.describeDisabledReason(skipReason)
+      })
+      return this.readStoredStatus(integrationId)
+    }
+
     const session = this.sessions.get(integrationId)
     if (!session) {
-      return {
-        integrationId,
-        state: 'disconnected',
-        connected: false,
-        shouldRun: false,
-        reconnectAttempts: 0
+      if (await this.isRegistered(integrationId)) {
+        void this.connect(integrationId).catch((error) => {
+          this.logger.warn(`[wecom-long] lazy connect failed integration=${integrationId}: ${this.stringifyError(error)}`)
+        })
       }
+      return this.readStoredStatus(integrationId)
     }
+
+    this.refreshSessionState(session)
+    await this.writeStatus(session)
     return this.buildStatus(session)
   }
 
@@ -309,59 +462,95 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     }
   }
 
-  private ensureSession(params: {
-    integrationId: string
-    botId: string
-    secret: string
-    wsOrigin: string | null
-    timeoutMs: number
-  }): WeComLongSession {
-    const existing = this.sessions.get(params.integrationId)
+  private ensureSession(integration: IIntegration<TIntegrationWeComLongOptions>): WeComLongSession {
+    const botId = this.normalizeString(integration.options?.botId)
+    const secret = this.normalizeString(integration.options?.secret)
+    if (!botId || !secret) {
+      throw new Error(`Integration ${integration.id} missing botId/secret`)
+    }
+
+    const existing = this.sessions.get(integration.id)
     if (existing) {
-      existing.botId = params.botId
-      existing.secret = params.secret
-      existing.wsOrigin = params.wsOrigin
-      existing.timeoutMs = params.timeoutMs
+      existing.botId = botId
+      existing.secret = secret
+      existing.wsOrigin = this.normalizeString(integration.options?.wsOrigin)
+      existing.timeoutMs = this.normalizeTimeout(integration.options?.timeoutMs, DEFAULT_TIMEOUT_MS)
       return existing
     }
 
     const created: WeComLongSession = {
-      integrationId: params.integrationId,
-      botId: params.botId,
-      secret: params.secret,
-      wsOrigin: params.wsOrigin,
-      timeoutMs: params.timeoutMs,
+      integrationId: integration.id,
+      botId,
+      secret,
+      wsOrigin: this.normalizeString(integration.options?.wsOrigin),
+      timeoutMs: this.normalizeTimeout(integration.options?.timeoutMs, DEFAULT_TIMEOUT_MS),
       shouldRun: false,
-      state: 'disconnected',
+      state: 'idle',
+      lockId: null,
+      ownerInstanceId: null,
+      connectedAt: null,
+      disconnectedAt: null,
+      lastCallbackAt: null,
+      lastPingAt: null,
+      lastError: null,
       reconnectAttempts: 0,
+      failureCount: 0,
+      nextReconnectAt: null,
+      disabledReason: null,
       websocket: null,
       pingTimer: null,
+      watchdogTimer: null,
+      renewTimer: null,
       reconnectTimer: null,
-      pendingRequests: new Map()
+      pendingRequests: new Map(),
+      pingFailureCount: 0
     }
 
-    this.sessions.set(params.integrationId, created)
+    this.sessions.set(integration.id, created)
     return created
   }
 
-  private async connectSession(session: WeComLongSession): Promise<void> {
-    if (session.state === 'connecting' || session.state === 'connected') {
+  private async startSession(session: WeComLongSession): Promise<void> {
+    if (session.state === 'connecting' || session.state === 'connected' || session.state === 'unhealthy') {
+      await this.writeStatus(session)
       return
     }
 
-    const WebSocketImpl = this.resolveWebSocketImpl()
+    if (!session.shouldRun) {
+      session.state = 'idle'
+      await this.writeStatus(session)
+      return
+    }
 
+    const lockKey = getWeComLongConnectionLockKey({ botId: session.botId })
+    const ownerKey = getWeComLongConnectionOwnerKey({ botId: session.botId })
+    const lockId = await this.acquireLock(lockKey, LOCK_TTL_MS)
+    if (!lockId) {
+      session.state = 'retrying'
+      session.disabledReason = 'lease_conflict'
+      session.lastError = 'Waiting for long-connection ownership from another instance'
+      session.ownerInstanceId = await this.readOwnerInstanceId(ownerKey)
+      this.scheduleReconnect(session, DEFAULT_RETRY_MS)
+      await this.writeStatus(session)
+      return
+    }
+
+    session.lockId = lockId
+    session.ownerInstanceId = this.instanceId
     session.state = 'connecting'
-    session.lastError = undefined
+    session.lastError = null
+    session.disabledReason = null
+    session.nextReconnectAt = null
+    await this.writeOwner(session, ownerKey)
+    await this.writeStatus(session)
 
     let websocket: any = null
     try {
+      const WebSocketImpl = this.resolveWebSocketImpl()
       const options = session.wsOrigin ? { origin: session.wsOrigin } : undefined
       websocket = new WebSocketImpl(WECOM_LONG_WS_URL, options)
     } catch (error) {
-      session.state = 'error'
-      session.lastError = error instanceof Error ? error.message : String(error)
-      this.scheduleReconnect(session)
+      await this.handleStartFailure(session, error)
       throw error
     }
 
@@ -374,47 +563,55 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       }
       this.handleIncomingMessage(session, text).catch((error) => {
         this.logger.error(
-          `[wecom-long] handle incoming failed integration=${session.integrationId}: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `[wecom-long] handle incoming failed integration=${session.integrationId}: ${this.stringifyError(error)}`,
           error instanceof Error ? error.stack : undefined
         )
       })
     })
 
     websocket.on('close', () => {
-      this.handleSocketClosed(session)
+      void this.handleSocketClosed(session)
     })
 
     websocket.on('error', (error: unknown) => {
-      const message =
-        (error instanceof Error ? error.message : null) ||
-        this.normalizeString((error as any)?.message) ||
-        'websocket error'
+      const message = this.stringifyError(error) || 'websocket error'
       session.lastError = message
       this.logger.warn(`[wecom-long] socket error integration=${session.integrationId}: ${message}`)
     })
 
-    await this.waitForOpen(session)
+    try {
+      await this.waitForOpen(session)
 
-    const subscribeReqId = randomUUID()
-    await this.sendCommand(session.integrationId, {
-      cmd: 'aibot_subscribe',
-      reqId: subscribeReqId,
-      useProvidedReqId: true,
-      allowConnecting: true,
-      timeoutMs: session.timeoutMs,
-      body: {
-        bot_id: session.botId,
-        secret: session.secret
-      }
-    })
+      const subscribeReqId = randomUUID()
+      await this.sendCommand(session.integrationId, {
+        cmd: 'aibot_subscribe',
+        reqId: subscribeReqId,
+        useProvidedReqId: true,
+        allowConnecting: true,
+        timeoutMs: session.timeoutMs,
+        body: {
+          bot_id: session.botId,
+          secret: session.secret
+        }
+      })
 
-    session.state = 'connected'
-    session.connectedAt = Date.now()
-    session.reconnectAttempts = 0
-    this.startPing(session)
-    this.logger.log(`[wecom-long] connected integration=${session.integrationId}`)
+      session.state = 'connected'
+      session.connectedAt = Date.now()
+      session.disconnectedAt = null
+      session.reconnectAttempts = 0
+      session.failureCount = 0
+      session.pingFailureCount = 0
+      session.disabledReason = null
+      session.lastError = null
+      session.nextReconnectAt = null
+      await this.writeStatus(session)
+      this.startRenew(session)
+      this.startPing(session)
+      this.startWatchdog(session)
+      this.logger.log(`[wecom-long] connected integration=${session.integrationId}`)
+    } catch (error) {
+      await this.handleStartFailure(session, error)
+    }
   }
 
   private async waitForOpen(session: WeComLongSession): Promise<void> {
@@ -423,11 +620,11 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       throw new Error('WebSocket not initialized')
     }
 
-    if (websocket.readyState === 1) {
+    if (this.isSocketOpen(websocket)) {
       return
     }
 
-    const timeoutMs = session.timeoutMs
+    const timeoutMs = session.timeoutMs || INITIAL_CONNECT_TIMEOUT_MS
     await new Promise<void>((resolve, reject) => {
       let resolved = false
       let timer: NodeJS.Timeout
@@ -449,11 +646,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
         resolved = true
         cleanup()
         clearTimeout(timer)
-        const message =
-          (event instanceof Error ? event.message : null) ||
-          this.normalizeString((event as any)?.message) ||
-          'websocket open failed'
-        reject(new Error(message))
+        reject(new Error(this.stringifyError(event) || 'websocket open failed'))
       }
 
       const cleanup = () => {
@@ -482,8 +675,48 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     })
   }
 
-  private handleSocketClosed(session: WeComLongSession): void {
+  private async handleStartFailure(session: WeComLongSession, error: unknown): Promise<void> {
+    const classification = classifyWeComLongConnectionError(error)
+    session.lastError = classification.reason
+    session.connectedAt = null
+    session.ownerInstanceId = null
+
+    if (!classification.recoverable) {
+      session.failureCount += 1
+    }
+
+    if (!classification.recoverable && session.failureCount >= MAX_UNRECOVERABLE_FAILURES) {
+      session.state = 'unhealthy'
+      session.disabledReason = classification.disabledReason
+      session.nextReconnectAt = null
+      session.shouldRun = false
+      await this.unregisterIntegration(session.integrationId)
+      await this.stopSession(session, true)
+      await this.writeStatus(session)
+      this.logger.error(
+        `[wecom-long] unhealthy integration=${session.integrationId} bot=${session.botId}: ${session.lastError}`
+      )
+      return
+    }
+
+    session.state = 'retrying'
+    session.disabledReason = classification.disabledReason
+    await this.stopSession(session, true)
+    this.scheduleReconnect(session, DEFAULT_RETRY_MS)
+    await this.writeStatus(session)
+    this.logger.warn(
+      `[wecom-long] connect failed integration=${session.integrationId} recoverable=${classification.recoverable}: ${session.lastError}`
+    )
+  }
+
+  private async handleSocketClosed(session: WeComLongSession): Promise<void> {
+    if (this.sessions.get(session.integrationId) !== session) {
+      return
+    }
+
     this.clearPingTimer(session)
+    this.clearWatchdogTimer(session)
+    this.clearRenewTimer(session)
     for (const [reqId, pending] of session.pendingRequests.entries()) {
       clearTimeout(pending.timer)
       pending.reject(new Error(`Socket closed before response (reqId=${reqId})`))
@@ -491,32 +724,43 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     session.pendingRequests.clear()
 
     session.websocket = null
+    const previousLockId = session.lockId
+    session.lockId = null
+    session.ownerInstanceId = null
+    if (previousLockId) {
+      await this.releaseLock(getWeComLongConnectionLockKey({ botId: session.botId }), previousLockId)
+      await this.clearOwner(session)
+    }
     session.disconnectedAt = Date.now()
     if (session.shouldRun) {
-      session.state = 'error'
-      this.scheduleReconnect(session)
+      session.state = 'retrying'
+      session.disabledReason = session.disabledReason || 'runtime_error'
+      this.scheduleReconnect(session, DEFAULT_RETRY_MS)
+      await this.writeStatus(session)
       this.logger.warn(`[wecom-long] disconnected integration=${session.integrationId}, schedule reconnect`)
       return
     }
 
-    session.state = 'disconnected'
+    session.state = 'idle'
+    await this.writeStatus(session)
     this.logger.log(`[wecom-long] disconnected integration=${session.integrationId}`)
   }
 
-  private scheduleReconnect(session: WeComLongSession): void {
-    if (!session.shouldRun) {
-      return
-    }
-    if (session.reconnectTimer) {
+  private scheduleReconnect(session: WeComLongSession, delayOverrideMs?: number): void {
+    if (!session.shouldRun || session.state === 'unhealthy' || session.reconnectTimer) {
       return
     }
 
+    session.state = 'retrying'
     session.reconnectAttempts += 1
-    const delay = Math.min(1000 * Math.pow(2, session.reconnectAttempts - 1), MAX_RECONNECT_DELAY_MS)
+    const delay =
+      delayOverrideMs ??
+      Math.min(1000 * Math.pow(2, Math.max(session.reconnectAttempts - 1, 0)), MAX_RETRY_MS)
+    session.nextReconnectAt = Date.now() + delay
     session.reconnectTimer = setTimeout(() => {
       session.reconnectTimer = null
-      this.connectSession(session).catch((error) => {
-        session.lastError = error instanceof Error ? error.message : String(error)
+      void this.startSession(session).catch((error) => {
+        session.lastError = this.stringifyError(error)
         this.logger.warn(
           `[wecom-long] reconnect failed integration=${session.integrationId}: ${session.lastError}`
         )
@@ -532,19 +776,72 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     }
   }
 
+  private startRenew(session: WeComLongSession): void {
+    this.clearRenewTimer(session)
+    session.renewTimer = setInterval(() => {
+      void this.renewOwnership(session)
+    }, RENEW_INTERVAL_MS)
+  }
+
+  private clearRenewTimer(session: WeComLongSession): void {
+    if (session.renewTimer) {
+      clearInterval(session.renewTimer)
+      session.renewTimer = null
+    }
+  }
+
+  private async renewOwnership(session: WeComLongSession): Promise<void> {
+    if (!session.lockId) {
+      return
+    }
+
+    const lockKey = getWeComLongConnectionLockKey({ botId: session.botId })
+    const ownerKey = getWeComLongConnectionOwnerKey({ botId: session.botId })
+    const renewed = await this.renewLock(lockKey, session.lockId, LOCK_TTL_MS)
+    if (!renewed) {
+      session.lastError = 'Lost long-connection ownership'
+      session.disabledReason = 'lease_conflict'
+      await this.stopSession(session, true)
+      this.scheduleReconnect(session, DEFAULT_RETRY_MS)
+      await this.writeStatus(session)
+      return
+    }
+
+    await this.writeOwner(session, ownerKey)
+    this.refreshSessionState(session)
+    await this.writeStatus(session)
+  }
+
   private startPing(session: WeComLongSession): void {
     this.clearPingTimer(session)
     session.pingTimer = setInterval(() => {
       this.sendCommand(session.integrationId, {
         cmd: 'ping',
         timeoutMs: Math.min(3000, session.timeoutMs)
-      }).catch((error) => {
-        this.logger.warn(
-          `[wecom-long] ping failed integration=${session.integrationId}: ${
-            error instanceof Error ? error.message : String(error)
-          }`
-        )
       })
+        .then(async () => {
+          session.lastPingAt = Date.now()
+          session.pingFailureCount = 0
+          await this.writeStatus(session)
+        })
+        .catch((error) => {
+          session.lastError = this.stringifyError(error)
+          session.pingFailureCount += 1
+          this.logger.warn(
+            `[wecom-long] ping failed integration=${session.integrationId}: ${session.lastError}`
+          )
+          if (session.pingFailureCount < MAX_PING_FAILURES || !session.websocket) {
+            return
+          }
+
+          try {
+            session.disabledReason = 'runtime_error'
+            session.websocket.terminate?.()
+            session.websocket.close?.()
+          } catch {
+            //
+          }
+        })
     }, PING_INTERVAL_MS)
   }
 
@@ -552,6 +849,45 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     if (session.pingTimer) {
       clearInterval(session.pingTimer)
       session.pingTimer = null
+    }
+  }
+
+  private startWatchdog(session: WeComLongSession): void {
+    this.clearWatchdogTimer(session)
+    session.watchdogTimer = setInterval(() => {
+      if (session.state !== 'connected') {
+        return
+      }
+
+      if (!this.isSocketOpen(session.websocket)) {
+        session.lastError = 'Long connection websocket is no longer open'
+        session.disabledReason = 'runtime_error'
+        try {
+          session.websocket?.terminate?.()
+          session.websocket?.close?.()
+        } catch {
+          //
+        }
+        return
+      }
+
+      if (session.lastPingAt && Date.now() - session.lastPingAt > WATCHDOG_STALE_MS) {
+        session.lastError = 'Long connection ping heartbeat is stale'
+        session.disabledReason = 'runtime_error'
+        try {
+          session.websocket?.terminate?.()
+          session.websocket?.close?.()
+        } catch {
+          //
+        }
+      }
+    }, WATCHDOG_INTERVAL_MS)
+  }
+
+  private clearWatchdogTimer(session: WeComLongSession): void {
+    if (session.watchdogTimer) {
+      clearInterval(session.watchdogTimer)
+      session.watchdogTimer = null
     }
   }
 
@@ -596,6 +932,9 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       return
     }
 
+    session.lastCallbackAt = Date.now()
+    await this.writeStatus(session)
+
     if (reqId) {
       this.sendAck(session, reqId)
     }
@@ -605,7 +944,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
 
   private sendAck(session: WeComLongSession, reqId: string): void {
     const websocket = session.websocket
-    if (!websocket || websocket.readyState !== 1) {
+    if (!websocket || !this.isSocketOpen(websocket)) {
       return
     }
 
@@ -621,9 +960,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       )
     } catch (error) {
       this.logger.warn(
-        `[wecom-long] ack failed integration=${session.integrationId}, reqId=${reqId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`
+        `[wecom-long] ack failed integration=${session.integrationId}, reqId=${reqId}: ${this.stringifyError(error)}`
       )
     }
   }
@@ -730,7 +1067,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       ? await this.ensureSessionReady(integrationId)
       : await this.ensureConnected(integrationId)
     const websocket = session.websocket
-    if (!websocket || websocket.readyState !== 1) {
+    if (!websocket || !this.isSocketOpen(websocket)) {
       throw new Error(`Long connection is not ready for integration ${integrationId}`)
     }
 
@@ -751,7 +1088,8 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       session.pendingRequests.set(reqId, {
         resolve,
         reject,
-        timer
+        timer,
+        command: params.cmd
       })
     })
 
@@ -807,17 +1145,502 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     return session
   }
 
-  private buildStatus(session: WeComLongSession): WeComLongConnectionStatus {
+  private refreshSessionState(session: WeComLongSession): void {
+    if (this.isSocketOpen(session.websocket)) {
+      session.state = 'connected'
+      session.disabledReason = null
+      session.nextReconnectAt = null
+      return
+    }
+
+    if (session.websocket && session.state === 'connected') {
+      session.state = 'retrying'
+      session.disabledReason = session.disabledReason || 'runtime_error'
+      session.nextReconnectAt = Date.now() + DEFAULT_RETRY_MS
+    }
+  }
+
+  private resetSessionForReconnect(session: WeComLongSession): void {
+    session.failureCount = 0
+    session.reconnectAttempts = 0
+    session.pingFailureCount = 0
+    session.disabledReason = null
+    session.lastError = null
+    session.nextReconnectAt = null
+    session.state = 'idle'
+    session.shouldRun = true
+  }
+
+  private async stopSession(session: WeComLongSession, clearOwnership: boolean): Promise<void> {
+    this.clearPingTimer(session)
+    this.clearWatchdogTimer(session)
+    this.clearRenewTimer(session)
+    this.clearReconnectTimer(session)
+
+    for (const [reqId, pending] of session.pendingRequests.entries()) {
+      clearTimeout(pending.timer)
+      pending.reject(new Error(`Long connection is closing (integration=${session.integrationId}, reqId=${reqId})`))
+    }
+    session.pendingRequests.clear()
+
+    const websocket = session.websocket
+    session.websocket = null
+    if (websocket) {
+      try {
+        websocket.terminate?.()
+        websocket.close?.()
+      } catch (error) {
+        this.logger.warn(
+          `[wecom-long] close socket failed integration=${session.integrationId}: ${this.stringifyError(error)}`
+        )
+      }
+    }
+
+    if (clearOwnership && session.lockId) {
+      await this.releaseLock(getWeComLongConnectionLockKey({ botId: session.botId }), session.lockId)
+      session.lockId = null
+      session.ownerInstanceId = null
+      await this.clearOwner(session)
+    }
+  }
+
+  private async registerIntegration(integrationId: string): Promise<void> {
+    const redis = this.redis
+    if (!redis) {
+      return
+    }
+    const registryKey = getWeComLongConnectionRegistryKey()
+    if (typeof redis.sadd === 'function') {
+      await redis.sadd(registryKey, integrationId)
+      return
+    }
+    if (typeof redis.sAdd === 'function') {
+      await redis.sAdd(registryKey, integrationId)
+    }
+  }
+
+  private async unregisterIntegration(integrationId: string): Promise<void> {
+    const redis = this.redis
+    if (!redis) {
+      return
+    }
+    const registryKey = getWeComLongConnectionRegistryKey()
+    if (typeof redis.srem === 'function') {
+      await redis.srem(registryKey, integrationId)
+      return
+    }
+    if (typeof redis.sRem === 'function') {
+      await redis.sRem(registryKey, integrationId)
+    }
+  }
+
+  private async isRegistered(integrationId: string): Promise<boolean> {
+    const redis = this.redis
+    if (!redis) {
+      return false
+    }
+    const registryKey = getWeComLongConnectionRegistryKey()
+    if (typeof redis.sismember === 'function') {
+      return Boolean(await redis.sismember(registryKey, integrationId))
+    }
+    if (typeof redis.sIsMember === 'function') {
+      return Boolean(await redis.sIsMember(registryKey, integrationId))
+    }
+    const members = await this.loadRegistry()
+    return members.includes(integrationId)
+  }
+
+  private async loadRegistry(): Promise<string[]> {
+    const redis = this.redis
+    if (!redis) {
+      return []
+    }
+    const registryKey = getWeComLongConnectionRegistryKey()
+    if (typeof redis.smembers === 'function') {
+      return (await redis.smembers(registryKey)) ?? []
+    }
+    if (typeof redis.sMembers === 'function') {
+      return (await redis.sMembers(registryKey)) ?? []
+    }
+    return []
+  }
+
+  private async loadBootstrapIntegrationIds(): Promise<string[]> {
+    try {
+      const findAll = (
+        this.integrationPermissionService as unknown as {
+          findAll?: (
+            options?: Record<string, unknown>
+          ) => Promise<{ items?: Array<IIntegration<TIntegrationWeComLongOptions>> }>
+        }
+      ).findAll
+
+      if (!findAll) {
+        return this.loadRegistry()
+      }
+
+      const result = await findAll({
+        where: {
+          provider: INTEGRATION_WECOM_LONG
+        },
+        relations: ['tenant']
+      })
+      const items = (result?.items ?? []).filter((item) => !this.resolveRestoreSkipReason(item))
+      for (const item of items) {
+        await this.registerIntegration(item.id)
+      }
+      return items.map((item) => item.id)
+    } catch (error) {
+      this.logger.warn(`[wecom-long] load from integration service failed: ${this.stringifyError(error)}`)
+    }
+
+    return this.loadRegistry()
+  }
+
+  private async writeOwner(session: WeComLongSession, ownerKey: string): Promise<void> {
+    const redis = this.redis
+    if (!redis || typeof redis.set !== 'function') {
+      return
+    }
+
+    const value = JSON.stringify({
+      instanceId: this.instanceId,
+      integrationId: session.integrationId,
+      botId: session.botId
+    })
+    await this.setWithTtl(ownerKey, value, LOCK_TTL_MS)
+  }
+
+  private async readOwnerInstanceId(ownerKey: string): Promise<string | null> {
+    const redis = this.redis
+    if (!redis || typeof redis.get !== 'function') {
+      return null
+    }
+    const value = await redis.get(ownerKey)
+    if (!value) {
+      return null
+    }
+    try {
+      const payload = JSON.parse(value) as Record<string, unknown>
+      return this.normalizeString(payload.instanceId)
+    } catch {
+      return null
+    }
+  }
+
+  private async clearOwner(session: WeComLongSession): Promise<void> {
+    await this.redis?.del?.(getWeComLongConnectionOwnerKey({ botId: session.botId }))
+  }
+
+  private async writeStatus(session: WeComLongSession): Promise<void> {
+    const redis = this.redis
+    if (!redis) {
+      return
+    }
+
+    const payload = {
+      state: session.state,
+      connectionMode: 'long_connection',
+      connected: session.state === 'connected' ? 'true' : 'false',
+      shouldRun: session.shouldRun ? 'true' : 'false',
+      ownerInstanceId: session.ownerInstanceId || '',
+      lastConnectedAt: session.connectedAt ? String(session.connectedAt) : '',
+      lastDisconnectedAt: session.disconnectedAt ? String(session.disconnectedAt) : '',
+      lastCallbackAt: session.lastCallbackAt ? String(session.lastCallbackAt) : '',
+      lastPingAt: session.lastPingAt ? String(session.lastPingAt) : '',
+      lastError: session.lastError || '',
+      failureCount: String(session.failureCount ?? 0),
+      reconnectAttempts: String(session.reconnectAttempts ?? 0),
+      nextReconnectAt: session.nextReconnectAt ? String(session.nextReconnectAt) : '',
+      disabledReason: session.disabledReason || ''
+    }
+
+    const statusKey = getWeComLongConnectionStatusKey(session.integrationId)
+    if (typeof redis.hset === 'function') {
+      await redis.hset(statusKey, ...Object.entries(payload).flat())
+    } else if (typeof redis.hSet === 'function') {
+      await redis.hSet(statusKey, payload)
+    }
+    if (typeof redis.expire === 'function') {
+      await redis.expire(statusKey, 60 * 60 * 24)
+    }
+  }
+
+  private async writeDetachedStatus(
+    integrationId: string,
+    reason: TWeComLongDisabledReason | null,
+    overrides?: {
+      shouldRun?: boolean
+      lastError?: string | null
+      lastConnectedAt?: number | null
+      lastDisconnectedAt?: number | null
+      lastCallbackAt?: number | null
+      lastPingAt?: number | null
+      reconnectAttempts?: number
+      failureCount?: number
+      nextReconnectAt?: number | null
+    }
+  ): Promise<void> {
+    const redis = this.redis
+    if (!redis) {
+      return
+    }
+
+    const payload = {
+      state: 'idle',
+      connectionMode: 'long_connection',
+      connected: 'false',
+      shouldRun: overrides?.shouldRun ? 'true' : 'false',
+      ownerInstanceId: '',
+      lastConnectedAt: overrides?.lastConnectedAt ? String(overrides.lastConnectedAt) : '',
+      lastDisconnectedAt: overrides?.lastDisconnectedAt ? String(overrides.lastDisconnectedAt) : '',
+      lastCallbackAt: overrides?.lastCallbackAt ? String(overrides.lastCallbackAt) : '',
+      lastPingAt: overrides?.lastPingAt ? String(overrides.lastPingAt) : '',
+      lastError: overrides?.lastError || '',
+      failureCount: String(overrides?.failureCount ?? 0),
+      reconnectAttempts: String(overrides?.reconnectAttempts ?? 0),
+      nextReconnectAt: overrides?.nextReconnectAt ? String(overrides.nextReconnectAt) : '',
+      disabledReason: reason || ''
+    }
+
+    const statusKey = getWeComLongConnectionStatusKey(integrationId)
+    if (typeof redis.hset === 'function') {
+      await redis.hset(statusKey, ...Object.entries(payload).flat())
+    } else if (typeof redis.hSet === 'function') {
+      await redis.hSet(statusKey, payload)
+    }
+    if (typeof redis.expire === 'function') {
+      await redis.expire(statusKey, 60 * 60 * 24)
+    }
+  }
+
+  private async clearStatus(integrationId: string): Promise<void> {
+    await this.redis?.del?.(getWeComLongConnectionStatusKey(integrationId))
+  }
+
+  private async dropMissingIntegration(integrationId: string): Promise<void> {
+    await this.unregisterIntegration(integrationId)
+    await this.removeSession(integrationId)
+    await this.clearStatus(integrationId)
+  }
+
+  private async removeSession(integrationId: string): Promise<void> {
+    const session = this.sessions.get(integrationId)
+    if (!session) {
+      return
+    }
+    await this.stopSession(session, true)
+    this.sessions.delete(integrationId)
+  }
+
+  private async readStoredStatus(integrationId: string): Promise<TWeComRuntimeStatus> {
+    const redis = this.redis
+    const statusKey = getWeComLongConnectionStatusKey(integrationId)
+    const data =
+      (redis && typeof redis.hgetall === 'function'
+        ? await redis.hgetall(statusKey)
+        : redis && typeof redis.hGetAll === 'function'
+          ? await redis.hGetAll(statusKey)
+          : {}) ?? {}
+
+    if (!Object.keys(data).length) {
+      return this.buildDetachedStatus(integrationId)
+    }
+
+    return {
+      integrationId,
+      connectionMode: 'long_connection',
+      connected: data.connected === 'true',
+      shouldRun: data.shouldRun === 'true',
+      state: (data.state as TWeComLongRuntimeState) || 'idle',
+      ownerInstanceId: data.ownerInstanceId || null,
+      lastConnectedAt: data.lastConnectedAt ? Number(data.lastConnectedAt) : null,
+      lastDisconnectedAt: data.lastDisconnectedAt ? Number(data.lastDisconnectedAt) : null,
+      lastCallbackAt: data.lastCallbackAt ? Number(data.lastCallbackAt) : null,
+      lastPingAt: data.lastPingAt ? Number(data.lastPingAt) : null,
+      lastError: data.lastError || null,
+      failureCount: data.failureCount ? Number(data.failureCount) : 0,
+      reconnectAttempts: data.reconnectAttempts ? Number(data.reconnectAttempts) : 0,
+      nextReconnectAt: data.nextReconnectAt ? Number(data.nextReconnectAt) : null,
+      disabledReason: (data.disabledReason as TWeComLongDisabledReason) || null
+    }
+  }
+
+  private buildStatus(session: WeComLongSession): TWeComRuntimeStatus {
     return {
       integrationId: session.integrationId,
-      state: session.state,
+      connectionMode: 'long_connection',
       connected: session.state === 'connected',
       shouldRun: session.shouldRun,
-      connectedAt: session.connectedAt,
-      disconnectedAt: session.disconnectedAt,
+      state: session.state,
+      ownerInstanceId: session.ownerInstanceId ?? null,
+      lastConnectedAt: session.connectedAt ?? null,
+      lastDisconnectedAt: session.disconnectedAt ?? null,
+      lastCallbackAt: session.lastCallbackAt ?? null,
+      lastPingAt: session.lastPingAt ?? null,
+      lastError: session.lastError ?? null,
+      failureCount: session.failureCount,
       reconnectAttempts: session.reconnectAttempts,
-      lastError: session.lastError
+      nextReconnectAt: session.nextReconnectAt ?? null,
+      disabledReason: session.disabledReason ?? null
     }
+  }
+
+  private buildDetachedStatus(
+    integrationId: string,
+    overrides?: Partial<TWeComRuntimeStatus>
+  ): TWeComRuntimeStatus {
+    return {
+      integrationId,
+      connectionMode: 'long_connection',
+      connected: false,
+      shouldRun: false,
+      state: 'idle',
+      ownerInstanceId: null,
+      lastConnectedAt: null,
+      lastDisconnectedAt: null,
+      lastCallbackAt: null,
+      lastPingAt: null,
+      lastError: null,
+      failureCount: 0,
+      reconnectAttempts: 0,
+      nextReconnectAt: null,
+      disabledReason: null,
+      ...overrides
+    }
+  }
+
+  private async safeReadLongIntegration(
+    integrationId: string
+  ): Promise<IIntegration<TIntegrationWeComLongOptions> | null> {
+    const integration = await this.integrationPermissionService.read<IIntegration<TIntegrationWeComLongOptions>>(
+      integrationId,
+      {
+        relations: ['tenant']
+      }
+    )
+
+    if (!integration || integration.provider !== INTEGRATION_WECOM_LONG) {
+      return null
+    }
+
+    return integration
+  }
+
+  private async readLongIntegration(integrationId: string): Promise<IIntegration<TIntegrationWeComLongOptions>> {
+    const integration = await this.safeReadLongIntegration(integrationId)
+    if (!integration) {
+      throw new Error(`Integration ${integrationId} not found`)
+    }
+    return integration
+  }
+
+  private resolveRestoreSkipReason(
+    integration: IIntegration<TIntegrationWeComLongOptions>
+  ): TWeComLongDisabledReason | null {
+    const enabled = (integration as unknown as Record<string, unknown>)?.enabled
+    if (enabled === false) {
+      return 'integration_disabled'
+    }
+
+    if (!this.normalizeString(integration.options?.xpertId)) {
+      return 'xpert_unbound'
+    }
+
+    return null
+  }
+
+  private describeDisabledReason(reason: TWeComLongDisabledReason | null): string | null {
+    switch (reason) {
+      case 'manual_disconnect':
+        return 'Long connection was disconnected manually'
+      case 'integration_disabled':
+        return 'Integration is disabled'
+      case 'xpert_unbound':
+        return 'Xpert is unbound'
+      case 'config_invalid':
+        return 'Long connection configuration is invalid'
+      case 'lease_conflict':
+        return 'Long connection ownership is held by another instance'
+      case 'runtime_error':
+        return 'Long connection runtime error'
+      case 'restore_skipped':
+        return 'Long connection restore was skipped'
+      default:
+        return null
+    }
+  }
+
+  private async acquireLock(key: string, ttlMs: number): Promise<string | null> {
+    const redis = this.redis
+    if (!redis || typeof redis.set !== 'function') {
+      return randomUUID()
+    }
+
+    const lockId = randomUUID()
+    const result = await redis.set(key, lockId, { PX: ttlMs, NX: true })
+    return result === 'OK' ? lockId : null
+  }
+
+  private async renewLock(key: string, lockId: string, ttlMs: number): Promise<boolean> {
+    const redis = this.redis
+    if (!redis || typeof redis.eval !== 'function') {
+      return true
+    }
+
+    const script = `
+      if redis.call("get", KEYS[1]) == ARGV[1]
+      then
+        return redis.call("pexpire", KEYS[1], ARGV[2])
+      else
+        return 0
+      end
+    `
+    const result = await this.evalRedisScript(redis, script, [key], [lockId, String(ttlMs)])
+    return result === 1
+  }
+
+  private async releaseLock(key: string, lockId: string): Promise<boolean> {
+    const redis = this.redis
+    if (!redis || typeof redis.eval !== 'function') {
+      return true
+    }
+
+    const script = `
+      if redis.call("get", KEYS[1]) == ARGV[1]
+      then
+        return redis.call("del", KEYS[1])
+      else
+        return 0
+      end
+    `
+    const result = await this.evalRedisScript(redis, script, [key], [lockId])
+    return result === 1
+  }
+
+  private async setWithTtl(key: string, value: string, ttlMs: number): Promise<void> {
+    const redis = this.redis
+    if (!redis || typeof redis.set !== 'function') {
+      return
+    }
+    await redis.set(key, value, { PX: ttlMs })
+  }
+
+  private async evalRedisScript(
+    redis: RedisLike,
+    script: string,
+    keys: string[],
+    args: string[]
+  ): Promise<any> {
+    try {
+      return await redis.eval?.(script, keys.length, ...keys, ...args)
+    } catch {
+      return await redis.eval?.(script, { keys, arguments: args })
+    }
+  }
+
+  private isSocketOpen(websocket: any | null | undefined): boolean {
+    return websocket?.readyState === 1
   }
 
   private resolveWebSocketImpl(): any {
@@ -829,8 +1652,7 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       }
       return WebSocketImpl
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      throw new Error(`Cannot load 'ws' dependency: ${message}`)
+      throw new Error(`Cannot load 'ws' dependency: ${this.stringifyError(error)}`)
     }
   }
 
@@ -877,25 +1699,6 @@ export class WeComLongConnectionService implements OnModuleDestroy {
     return ''
   }
 
-  private async readLongIntegration(integrationId: string): Promise<IIntegration<TIntegrationWeComLongOptions>> {
-    const integration = await this.integrationPermissionService.read<IIntegration<TIntegrationWeComLongOptions>>(
-      integrationId,
-      {
-        relations: ['tenant']
-      }
-    )
-
-    if (!integration) {
-      throw new Error(`Integration ${integrationId} not found`)
-    }
-
-    if (integration.provider !== INTEGRATION_WECOM_LONG) {
-      throw new Error(`Integration ${integrationId} is not provider '${INTEGRATION_WECOM_LONG}'`)
-    }
-
-    return integration
-  }
-
   private normalizeString(value: unknown): string | null {
     if (typeof value !== 'string') {
       return null
@@ -917,5 +1720,19 @@ export class WeComLongConnectionService implements OnModuleDestroy {
       return fallback
     }
     return Math.max(MIN_TIMEOUT_MS, Math.min(MAX_TIMEOUT_MS, Math.floor(timeout)))
+  }
+
+  private stringifyError(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message
+    }
+    if (typeof error === 'string') {
+      return error
+    }
+    try {
+      return JSON.stringify(error)
+    } catch {
+      return String(error)
+    }
   }
 }

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.utils.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.utils.ts
@@ -1,0 +1,109 @@
+import {
+  TIntegrationWeComLongOptions,
+  TWeComLongDisabledReason
+} from './types.js'
+
+export type TWeComLongConnectionErrorClassification = {
+  recoverable: boolean
+  disabledReason: Extract<TWeComLongDisabledReason, 'config_invalid' | 'runtime_error'>
+  reason: string
+}
+
+const UNRECOVERABLE_PATTERNS = [
+  'missing botid/secret',
+  'missing bot id',
+  'missing secret',
+  'botid is required',
+  'secret is required',
+  'invalid bot',
+  'invalid secret',
+  'unauthorized',
+  'forbidden',
+  'permission denied',
+  'not enabled',
+  'deleted',
+  'errcode=400',
+  'errcode=401',
+  'errcode=403'
+]
+
+const RECOVERABLE_PATTERNS = [
+  'timeout',
+  'timed out',
+  'econnreset',
+  'enotfound',
+  'eai_again',
+  'network',
+  'socket hang up',
+  'gateway',
+  'temporarily unavailable',
+  'websocket',
+  'connection closed',
+  'connect etimedout',
+  'ws close',
+  'socket error',
+  'ping failed'
+]
+
+function toReasonMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+export function getWeComLongConnectionRegistryKey(): string {
+  return 'wecom:ws:registry'
+}
+
+export function getWeComLongConnectionLockKey(
+  options: Pick<TIntegrationWeComLongOptions, 'botId'>
+): string {
+  return `wecom:ws:bot:${String(options?.botId || 'unknown').trim() || 'unknown'}`
+}
+
+export function getWeComLongConnectionOwnerKey(
+  options: Pick<TIntegrationWeComLongOptions, 'botId'>
+): string {
+  return `wecom:ws:bot-owner:${String(options?.botId || 'unknown').trim() || 'unknown'}`
+}
+
+export function getWeComLongConnectionStatusKey(integrationId: string): string {
+  return `wecom:ws:status:${integrationId}`
+}
+
+export function classifyWeComLongConnectionError(
+  error: unknown
+): TWeComLongConnectionErrorClassification {
+  const message = toReasonMessage(error)
+  const normalized = message.toLowerCase()
+
+  if (UNRECOVERABLE_PATTERNS.some((pattern) => normalized.includes(pattern))) {
+    return {
+      recoverable: false,
+      disabledReason: 'config_invalid',
+      reason: message
+    }
+  }
+
+  if (RECOVERABLE_PATTERNS.some((pattern) => normalized.includes(pattern))) {
+    return {
+      recoverable: true,
+      disabledReason: 'runtime_error',
+      reason: message
+    }
+  }
+
+  return {
+    recoverable: false,
+    disabledReason: 'config_invalid',
+    reason: message
+  }
+}

--- a/xpertai/integrations/wecom/src/lib/wecom-long-integration.strategy.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-integration.strategy.spec.ts
@@ -1,0 +1,79 @@
+import { IIntegration } from '@metad/contracts'
+import { WeComLongIntegrationStrategy } from './wecom-long-integration.strategy.js'
+import { TIntegrationWeComLongOptions } from './types.js'
+
+describe('WeComLongIntegrationStrategy', () => {
+  function createIntegration(
+    overrides?: Partial<IIntegration<TIntegrationWeComLongOptions>> & { enabled?: boolean }
+  ) {
+    return {
+      id: 'integration-1',
+      provider: 'wecom_long',
+      enabled: true,
+      options: {
+        botId: 'bot-1',
+        secret: 'secret-1',
+        xpertId: 'xpert-1'
+      },
+      ...overrides
+    } as IIntegration<TIntegrationWeComLongOptions>
+  }
+
+  function createFixture() {
+    const longConnection = {
+      connectWithConfig: jest.fn().mockResolvedValue(undefined),
+      reconnect: jest.fn().mockResolvedValue(undefined),
+      disconnect: jest.fn().mockResolvedValue(undefined)
+    }
+
+    return {
+      longConnection,
+      strategy: new WeComLongIntegrationStrategy(longConnection as any)
+    }
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('disconnects runtime with integration_disabled reason when integration is disabled', async () => {
+    const { strategy, longConnection } = createFixture()
+
+    await strategy.onUpdate(createIntegration(), createIntegration({ enabled: false }))
+
+    expect(longConnection.disconnect).toHaveBeenCalledWith('integration-1', {
+      reason: 'integration_disabled'
+    })
+  })
+
+  it('disconnects runtime with xpert_unbound reason when xpert is removed', async () => {
+    const { strategy, longConnection } = createFixture()
+
+    await strategy.onUpdate(createIntegration(), createIntegration({ options: { botId: 'bot-1', secret: 'secret-1' } }))
+
+    expect(longConnection.disconnect).toHaveBeenCalledWith('integration-1', {
+      reason: 'xpert_unbound'
+    })
+  })
+
+  it('reconnects runtime when integration becomes restorable again', async () => {
+    const { strategy, longConnection } = createFixture()
+
+    await strategy.onUpdate(
+      createIntegration({ enabled: false, options: { botId: 'bot-1', secret: 'secret-1' } }),
+      createIntegration()
+    )
+
+    expect(longConnection.reconnect).toHaveBeenCalledWith('integration-1')
+  })
+
+  it('clears runtime status on delete', async () => {
+    const { strategy, longConnection } = createFixture()
+
+    await strategy.onDelete(createIntegration())
+
+    expect(longConnection.disconnect).toHaveBeenCalledWith('integration-1', {
+      clearStatus: true
+    })
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/wecom-long-integration.strategy.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-integration.strategy.ts
@@ -1,7 +1,11 @@
 import { IIntegration, TIntegrationProvider } from '@metad/contracts'
 import { Injectable, Logger } from '@nestjs/common'
 import { IntegrationStrategy, IntegrationStrategyKey, TIntegrationStrategyParams } from '@xpert-ai/plugin-sdk'
-import { iconImage, INTEGRATION_WECOM_LONG, TIntegrationWeComLongOptions } from './types.js'
+import {
+  iconImage,
+  INTEGRATION_WECOM_LONG,
+  TIntegrationWeComLongOptions
+} from './types.js'
 import { WeComLongConnectionService } from './wecom-long-connection.service.js'
 
 @Injectable()
@@ -115,6 +119,58 @@ export class WeComLongIntegrationStrategy implements IntegrationStrategy<TIntegr
     return null
   }
 
+  async onUpdate(
+    previous: IIntegration<TIntegrationWeComLongOptions>,
+    current: IIntegration<TIntegrationWeComLongOptions>
+  ): Promise<void> {
+    const wasLongConnection = previous.provider === INTEGRATION_WECOM_LONG
+    const isStillLongConnection = current.provider === INTEGRATION_WECOM_LONG
+
+    if (wasLongConnection && !isStillLongConnection) {
+      await this.longConnection.disconnect(previous.id, {
+        clearStatus: true
+      })
+      return
+    }
+
+    if (!isStillLongConnection) {
+      return
+    }
+
+    const previousEnabled = this.isEnabled(previous)
+    const currentEnabled = this.isEnabled(current)
+    const previousXpertId = this.normalizeString(previous.options?.xpertId)
+    const currentXpertId = this.normalizeString(current.options?.xpertId)
+
+    if (!currentEnabled) {
+      await this.longConnection.disconnect(current.id, {
+        reason: 'integration_disabled'
+      })
+      return
+    }
+
+    if (!currentXpertId) {
+      await this.longConnection.disconnect(current.id, {
+        reason: 'xpert_unbound'
+      })
+      return
+    }
+
+    if (!previousEnabled || !previousXpertId) {
+      await this.longConnection.reconnect(current.id)
+    }
+  }
+
+  async onDelete(integration: IIntegration<TIntegrationWeComLongOptions>): Promise<void> {
+    if (integration.provider !== INTEGRATION_WECOM_LONG) {
+      return
+    }
+
+    await this.longConnection.disconnect(integration.id, {
+      clearStatus: true
+    })
+  }
+
   async validateConfig(
     config: TIntegrationWeComLongOptions,
     integration?: IIntegration<TIntegrationWeComLongOptions>
@@ -129,13 +185,26 @@ export class WeComLongIntegrationStrategy implements IntegrationStrategy<TIntegr
     const integrationId = integration?.id?.trim()
     if (integrationId) {
       try {
-        await this.longConnection.connectWithConfig({
-          integrationId,
-          botId: config.botId,
-          secret: config.secret,
-          wsOrigin: config.wsOrigin,
-          timeoutMs: config.timeoutMs
-        })
+        const enabled = this.isEnabled(integration)
+        const xpertId = this.normalizeString(config.xpertId)
+
+        if (!enabled) {
+          await this.longConnection.disconnect(integrationId, {
+            reason: 'integration_disabled'
+          })
+        } else if (!xpertId) {
+          await this.longConnection.disconnect(integrationId, {
+            reason: 'xpert_unbound'
+          })
+        } else {
+          await this.longConnection.connectWithConfig({
+            integrationId,
+            botId: config.botId,
+            secret: config.secret,
+            wsOrigin: config.wsOrigin,
+            timeoutMs: config.timeoutMs
+          })
+        }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         this.logger.warn(`[wecom-long] auto connect on save failed integration=${integrationId}: ${message}`)
@@ -147,5 +216,20 @@ export class WeComLongIntegrationStrategy implements IntegrationStrategy<TIntegr
       websocketUrl: 'wss://openws.work.weixin.qq.com',
       mode: 'long_connection'
     }
+  }
+
+  private isEnabled(integration?: IIntegration<TIntegrationWeComLongOptions> | null): boolean {
+    if (!integration || typeof integration !== 'object') {
+      return true
+    }
+    return (integration as unknown as Record<string, unknown>).enabled !== false
+  }
+
+  private normalizeString(value: unknown): string | null {
+    if (typeof value !== 'string') {
+      return null
+    }
+    const text = value.trim()
+    return text || null
   }
 }

--- a/xpertai/integrations/wecom/src/lib/wecom-markdown.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-markdown.spec.ts
@@ -1,0 +1,41 @@
+import { convertMarkdownToWeComMarkdown } from './wecom-markdown.js'
+
+describe('convertMarkdownToWeComMarkdown', () => {
+  it('normalizes headings, lists, bold text, tables, and horizontal rules', () => {
+    const input = [
+      '##一级评估要点',
+      '',
+      '__要求1：__ 应在关键工序应用自动化设备',
+      '*查证证据：关键工序设备台账',
+      '+抽样数据：现场查看关键工序设备自动化应用情况',
+      '',
+      '| 指标 | 说明 |',
+      '| --- | --- |',
+      '| 自动化 | 已覆盖 |',
+      '| 数字化 | 部分覆盖 |',
+      '',
+      '***'
+    ].join('\n')
+
+    expect(convertMarkdownToWeComMarkdown(input)).toBe(
+      [
+        '## 一级评估要点',
+        '',
+        '**要求1：** 应在关键工序应用自动化设备',
+        '- 查证证据：关键工序设备台账',
+        '- 抽样数据：现场查看关键工序设备自动化应用情况',
+        '',
+        '- **指标:** 自动化; **说明:** 已覆盖',
+        '- **指标:** 数字化; **说明:** 部分覆盖',
+        '',
+        '---'
+      ].join('\n')
+    )
+  })
+
+  it('keeps fenced code blocks unchanged while converting surrounding markdown', () => {
+    const input = ['#标题', '', '```md', '##Raw', '| A | B |', '```', '', '-列表项'].join('\n')
+
+    expect(convertMarkdownToWeComMarkdown(input)).toBe(['# 标题', '', '```md', '##Raw', '| A | B |', '```', '', '- 列表项'].join('\n'))
+  })
+})

--- a/xpertai/integrations/wecom/src/lib/wecom-markdown.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-markdown.ts
@@ -1,0 +1,227 @@
+const FENCED_CODE_BLOCK_RE = /(```[\s\S]*?```|~~~[\s\S]*?~~~)/g
+const HEADING_RE = /^(\s{0,3}#{1,6})(?!#)\s*(.*)$/
+const HORIZONTAL_RULE_RE = /^\s{0,3}(?:(?:-\s*){3,}|(?:_\s*){3,}|(?:\*\s*){3,})$/
+const TABLE_SEPARATOR_CELL_RE = /^:?-{3,}:?$/
+
+export function convertMarkdownToWeComMarkdown(markdown: string): string {
+  const normalized = normalizeLineEndings(markdown)
+  if (!normalized) {
+    return ''
+  }
+
+  const extracted = extractFencedCodeBlocks(normalized)
+  const converted = convertMarkdownSegment(extracted.content)
+  return restoreFencedCodeBlocks(collapseBlankLines(converted).trim(), extracted.blocks)
+}
+
+function convertMarkdownSegment(segment: string): string {
+  if (!segment) {
+    return ''
+  }
+
+  const lines = segment.split('\n')
+  const result: string[] = []
+
+  for (let index = 0; index < lines.length; index += 1) {
+    if (isMarkdownTableBlockStart(lines, index)) {
+      const { lines: tableLines, nextIndex } = consumeMarkdownTableBlock(lines, index)
+      if (result.length > 0 && result[result.length - 1] !== '') {
+        result.push('')
+      }
+      result.push(...convertMarkdownTableBlock(tableLines))
+
+      const nextLine = lines[nextIndex]
+      if (typeof nextLine === 'string' && nextLine.trim() !== '') {
+        result.push('')
+      }
+
+      index = nextIndex - 1
+      continue
+    }
+
+    const normalizedLine = normalizeMarkdownLine(lines[index])
+    const isBlank = normalizedLine.trim().length === 0
+    const isHeading = HEADING_RE.test(normalizedLine)
+    const isHorizontalRule = HORIZONTAL_RULE_RE.test(normalizedLine)
+
+    if (isBlank) {
+      if (result.length > 0 && result[result.length - 1] !== '') {
+        result.push('')
+      }
+      continue
+    }
+
+    if ((isHeading || isHorizontalRule) && result.length > 0 && result[result.length - 1] !== '') {
+      result.push('')
+    }
+
+    result.push(normalizedLine)
+
+    const nextLine = lines[index + 1]
+    if ((isHeading || isHorizontalRule) && typeof nextLine === 'string' && nextLine.trim() !== '') {
+      result.push('')
+    }
+  }
+
+  return collapseBlankLines(result.join('\n'))
+}
+
+function normalizeMarkdownLine(line: string): string {
+  const trimmedEnd = line.replace(/[ \t]+$/g, '')
+  if (!trimmedEnd.trim()) {
+    return ''
+  }
+
+  const headingMatch = trimmedEnd.match(HEADING_RE)
+  if (headingMatch) {
+    const [, prefix, title] = headingMatch
+    return `${prefix} ${normalizeInlineMarkdown(title.trim())}`.trimEnd()
+  }
+
+  if (HORIZONTAL_RULE_RE.test(trimmedEnd)) {
+    return '---'
+  }
+
+  const unorderedListMatch = trimmedEnd.match(/^(\s*)[-+*]\s*(.*)$/)
+  if (unorderedListMatch) {
+    const [, indent, content] = unorderedListMatch
+    return `${indent}- ${normalizeInlineMarkdown(content.trim())}`.trimEnd()
+  }
+
+  const orderedListMatch = trimmedEnd.match(/^(\s*)(\d+)\.\s*(.*)$/)
+  if (orderedListMatch) {
+    const [, indent, order, content] = orderedListMatch
+    return `${indent}${order}. ${normalizeInlineMarkdown(content.trim())}`.trimEnd()
+  }
+
+  return normalizeInlineMarkdown(trimmedEnd)
+}
+
+function normalizeInlineMarkdown(content: string): string {
+  if (!content) {
+    return ''
+  }
+
+  return content
+    .replace(/__(.+?)__/g, '**$1**')
+    .replace(/\*\*\s+(.+?)\s+\*\*/g, '**$1**')
+}
+
+function isMarkdownTableBlockStart(lines: string[], index: number): boolean {
+  if (index + 1 >= lines.length) {
+    return false
+  }
+
+  const headerLine = lines[index]
+  const separatorLine = lines[index + 1]
+
+  return headerLine.includes('|') && isMarkdownTableSeparator(separatorLine)
+}
+
+function consumeMarkdownTableBlock(lines: string[], startIndex: number): { lines: string[]; nextIndex: number } {
+  const block: string[] = [lines[startIndex], lines[startIndex + 1]]
+  let index = startIndex + 2
+
+  while (index < lines.length) {
+    const currentLine = lines[index]
+    if (!currentLine.trim() || !currentLine.includes('|')) {
+      break
+    }
+    block.push(currentLine)
+    index += 1
+  }
+
+  return {
+    lines: block,
+    nextIndex: index
+  }
+}
+
+function convertMarkdownTableBlock(lines: string[]): string[] {
+  const headerRow = splitMarkdownTableRow(lines[0])
+  const dataRows = lines.slice(2).map(splitMarkdownTableRow).filter((row) => row.some((cell) => cell.length > 0))
+
+  if (dataRows.length === 0) {
+    return [headerRow.map(normalizeInlineMarkdown).join(' | ')]
+  }
+
+  const columnCount = Math.max(headerRow.length, ...dataRows.map((row) => row.length))
+  const headers = Array.from({ length: columnCount }, (_, index) => normalizeInlineMarkdown(headerRow[index] || `Column ${index + 1}`))
+
+  return dataRows.map((row) => {
+    const cells = Array.from({ length: columnCount }, (_, index) => normalizeInlineMarkdown(row[index] || ''))
+    const pairs = headers.map((header, index) => `**${header}:** ${cells[index] || '-'}`)
+    return `- ${pairs.join('; ')}`
+  })
+}
+
+function splitMarkdownTableRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '')
+  const cells: string[] = []
+  let current = ''
+  let escaped = false
+
+  for (const char of trimmed) {
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+
+    if (char === '\\') {
+      escaped = true
+      continue
+    }
+
+    if (char === '|') {
+      cells.push(current.trim())
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  cells.push(current.trim())
+  return cells
+}
+
+function isMarkdownTableSeparator(line: string): boolean {
+  if (!line.includes('|')) {
+    return false
+  }
+
+  const cells = splitMarkdownTableRow(line)
+  return cells.length > 0 && cells.every((cell) => TABLE_SEPARATOR_CELL_RE.test(cell.replace(/\s+/g, '')))
+}
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n?/g, '\n')
+}
+
+function collapseBlankLines(value: string): string {
+  return value
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]+\n/g, '\n')
+}
+
+function extractFencedCodeBlocks(content: string): { content: string; blocks: string[] } {
+  const blocks: string[] = []
+  const extractedContent = content.replace(FENCED_CODE_BLOCK_RE, (block) => {
+    const token = `@@WECOM_CODE_BLOCK_${blocks.length}@@`
+    blocks.push(block)
+    return token
+  })
+
+  return {
+    content: extractedContent,
+    blocks
+  }
+}
+
+function restoreFencedCodeBlocks(content: string, blocks: string[]): string {
+  return content.replace(/@@WECOM_CODE_BLOCK_(\d+)@@/g, (_match, indexText: string) => {
+    const index = Number.parseInt(indexText, 10)
+    return Number.isInteger(index) && blocks[index] ? blocks[index] : ''
+  })
+}

--- a/xpertai/integrations/wecom/src/lib/wecom.controller.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom.controller.ts
@@ -33,6 +33,8 @@ import {
   decryptWeComMessage,
   INTEGRATION_WECOM,
   INTEGRATION_WECOM_LONG,
+  TWeComLongDisabledReason,
+  TWeComLegacyLongConnectionStatus,
   TIntegrationWeComOptions,
   verifyWeComSignature,
 } from './types.js'
@@ -294,7 +296,7 @@ export class WeComHooksController {
   @Post('long/:id/connect')
   async connectLong(@Param('id') integrationId: string) {
     try {
-      return await this.longConnection.connect(integrationId)
+      return this.toLegacyLongStatus(await this.longConnection.connect(integrationId))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       throw new BadRequestException(`WeCom long connect failed: ${message}`)
@@ -304,7 +306,7 @@ export class WeComHooksController {
   @Post('long/:id/disconnect')
   async disconnectLong(@Param('id') integrationId: string) {
     try {
-      return await this.longConnection.disconnect(integrationId)
+      return this.toLegacyLongStatus(await this.longConnection.disconnect(integrationId))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       throw new BadRequestException(`WeCom long disconnect failed: ${message}`)
@@ -314,10 +316,46 @@ export class WeComHooksController {
   @Get('long/:id/status')
   async statusLong(@Param('id') integrationId: string) {
     try {
-      return await this.longConnection.status(integrationId)
+      return this.toLegacyLongStatus(await this.longConnection.status(integrationId))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       throw new BadRequestException(`WeCom long status failed: ${message}`)
+    }
+  }
+
+  @Get('long/:id/runtime-status')
+  async getRuntimeStatus(@Param('id') integrationId: string) {
+    const integration = await this.readLongIntegration(integrationId)
+    const runtimeStatus = await this.longConnection.status(integrationId)
+    return {
+      ...runtimeStatus,
+      capabilities: this.wecomChannel.capabilities,
+      integrationName: this.toSafeString(integration.name),
+      botId: this.toSafeString(integration.options?.botId)
+    }
+  }
+
+  @Post('long/:id/runtime-status/reconnect')
+  async reconnectRuntimeStatus(@Param('id') integrationId: string) {
+    const integration = await this.readLongIntegration(integrationId)
+    const runtimeStatus = await this.longConnection.reconnect(integrationId)
+    return {
+      ...runtimeStatus,
+      capabilities: this.wecomChannel.capabilities,
+      integrationName: this.toSafeString(integration.name),
+      botId: this.toSafeString(integration.options?.botId)
+    }
+  }
+
+  @Post('long/:id/runtime-status/disconnect')
+  async disconnectRuntimeStatus(@Param('id') integrationId: string) {
+    const integration = await this.readLongIntegration(integrationId)
+    const runtimeStatus = await this.longConnection.disconnect(integrationId)
+    return {
+      ...runtimeStatus,
+      capabilities: this.wecomChannel.capabilities,
+      integrationName: this.toSafeString(integration.name),
+      botId: this.toSafeString(integration.options?.botId)
     }
   }
 
@@ -346,6 +384,49 @@ export class WeComHooksController {
       )
     }
     return integration
+  }
+
+  private async readLongIntegration(integrationId: string): Promise<IIntegration<TIntegrationWeComOptions>> {
+    const integration = await this.readIntegration(integrationId)
+    if (integration.provider !== INTEGRATION_WECOM_LONG) {
+      throw new BadRequestException(
+        `Integration ${integrationId} is not long connection provider '${INTEGRATION_WECOM_LONG}'`
+      )
+    }
+    return integration
+  }
+
+  private toLegacyLongStatus(status: {
+    integrationId: string
+    state: 'idle' | 'connecting' | 'connected' | 'retrying' | 'unhealthy'
+    connected: boolean
+    shouldRun?: boolean
+    lastConnectedAt?: number | null
+    lastDisconnectedAt?: number | null
+    reconnectAttempts?: number
+    lastError?: string | null
+    disabledReason?: TWeComLongDisabledReason | string | null
+  }): TWeComLegacyLongConnectionStatus {
+    const legacyState =
+      status.state === 'connected'
+        ? 'connected'
+        : status.state === 'connecting'
+          ? 'connecting'
+          : status.state === 'idle'
+            ? 'disconnected'
+            : 'error'
+
+    return {
+      integrationId: status.integrationId,
+      state: legacyState,
+      connected: status.connected,
+      shouldRun: status.shouldRun === true,
+      connectedAt: status.lastConnectedAt ?? undefined,
+      disconnectedAt: status.lastDisconnectedAt ?? undefined,
+      reconnectAttempts: status.reconnectAttempts ?? 0,
+      lastError: this.toSafeString(status.lastError) || undefined,
+      disabledReason: (this.toSafeString(status.disabledReason) || null) as TWeComLongDisabledReason | null
+    }
   }
 
   private async fetchProviderSelectOptions(

--- a/xpertai/integrations/wecom/src/lib/wecom.plugin.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom.plugin.ts
@@ -18,6 +18,7 @@ import { WeComTriggerStrategy } from './workflow/wecom-trigger.strategy.js'
 import { WeComLongIntegrationStrategy } from './wecom-long-integration.strategy.js'
 import { WeComLongConnectionService } from './wecom-long-connection.service.js'
 import { WECOM_LONG_CONNECTION_SERVICE } from './tokens.js'
+import { WeComIntegrationViewProvider } from './views/index.js'
 
 @XpertServerPlugin({
   imports: [
@@ -33,6 +34,7 @@ import { WECOM_LONG_CONNECTION_SERVICE } from './tokens.js'
     WeComLongIntegrationStrategy,
     WeComTriggerStrategy,
     WeComLongConnectionService,
+    WeComIntegrationViewProvider,
     WeComChatDispatchService,
     WeComChatRunStateService,
     WeComChatStreamCallbackProcessor,


### PR DESCRIPTION
## Summary
- add WeCom long-connection runtime status and recovery flow backed by Redis registry/status/lease
- add a WeCom integration status view with refresh, reconnect, and disconnect actions
- improve WeCom callback and markdown handling, plus include a changeset for `@xpert-ai/plugin-wecom`

## Validation
- `pnpm -C /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai exec tsc -p /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/integrations/wecom/tsconfig.lib.json --noEmit`
- `pnpm -C /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai exec tsc -p /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/integrations/wecom/tsconfig.spec.json --noEmit`
- `node /Users/jiangyimin/Documents/Git/xpert-plugins/plugin-dev-harness/dist/index.js --workspace /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/integrations/wecom --plugin @xpert-ai/plugin-wecom --verbose`