### PR TITLE
Enable Tongyi context cache

### DIFF
--- a/xpertai/.changeset/tongyi-context-cache-option.md
+++ b/xpertai/.changeset/tongyi-context-cache-option.md
@@ -2,8 +2,8 @@
 '@xpert-ai/plugin-tongyi': patch
 ---
 
-Add an opt-in context cache parameter for supported Tongyi-compatible chat models.
+Enable explicit context cache control for supported Tongyi-compatible chat models.
 
-- Expose a `Context Cache` toggle in supported model parameter panels.
-- Apply explicit ephemeral cache control only when the toggle is enabled.
-- Keep existing model behavior unchanged by default.
+- Apply ephemeral cache control to stable system prompts for supported models.
+- Keep model parameter schemas unchanged.
+- Avoid duplicate cache markers when a request already contains cache control.

--- a/xpertai/models/tongyi/src/llm/deepseek-v3.2.yaml
+++ b/xpertai/models/tongyi/src/llm/deepseek-v3.2.yaml
@@ -57,16 +57,6 @@ parameter_rules:
     help:
       zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。
       en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/glm-5.1.yaml
+++ b/xpertai/models/tongyi/src/llm/glm-5.1.yaml
@@ -89,16 +89,6 @@ parameter_rules:
     help:
       zh_Hans: 以增量方式返回工具调用参数，适合长参数或多工具调用场景。
       en_US: Stream tool call arguments incrementally for long arguments or multi-tool-call scenarios.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/llm.spec.ts
+++ b/xpertai/models/tongyi/src/llm/llm.spec.ts
@@ -9,7 +9,7 @@ describe('applyTongyiExplicitCache', () => {
     'deepseek-v3.2',
     'glm-5.1'
   ])(
-    'adds ephemeral cache control to %s system text content when enabled',
+    'adds ephemeral cache control to %s system text content',
     (model) => {
       const request = {
         model,
@@ -19,7 +19,7 @@ describe('applyTongyiExplicitCache', () => {
         ]
       }
 
-      const patched = applyTongyiExplicitCache(request, { model, enabled: true })
+      const patched = applyTongyiExplicitCache(request, { model })
 
       expect(patched).not.toBe(request)
       expect(request.messages[0].content).toBe('Long stable system prompt')
@@ -33,22 +33,13 @@ describe('applyTongyiExplicitCache', () => {
     }
   )
 
-  it('does not change supported models when disabled', () => {
-    const request = {
-      model: 'qwen3.6-plus',
-      messages: [{ role: 'system', content: 'Long stable system prompt' }]
-    }
-
-    expect(applyTongyiExplicitCache(request, { model: 'qwen3.6-plus' })).toBe(request)
-  })
-
-  it('does not change other models even when enabled', () => {
+  it('does not change other models', () => {
     const request = {
       model: 'qwen-turbo',
       messages: [{ role: 'system', content: 'Long stable system prompt' }]
     }
 
-    expect(applyTongyiExplicitCache(request, { model: 'qwen-turbo', enabled: true })).toBe(request)
+    expect(applyTongyiExplicitCache(request, { model: 'qwen-turbo' })).toBe(request)
   })
 
   it('does not add duplicate cache control', () => {
@@ -68,6 +59,6 @@ describe('applyTongyiExplicitCache', () => {
       ]
     }
 
-    expect(applyTongyiExplicitCache(request, { model: 'qwen3.6-plus', enabled: true })).toBe(request)
+    expect(applyTongyiExplicitCache(request, { model: 'qwen3.6-plus' })).toBe(request)
   })
 })

--- a/xpertai/models/tongyi/src/llm/llm.ts
+++ b/xpertai/models/tongyi/src/llm/llm.ts
@@ -49,7 +49,6 @@ type TongyiChatCompletionRequest = {
 
 type TongyiCacheFields = {
   model?: string
-  enabled?: boolean
 }
 
 function hasOwn(value: object, key: string) {
@@ -110,7 +109,6 @@ export function applyTongyiExplicitCache<TRequest extends TongyiChatCompletionRe
 ): TRequest {
   const model = request?.model ?? fields?.model
   if (
-    fields?.enabled !== true ||
     !model ||
     !TONGYI_EXPLICIT_CACHE_MODELS.has(model) ||
     !Array.isArray(request?.messages)
@@ -210,14 +208,12 @@ export class TongyiLargeLanguageModel extends LargeLanguageModel {
       }
     })
 
-    if (modelCredentials?.enable_context_cache === true) {
-      const originalCompletionWithRetry = chatModel.completionWithRetry.bind(chatModel)
+    const originalCompletionWithRetry = chatModel.completionWithRetry.bind(chatModel)
 
-      chatModel.completionWithRetry = (async (request, requestOptions) => {
-        const requestWithExplicitCache = applyTongyiExplicitCache(request, { model, enabled: true })
-        return originalCompletionWithRetry(requestWithExplicitCache, requestOptions)
-      }) as typeof chatModel.completionWithRetry
-    }
+    chatModel.completionWithRetry = (async (request, requestOptions) => {
+      const requestWithExplicitCache = applyTongyiExplicitCache(request, { model })
+      return originalCompletionWithRetry(requestWithExplicitCache, requestOptions)
+    }) as typeof chatModel.completionWithRetry
 
     return chatModel
   }

--- a/xpertai/models/tongyi/src/llm/qwen-flash.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen-flash.yaml
@@ -99,16 +99,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen-plus.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen-plus.yaml
@@ -78,16 +78,6 @@ parameter_rules:
     help:
       zh_Hans: 模型内置了互联网搜索服务，该参数控制模型在生成文本时是否参考使用互联网搜索结果。启用互联网搜索，模型会将搜索结果作为文本生成过程中的参考信息，但模型会基于其内部逻辑“自行判断”是否使用互联网搜索结果。
       en_US: The model has a built-in Internet search service. This parameter controls whether the model refers to Internet search results when generating text. When Internet search is enabled, the model will use the search results as reference information in the text generation process, but the model will "judge" whether to use Internet search results based on its internal logic.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen3-coder-plus.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3-coder-plus.yaml
@@ -66,16 +66,6 @@ parameter_rules:
     help:
       zh_Hans: 用于控制模型生成时的重复度。提高repetition_penalty时可以降低模型生成的重复度。1.0表示不做惩罚。
       en_US: Used to control the repeatability when generating models. Increasing repetition_penalty can reduce the duplication of model generation. 1.0 means no punishment.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
 pricing:
   input: '0.0035'
   output: '0.007'

--- a/xpertai/models/tongyi/src/llm/qwen3-max-preview.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3-max-preview.yaml
@@ -90,16 +90,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen3-max.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3-max.yaml
@@ -99,16 +99,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen3-vl-plus.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3-vl-plus.yaml
@@ -90,16 +90,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen3.5-flash.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3.5-flash.yaml
@@ -101,16 +101,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen3.5-plus.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3.5-plus.yaml
@@ -101,16 +101,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/llm/qwen3.6-plus.yaml
+++ b/xpertai/models/tongyi/src/llm/qwen3.6-plus.yaml
@@ -101,16 +101,6 @@ parameter_rules:
     help:
       zh_Hans: 思考过程的最大长度，只在思考模式为 true 时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
-  - name: enable_context_cache
-    required: false
-    type: boolean
-    default: false
-    label:
-      zh_Hans: 上下文缓存
-      en_US: Context Cache
-    help:
-      zh_Hans: 开启后，为稳定的系统提示词添加显式上下文缓存标记。
-      en_US: Add explicit context cache control to stable system prompts.
   - name: response_format
     label:
       zh_Hans: 回复格式

--- a/xpertai/models/tongyi/src/types.ts
+++ b/xpertai/models/tongyi/src/types.ts
@@ -24,7 +24,6 @@ export interface TongyiModelCredentials extends CommonChatModelParameters {
     thinking_budget?: number
     tool_stream?: boolean
     enable_search?: boolean
-    enable_context_cache?: boolean
     response_format?: 'text' | 'json_object'
 }
 


### PR DESCRIPTION
## Summary

Enable explicit context cache control for supported Tongyi-compatible chat models by automatically adding ephemeral cache control to stable system prompts.

This keeps model parameter schemas unchanged and avoids exposing a UI toggle. The runtime only applies the cache marker for the supported model whitelist and skips requests that already include cache control.

## Changes

- Add Tongyi explicit context cache handling in `models/tongyi/src/llm/llm.ts`.
- Add tests for supported models, unsupported models, and duplicate cache control handling.
- Add a patch changeset for `@xpert-ai/plugin-tongyi`.

## Validation

- `pnpm --dir /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai exec jest models/tongyi/src/llm/llm.spec.ts --config models/tongyi/jest.config.cjs`
- `pnpm --dir /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai exec nx build @xpert-ai/plugin-tongyi --skipNxCache`