### PR TITLE
[codex] Clarify Playwright CLI sandbox shell usage

### DIFF
--- a/xpertai/.changeset/playwright-cli-sandbox-shell-guidance.md
+++ b/xpertai/.changeset/playwright-cli-sandbox-shell-guidance.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-playwright-cli': patch
+---
+
+Clarify that Playwright CLI commands should run one per sandbox shell call.

--- a/xpertai/middlewares/playwright-cli/src/lib/playwright-bootstrap.service.spec.ts
+++ b/xpertai/middlewares/playwright-cli/src/lib/playwright-bootstrap.service.spec.ts
@@ -265,6 +265,8 @@ describe('PlaywrightBootstrapService', () => {
     expect(prompt).toContain('/workspace/.xpert/skills/playwright-cli/SKILL.md')
     expect(prompt).toContain('/workspace/.xpert/skills/playwright-cli/references/')
     expect(prompt).toContain(DEFAULT_PLAYWRIGHT_MANAGED_CONFIG_PATH)
+    expect(prompt).toContain('Run one `playwright-cli` command per `sandbox_shell` call')
+    expect(prompt).toContain('Do not chain multiple `playwright-cli` commands')
   })
 
   it('detects playwright-cli commands correctly', () => {

--- a/xpertai/middlewares/playwright-cli/src/lib/playwright-bootstrap.service.ts
+++ b/xpertai/middlewares/playwright-cli/src/lib/playwright-bootstrap.service.ts
@@ -83,6 +83,7 @@ export class PlaywrightBootstrapService {
       'Use headless mode only (do not pass `--headed`).',
       'Prefer non-interactive CLI flows: snapshots, screenshots, clicks, fills, evals, test runs.',
       'Do not use `codegen`, UI mode, or `show`.',
+      'Run one `playwright-cli` command per `sandbox_shell` call. Do not chain multiple `playwright-cli` commands with `&&`, `;`, or `|`; use separate `sandbox_shell` calls so each command can be prepared and rewritten correctly.',
       '',
       'TIMEOUT GUIDELINES for sandbox_shell with playwright-cli:',
       '- `playwright-cli open` and `playwright-cli open <url>` are long-running processes that keep the browser alive. A short timeout is enforced automatically — the browser opens immediately and the output is returned within seconds.',

--- a/xpertai/middlewares/playwright-cli/src/lib/skills/SKILL.md
+++ b/xpertai/middlewares/playwright-cli/src/lib/skills/SKILL.md
@@ -23,6 +23,10 @@ playwright-cli screenshot
 playwright-cli close
 ```
 
+## sandbox_shell usage
+
+Run one `playwright-cli` command per `sandbox_shell` call. Do not chain multiple `playwright-cli` commands with `&&`, `;`, or `|`; use separate `sandbox_shell` calls so each command can be prepared and rewritten correctly.
+
 ## Commands
 
 ### Core


### PR DESCRIPTION
## Summary

- Add Playwright CLI guidance to the plugin system prompt: run one `playwright-cli` command per `sandbox_shell` call.
- Add the same guidance to the embedded `playwright-cli` skill file that is written into the sandbox.
- Extend the bootstrap prompt test to lock the guidance in place.

## Root Cause

The one-command guidance belongs to `@xpert-ai/plugin-playwright-cli` because this plugin prepares and rewrites `playwright-cli` commands before they run through `sandbox_shell`. It is not a generic `sandbox_shell` limitation.

## Validation

- `pnpm exec nx test @xpert-ai/plugin-playwright-cli --runInBand`