### PR TITLE
Guard FileMemory command output logging

### DIFF
--- a/xpertai/.changeset/file-memory-command-output-guard.md
+++ b/xpertai/.changeset/file-memory-command-output-guard.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-file-memory': patch
+---
+
+Guard FileMemory tool output logging so LangGraph Command results are not treated as ToolMessages.

--- a/xpertai/middlewares/file-memory/src/lib/file-memory.middleware.spec.ts
+++ b/xpertai/middlewares/file-memory/src/lib/file-memory.middleware.spec.ts
@@ -1,4 +1,6 @@
 import { HumanMessage } from '@langchain/core/messages'
+import { Command } from '@langchain/langgraph'
+import { Logger } from '@nestjs/common'
 
 jest.mock('@xpert-ai/contracts', () => ({
   __esModule: true,
@@ -316,6 +318,43 @@ describe('FileMemorySystemMiddleware hybrid recall flow', () => {
 
     expect(writeTool.description).toContain('Durable memory should be saved in Chinese except unavoidable technical proper nouns')
     expect(writeTool.description).toContain('Do not mix English prose into otherwise Chinese memory text')
+  })
+
+  it('logs Command tool outputs without treating them as ToolMessages', async () => {
+    const loggerSpy = jest.spyOn(Logger, 'isLevelEnabled').mockReturnValue(true)
+    try {
+      const service = createServiceMock()
+      const strategy = new FileMemorySystemMiddleware(service, {
+        enqueue: jest.fn(),
+        softDrain: jest.fn()
+      })
+      const middleware = await strategy.createMiddleware({}, createContext())
+      const runtime = createRuntime()
+      const command = new Command({
+        update: {
+          todos: [],
+          messages: []
+        }
+      })
+      const handler = jest.fn().mockResolvedValue(command)
+
+      await expect(
+        middleware.wrapToolCall!(
+          {
+            tool: { name: 'write_todos' },
+            toolCall: {
+              id: 'tool-call-1',
+              name: 'write_todos',
+              args: { todos: [] }
+            },
+            runtime
+          },
+          handler
+        )
+      ).resolves.toBe(command)
+    } finally {
+      loggerSpy.mockRestore()
+    }
   })
 
   it('formats query and exact lookup results with canonical follow-up guidance', async () => {

--- a/xpertai/middlewares/file-memory/src/lib/file-memory.middleware.ts
+++ b/xpertai/middlewares/file-memory/src/lib/file-memory.middleware.ts
@@ -3,6 +3,7 @@ import {
   BaseMessage,
   HumanMessage,
   SystemMessage,
+  isBaseMessage,
   isAIMessage,
   isHumanMessage,
   isToolMessage
@@ -1379,5 +1380,5 @@ function stringifyScalar(value: unknown) {
 }
 
 function isLoggedToolMessage(value: unknown): value is BaseMessage & { artifact?: unknown; name?: string } {
-  return Boolean(value && typeof value === 'object' && isToolMessage(value as BaseMessage))
+  return isBaseMessage(value) && isToolMessage(value)
 }


### PR DESCRIPTION
## Summary

Fix FileMemory tool output logging so LangGraph `Command` results, such as the value returned by `write_todos`, are not treated as LangChain `ToolMessage` instances.

## Root Cause

`write_todos` returns a LangGraph `Command` to update graph state with `todos` and append tool messages. When FileMemory debug logging was enabled, the middleware rendered every tool output and called `isToolMessage(output)` without first checking that the output was actually a LangChain base message. `Command` does not implement `_getType()`, so this could surface as `x._getType is not a function` during an otherwise successful tool call.

## Changes

- Guard FileMemory tool-output logging with `isBaseMessage` before `isToolMessage`.
- Add a regression test covering `Command` output from a `write_todos`-style tool call while debug logging is enabled.
- Add a patch changeset for `@xpert-ai/plugin-file-memory`.

## Validation

- `pnpm exec jest middlewares/file-memory/src/lib/file-memory.middleware.spec.ts --config middlewares/file-memory/jest.config.cjs --runInBand`
- `NX_DAEMON=false pnpm exec nx build @xpert-ai/plugin-file-memory --verbose`