### PR TITLE
[codex] fix MinerU self-hosted file uploads

### DIFF
--- a/xpertai/.changeset/mineru-self-hosted-file-field.md
+++ b/xpertai/.changeset/mineru-self-hosted-file-field.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-mineru': patch
+---
+
+Support self-hosted MinerU services that require the singular file upload field.

--- a/xpertai/integrations/mineru/src/lib/mineru.client.spec.ts
+++ b/xpertai/integrations/mineru/src/lib/mineru.client.spec.ts
@@ -94,6 +94,21 @@ const isConnectionRefused = (error: any): boolean => {
   return Boolean(error.cause && error.cause.code === 'ECONNREFUSED');
 };
 
+const getFormFieldNames = (form: unknown): string[] => {
+  if (!form || typeof form !== 'object' || !('_streams' in form)) {
+    return [];
+  }
+
+  const streams = (form as { _streams?: unknown })._streams;
+  if (!Array.isArray(streams)) {
+    return [];
+  }
+
+  return streams
+    .filter((stream): stream is string => typeof stream === 'string')
+    .flatMap((stream) => [...stream.matchAll(/name="([^"]+)"/g)].map((match) => match[1]));
+};
+
 describe('MinerUClient', () => {
   afterEach(() => {
     jest.restoreAllMocks();
@@ -410,6 +425,58 @@ describe('MinerUClient', () => {
     expect(result.sourceUrl).toBe(sourceUrl);
   });
 
+  it('should retry self-hosted parse with singular file field when required', async () => {
+    const { instance: configService } = createConfigServiceMock();
+    const client = new MinerUClient(configService, {
+      integration: {
+        options: {
+          apiUrl: 'http://127.0.0.1:9000',
+          serverType: 'self-hosted',
+        },
+      },
+      fileSystem: {
+        fullPath: (filePath: string) => filePath,
+      } as XpFileSystem,
+    });
+
+    const missingFileResponse = {
+      data: {
+        error: 'Must provide either file or file_path',
+      },
+      status: 400,
+      statusText: 'Bad Request',
+      headers: {},
+      config: {},
+    } as AxiosResponse;
+    const parseResponse = {
+      data: {
+        md_content: '# Parsed',
+        content_list: [],
+        images: {},
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: {},
+    } as AxiosResponse;
+
+    const postSpy = jest
+      .spyOn(axios, 'post')
+      .mockResolvedValueOnce(missingFileResponse)
+      .mockResolvedValueOnce(parseResponse);
+
+    const { taskId } = await client.createTask({
+      url: 'https://example.com/local.pdf',
+      filePath: sampleDocumentPath,
+      fileName: 'local.pdf',
+    });
+
+    expect(client.getSelfHostedTask(taskId)?.mdContent).toBe('# Parsed');
+    expect(postSpy).toHaveBeenCalledTimes(2);
+    expect(getFormFieldNames(postSpy.mock.calls[0]?.[1])).toContain('files');
+    expect(getFormFieldNames(postSpy.mock.calls[1]?.[1])).toContain('file');
+  });
+
   it('should derive self-hosted mode from environment settings', async () => {
     const configValues = {
       [ENV_MINERU_SERVER_TYPE]: 'self-hosted',
@@ -417,18 +484,11 @@ describe('MinerUClient', () => {
       [ENV_MINERU_API_TOKEN]: 'local-token',
     };
     const { instance: configService } = createConfigServiceMock(configValues);
-    const client = new MinerUClient(configService);
-
-    const downloadResponse = {
-      data: Buffer.from('pdf-file'),
-      headers: {
-        'content-type': 'application/pdf',
-      },
-      status: 200,
-      statusText: 'OK',
-      config: {},
-      request: {},
-    } as AxiosResponse;
+    const client = new MinerUClient(configService, {
+      fileSystem: {
+        fullPath: (filePath: string) => filePath,
+      } as XpFileSystem,
+    });
 
     const parseResponse = {
       data: {
@@ -442,14 +502,15 @@ describe('MinerUClient', () => {
       config: {},
     } as AxiosResponse;
 
-    const getSpy = jest.spyOn(axios, 'get').mockResolvedValueOnce(downloadResponse);
     const postSpy = jest.spyOn(axios, 'post').mockResolvedValueOnce(parseResponse);
 
-    const { taskId } = await client.createTask({ url: 'https://example.com/local.pdf' });
-    const result = await client.getTaskResult(taskId);
+    const { taskId } = await client.createTask({
+      url: 'https://example.com/local.pdf',
+      filePath: sampleDocumentPath,
+    });
+    const result = client.getSelfHostedTask(taskId);
 
-    expect(result.mdContent).toBe('# Local');
-    expect(getSpy).toHaveBeenCalledWith('https://example.com/local.pdf', expect.objectContaining({ responseType: 'arraybuffer' }));
+    expect(result?.mdContent).toBe('# Local');
     expect(postSpy).toHaveBeenCalledWith(
       'http://127.0.0.1:9000/file_parse',
       expect.any(FormData),

--- a/xpertai/integrations/mineru/src/lib/mineru.client.ts
+++ b/xpertai/integrations/mineru/src/lib/mineru.client.ts
@@ -67,6 +67,8 @@ interface TaskResultOptions {
   language?: string;
 }
 
+type SelfHostedFileField = 'files' | 'file';
+
 interface MineruTaskResult {
   code: number;
   msg: string;
@@ -500,54 +502,23 @@ export class MinerUClient {
   ): Promise<MineruSelfHostedTaskResult> {
     const parseUrl = this.buildApiUrl('file_parse');
     this.logger.debug(`Sending parse request to: ${parseUrl}, file: ${fileName}`);
-    
-    const form = new FormData();
-    
-    // Create file read stream (file existence is already validated in createSelfHostedTask)
-    try {
-      form.append(
-        'files',
-        fs.createReadStream(filePath),
-        {
-          filename: fileName,
-        },
-      );
-    } catch (error) {
-      this.logger.error(`Failed to create read stream for file: ${filePath}`, error instanceof Error ? error.stack : error);
-      throw new Error(`Failed to read file: ${filePath}. ${error instanceof Error ? error.message : String(error)}`);
-    }
-    // form.append('files', fileBuffer, { filename: fileName, contentType: contentType || 'application/pdf' });
-    form.append('parse_method', options.parseMethod ?? 'auto');
-    form.append('return_md', 'true');
-    form.append('return_model_output', 'false');
-    form.append('return_content_list', 'true');
-    // form.append('lang_list', JSON.stringify(this.buildLanguageList(options.language)));
-    form.append('return_images', 'true');
-    form.append('backend', options.backend ?? options.modelVersion ?? 'pipeline');
-    form.append('formula_enable', this.booleanToString(options.enableFormula ?? true));
-    form.append('table_enable', this.booleanToString(options.enableTable ?? true));
-    form.append('return_middle_json', this.booleanToString(options.returnMiddleJson ?? false));
-    if (options.serverUrl) {
-      form.append('server_url', options.serverUrl);
-    }
 
-    const headers = {
-      ...this.getSelfHostedHeaders(),
-      ...form.getHeaders(),
-    };
-
-    const response = await axios.post(parseUrl, form, {
-      headers,
-      maxBodyLength: Infinity,
-      validateStatus: () => true,
-    });
+    let response = await this.postSelfHostedParse(parseUrl, filePath, fileName, options, 'files');
 
     if (this.isSelfHostedApiV1(response)) {
       return this.invokeSelfHostedParseV1(filePath, fileName, options);
     }
 
+    if (this.isSelfHostedFileInputMissing(response)) {
+      this.logger.debug('Retrying MinerU self-hosted parse with singular file field');
+      response = await this.postSelfHostedParse(parseUrl, filePath, fileName, options, 'file');
+      if (this.isSelfHostedApiV1(response)) {
+        return this.invokeSelfHostedParseV1(filePath, fileName, options);
+      }
+    }
+
     if (response.status === 400) {
-      const errorMessage = getErrorMessage(response.data);
+      const errorMessage = this.getResponseErrorMessage(response);
       this.logger.error(`MinerU self-hosted parse failed with 400: ${errorMessage}`, JSON.stringify(response.data));
       throw new BadRequestException(
         `MinerU self-hosted parse failed: ${response.status} ${errorMessage}`
@@ -582,20 +553,75 @@ export class MinerUClient {
     return this.normalizeSelfHostedResponse(response.data);
   }
 
+  private async postSelfHostedParse(
+    parseUrl: string,
+    filePath: string,
+    fileName: string,
+    options: CreateTaskOptions,
+    fileField: SelfHostedFileField,
+  ): Promise<AxiosResponse> {
+    const form = this.createSelfHostedParseForm(filePath, fileName, options, fileField);
+    const headers = {
+      ...this.getSelfHostedHeaders(),
+      ...form.getHeaders(),
+    };
+
+    return axios.post(parseUrl, form, {
+      headers,
+      maxBodyLength: Infinity,
+      validateStatus: () => true,
+    });
+  }
+
+  private createSelfHostedParseForm(
+    filePath: string,
+    fileName: string,
+    options: CreateTaskOptions,
+    fileField: SelfHostedFileField,
+  ): FormData {
+    const form = this.createSelfHostedFileForm(filePath, fileName, fileField);
+    form.append('parse_method', options.parseMethod ?? 'auto');
+    form.append('return_md', 'true');
+    form.append('return_model_output', 'false');
+    form.append('return_content_list', 'true');
+    // form.append('lang_list', JSON.stringify(this.buildLanguageList(options.language)));
+    form.append('return_images', 'true');
+    form.append('backend', options.backend ?? options.modelVersion ?? 'pipeline');
+    form.append('formula_enable', this.booleanToString(options.enableFormula ?? true));
+    form.append('table_enable', this.booleanToString(options.enableTable ?? true));
+    form.append('return_middle_json', this.booleanToString(options.returnMiddleJson ?? false));
+    if (options.serverUrl) {
+      form.append('server_url', options.serverUrl);
+    }
+    return form;
+  }
+
+  private createSelfHostedFileForm(filePath: string, fileName: string, fileField: SelfHostedFileField): FormData {
+    const form = new FormData();
+
+    try {
+      form.append(
+        fileField,
+        fs.createReadStream(filePath),
+        {
+          filename: fileName,
+        },
+      );
+    } catch (error) {
+      this.logger.error(`Failed to create read stream for file: ${filePath}`, error instanceof Error ? error.stack : error);
+      throw new Error(`Failed to read file: ${filePath}. ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return form;
+  }
+
   private async invokeSelfHostedParseV1(
     filePath: string,
     fileName: string,
     options: CreateTaskOptions,
   ): Promise<MineruSelfHostedTaskResult> {
     const parseUrl = this.buildApiUrl('file_parse');
-    const form = new FormData();
-    form.append(
-      'files',
-      fs.createReadStream(filePath),
-      {
-        filename: fileName,
-      },
-    );
+    const form = this.createSelfHostedFileForm(filePath, fileName, 'file');
 
     const params = {
       parse_method: options.parseMethod ?? 'auto',
@@ -650,6 +676,24 @@ export class MinerUClient {
       const loc = item?.loc;
       return item?.type === 'missing' && Array.isArray(loc) && loc[0] === 'body' && loc[1] === 'file';
     });
+  }
+
+  private isSelfHostedFileInputMissing(response: AxiosResponse): boolean {
+    if (response.status !== 400) {
+      return false;
+    }
+
+    const errorMessage = this.getResponseErrorMessage(response);
+    return errorMessage.includes('Must provide either file or file_path') || errorMessage.includes('file or file_path');
+  }
+
+  private getResponseErrorMessage(response: AxiosResponse): string {
+    const directMessage = getErrorMessage(response.data);
+    if (directMessage) {
+      return directMessage;
+    }
+
+    return response.statusText;
   }
 
   private normalizeSelfHostedResponse(payload: any): MineruSelfHostedTaskResult {


### PR DESCRIPTION
## Summary

Fix the MinerU self-hosted parser integration so it can work with services that require the singular multipart upload field `file` instead of the plural `files` field.

## Root Cause

The existing self-hosted path always uploaded documents with the multipart field name `files`. The target MinerU 2.0 FastAPI service exposes `POST /file_parse` with `file` or `file_path` fields, so it returned `400` with `Must provide either file or file_path` even though Xpert had supplied a local document.

## Changes

- Keep the existing `files` request as the first attempt to preserve compatibility with current self-hosted MinerU services.
- Detect the `Must provide either file or file_path` response and retry once with the singular `file` upload field.
- Reuse the same form construction for the legacy self-hosted branch.
- Add a patch changeset for `@xpert-ai/plugin-mineru`.
- Add a regression test covering the `files` failure followed by `file` retry.

## Validation

Passed:

- `pnpm exec nx build @xpert-ai/plugin-mineru --skip-nx-cache`
- `pnpm exec nx typecheck @xpert-ai/plugin-mineru --skip-nx-cache`
- `pnpm exec eslint integrations/mineru/src/lib/mineru.client.ts integrations/mineru/src/lib/mineru.client.spec.ts --quiet`
- `git diff --check`

Blocked:

- `pnpm exec nx test @xpert-ai/plugin-mineru --runInBand` does not reach test execution because Jest cannot read `integrations/mineru/tsconfig.jest.json`, which is missing in the current project config.