### PR TITLE
fix(changeset): add wecom patch release note

### DIFF
--- a/xpertai/.changeset/calm-rabbits-wink.md
+++ b/xpertai/.changeset/calm-rabbits-wink.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-wecom": patch
+---
+
+Fix WeCom long-connection runtime recovery, status visibility, and callback reply handling.


### PR DESCRIPTION
## Summary
- add a patch changeset for `@xpert-ai/plugin-wecom`
- document the WeCom long-connection runtime recovery, status visibility, and callback reply handling fixes

## Testing
- `pnpm -C xpertai exec changeset status`