### PR TITLE
revert(changeset): remove wecom patch release note

### DIFF
--- a/xpertai/.changeset/calm-rabbits-wink.md
+++ b/xpertai/.changeset/calm-rabbits-wink.md
@@ -1,5 +1,0 @@
----
-"@xpert-ai/plugin-wecom": patch
----
-
-Fix WeCom long-connection runtime recovery, status visibility, and callback reply handling.


### PR DESCRIPTION
## Summary
- delete `xpertai/.changeset/calm-rabbits-wink.md`
- remove the extra WeCom patch changeset from `main`

## Testing
- not run (changeset file deletion only)