### PR TITLE
[codex] fix wecom long reconnect policy

### DIFF
--- a/xpertai/.changeset/wecom-long-reconnect-policy.md
+++ b/xpertai/.changeset/wecom-long-reconnect-policy.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-wecom': patch
+---
+
+Fix WeCom long-connection auto-restore policy so API restarts do not recover manually stopped sessions while explicit reconnects and valid configuration saves can start them again.

--- a/xpertai/integrations/wecom/README.md
+++ b/xpertai/integrations/wecom/README.md
@@ -136,6 +136,46 @@ Optional runtime context:
 - Long-connection integrations use websocket session context from the active AI Bot connection.
 - If no valid robot context is available, the middleware returns a context-missing error instead of falling back to application OpenAPI sending.
 
+### Long-connection reconnect policy
+
+Automatic restore is allowed only when all of these conditions are true:
+
+- The integration provider is `wecom_long`.
+- The integration is enabled.
+- A routing target exists from a persisted trigger binding.
+- The connection was not persistently stopped by a user or by a terminal system state.
+
+States that should reconnect:
+
+| Situation | Expected behavior | Notes |
+| --- | --- | --- |
+| API process restarts after a normal active long connection | Reconnect automatically | The previous runtime should be restored only if it was not manually disconnected. |
+| Runtime websocket closes while `shouldRun=true` | Reconnect automatically | Covers network drops, WebSocket close, ping failure, timeout, and temporary gateway errors. |
+| Another API instance owns the same bot lease | Stay in `retrying` and retry | `lease_conflict` means this instance is waiting for ownership; it is not a terminal stop state. |
+| User clicks `Reconnect` | Reconnect explicitly | This action may restart a connection from `manual_disconnect` or `runtime_error`. |
+
+States that should not reconnect automatically:
+
+| Stop reason | Expected behavior | Notes |
+| --- | --- | --- |
+| `manual_disconnect` | Do not restore on API restart | Manual disconnect is a persistent user intent and must not rely only on in-memory session state. |
+| `integration_disabled` | Do not reconnect | The integration must be enabled before any runtime is started. |
+| `xpert_unbound` | Do not reconnect | A long connection without a routing target cannot process inbound messages safely. |
+| `config_invalid` | Do not reconnect after terminal failure | Covers invalid Bot ID, Secret, auth, permissions, or other unrecoverable configuration errors. |
+| Integration deleted or provider is not `wecom_long` | Do not reconnect | Registry and runtime state should be cleaned up. |
+
+Runtime state meanings:
+
+| State | Meaning |
+| --- | --- |
+| `idle` | No active websocket is running. This can be a valid stopped state when `shouldRun=false`. |
+| `connecting` | A websocket is being opened and authenticated. |
+| `connected` | The websocket is authenticated and available for callbacks or replies. |
+| `retrying` | The runtime intends to keep running and is waiting for retry, reconnect, or lease ownership. |
+| `unhealthy` | The runtime reached a terminal failure and should not reconnect without an explicit user action or valid configuration save. |
+
+`shouldRun` records the runtime intent. `shouldRun=true` means transient disconnects should be retried. `shouldRun=false` means the service must stay stopped until an explicit `Reconnect` action or a valid configuration save starts it again. `disabledReason` records why the service stopped; `manual_disconnect`, `integration_disabled`, `xpert_unbound`, and terminal `config_invalid` must survive API restarts.
+
 ## Local Build
 
 ```bash

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.spec.ts
@@ -150,7 +150,49 @@ describe('WeComLongConnectionService', () => {
 
     await service.onModuleInit()
 
-    expect(connectSpy).toHaveBeenCalledWith('integration-1')
+    expect(connectSpy).toHaveBeenCalledWith('integration-1', { autoRestore: true })
+  })
+
+  it('marks restored integrations as runnable before starting the session', async () => {
+    const { service, integration } = createFixture()
+    const startSessionSpy = jest.spyOn(service as any, 'startSession').mockImplementation(async (session) => {
+      expect(session.integrationId).toBe(integration.id)
+      expect(session.shouldRun).toBe(true)
+    })
+
+    await service.connect(integration.id)
+
+    expect(startSessionSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not bootstrap a manually disconnected integration on module init', async () => {
+    const { service, integration } = createFixture()
+    ;(service as any).ensureSession(integration)
+    await service.disconnect(integration.id)
+    const startSessionSpy = jest.spyOn(service as any, 'startSession').mockResolvedValue(undefined)
+
+    await service.onModuleInit()
+
+    expect(startSessionSpy).not.toHaveBeenCalled()
+    await expect(service.status(integration.id)).resolves.toMatchObject({
+      state: 'idle',
+      shouldRun: false,
+      disabledReason: 'manual_disconnect'
+    })
+  })
+
+  it('allows explicit connect to recover a manually disconnected integration', async () => {
+    const { service, integration } = createFixture()
+    ;(service as any).ensureSession(integration)
+    await service.disconnect(integration.id)
+    const startSessionSpy = jest.spyOn(service as any, 'startSession').mockImplementation(async (session) => {
+      expect(session.integrationId).toBe(integration.id)
+      expect(session.shouldRun).toBe(true)
+    })
+
+    await service.connect(integration.id)
+
+    expect(startSessionSpy).toHaveBeenCalledTimes(1)
   })
 
   it('treats trigger binding as a valid routing target during bootstrap', async () => {
@@ -186,7 +228,7 @@ describe('WeComLongConnectionService', () => {
 
     await service.onModuleInit()
 
-    expect(connectSpy).toHaveBeenCalledWith('integration-1')
+    expect(connectSpy).toHaveBeenCalledWith('integration-1', { autoRestore: true })
   })
 
   it('hasRoutingTarget depends only on persisted trigger bindings', async () => {

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
@@ -179,14 +179,14 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
     this.logger.debug(
       `[wecom-long] bootstrapping long connection sessions for integrations: [${integrationIds.join(', ')}]`
     )
-    await Promise.allSettled(integrationIds.map((integrationId) => this.connect(integrationId)))
+    await Promise.allSettled(integrationIds.map((integrationId) => this.connect(integrationId, { autoRestore: true })))
   }
 
   async onModuleDestroy(): Promise<void> {
     await Promise.allSettled([...this.sessions.values()].map((session) => this.stopSession(session, true)))
   }
 
-  async connect(integrationId: string): Promise<TWeComRuntimeStatus> {
+  async connect(integrationId: string, options?: { autoRestore?: boolean }): Promise<TWeComRuntimeStatus> {
     const integration = await this.safeReadLongIntegration(integrationId)
     if (!integration) {
       await this.dropMissingIntegration(integrationId)
@@ -198,19 +198,24 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
       await this.unregisterIntegration(integrationId)
       await this.removeSession(integrationId)
       await this.writeDetachedStatus(integrationId, skipReason, {
-            shouldRun: false,
-            lastError:
-          skipReason === 'integration_disabled'
-            ? 'Integration is disabled'
-            : skipReason === 'xpert_unbound'
-            ? 'WeCom trigger binding is missing'
-            : 'Restore skipped'
+        shouldRun: false,
+        lastError: this.describeDisabledReason(skipReason) ?? 'Restore skipped'
       })
       return this.readStoredStatus(integrationId)
     }
 
+    if (options?.autoRestore) {
+      const persistentStopReason = await this.resolvePersistentAutoRestoreStopReason(integrationId)
+      if (persistentStopReason) {
+        await this.unregisterIntegration(integrationId)
+        await this.removeSession(integrationId)
+        return this.readStoredStatus(integrationId)
+      }
+    }
+
     await this.registerIntegration(integrationId)
     const session = this.ensureSession(integration)
+    session.shouldRun = true
 
     if (session.state === 'unhealthy') {
       await this.writeStatus(session)
@@ -1597,7 +1602,7 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
       const evaluatedItems = await Promise.all(
         (result?.items ?? []).map(async (item) => ({
           item,
-          skipReason: await this.resolveRestoreSkipReason(item)
+          skipReason: await this.resolveAutoBootstrapSkipReason(item)
         }))
       )
       const items = evaluatedItems.filter(({ skipReason }) => !skipReason).map(({ item }) => item)
@@ -1875,8 +1880,35 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
     if (!hasRoutingTarget) {
       return 'xpert_unbound'
     }
-
     return null
+  }
+
+  private async resolveAutoBootstrapSkipReason(
+    integration: IIntegration<TIntegrationWeComLongOptions>
+  ): Promise<TWeComLongDisabledReason | null> {
+    const restoreSkipReason = await this.resolveRestoreSkipReason(integration)
+    if (restoreSkipReason) {
+      return restoreSkipReason
+    }
+    return this.resolvePersistentAutoRestoreStopReason(integration.id)
+  }
+
+  private async resolvePersistentAutoRestoreStopReason(
+    integrationId: string
+  ): Promise<TWeComLongDisabledReason | null> {
+    const storedStatus = await this.readStoredStatus(integrationId)
+    const disabledReason = storedStatus.disabledReason ?? null
+    return this.isAutoRestoreBlockedReason(disabledReason) ? disabledReason : null
+  }
+
+  private isAutoRestoreBlockedReason(reason: TWeComLongDisabledReason | null): boolean {
+    return (
+      reason === 'manual_disconnect' ||
+      reason === 'integration_disabled' ||
+      reason === 'xpert_unbound' ||
+      reason === 'config_invalid' ||
+      reason === 'restore_skipped'
+    )
   }
 
   private describeDisabledReason(reason: TWeComLongDisabledReason | null): string | null {


### PR DESCRIPTION
## Summary

- Document the WeCom long-connection reconnect policy for API restart, runtime disconnect, manual disconnect, and terminal disabled states.
- Make API bootstrap use an explicit auto-restore mode so persisted manual stops are not recovered after restart.
- Keep normal `connect()` usable for explicit reconnects and valid configuration saves.
- Add focused tests for manual disconnect persistence, bootstrap skip behavior, explicit recovery, and restored session intent.

## Root Cause

The WeCom long-connection runtime used the same `connect()` entrypoint for API restart bootstrap and explicit user/configuration-triggered recovery. Without separating those intents, a persisted manual stop could either be ignored during API restart or incorrectly block explicit recovery.

## Validation

- `git diff --check`
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false pnpm exec nx test @xpert-ai/plugin-wecom --runTestsByPath src/lib/wecom-long-connection.service.spec.ts --runInBand`
- `NX_DAEMON=false NX_ISOLATE_PLUGINS=false pnpm exec nx build @xpert-ai/plugin-wecom`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin ./integrations/wecom`