### PR TITLE
Add OpenAI-compatible custom body params

### DIFF
--- a/xpertai/.changeset/openai-compatible-custom-body-params.md
+++ b/xpertai/.changeset/openai-compatible-custom-body-params.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-openai-compatible': patch
+---
+
+Add LLM custom body params support and forward runtime sampling options for OpenAI-compatible models.

--- a/xpertai/models/openai-compatible/package.json
+++ b/xpertai/models/openai-compatible/package.json
@@ -31,6 +31,7 @@
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
+    "build": "tsc --build tsconfig.lib.json && node ./scripts/copy-assets.mjs",
     "prepack": "node ./scripts/copy-assets.mjs"
   },
   "dependencies": {

--- a/xpertai/models/openai-compatible/src/llm/llm.spec.ts
+++ b/xpertai/models/openai-compatible/src/llm/llm.spec.ts
@@ -2,7 +2,7 @@ import { OAIAPICompatLargeLanguageModel } from './llm.js'
 import { OpenAICompatibleProviderStrategy } from '../provider.strategy.js'
 import { ModelFeature } from '@metad/contracts'
 import { TChatModelOptions } from '@xpert-ai/plugin-sdk'
-import { OpenAICompatModelCredentials } from '../types.js'
+import { OpenAICompatModelCredentials, toCredentialKwargs } from '../types.js'
 
 describe('getCustomizableModelSchemaFromCredentials', () => {
   let llm: OAIAPICompatLargeLanguageModel
@@ -160,5 +160,174 @@ describe('getCustomizableModelSchemaFromCredentials', () => {
     expect(invocationParams['chat_template_kwargs']).toEqual({
       enable_thinking: false
     })
+  })
+
+  it('should pass runtime sampling, penalty, and retry options', () => {
+    const credentials: OpenAICompatModelCredentials = {
+      api_key: 'test-key',
+      endpoint_url: 'http://test.com',
+      endpoint_model_name: 'test-model',
+      mode: 'chat',
+      context_size: '4096',
+      max_tokens_to_sample: '4096',
+      vision_support: 'no_support'
+    }
+    const model = llm.getChatModel(
+      {
+        model: 'test-model',
+        options: {
+          temperature: 0.2,
+          max_tokens: 8192,
+          top_p: 0.8,
+          presence_penalty: 0.3,
+          frequency_penalty: 0.4,
+          maxRetries: 6
+        }
+      },
+      { modelProperties: credentials } as unknown as TChatModelOptions,
+      null
+    )
+
+    const invocationParams = model.invocationParams()
+    expect(invocationParams['temperature']).toBe(0.2)
+    expect(invocationParams['max_completion_tokens']).toBe(8192)
+    expect(invocationParams['top_p']).toBe(0.8)
+    expect(invocationParams['presence_penalty']).toBe(0.3)
+    expect(invocationParams['frequency_penalty']).toBe(0.4)
+    expect((model as any).caller.maxRetries).toBe(6)
+  })
+
+  it('should merge custom body params into invocation params with typed values', () => {
+    const credentials = {
+      api_key: 'test-key',
+      endpoint_url: 'http://test.com',
+      endpoint_model_name: 'test-model',
+      mode: 'chat',
+      context_size: '4096',
+      max_tokens_to_sample: '4096',
+      vision_support: 'no_support',
+      enable_thinking: true,
+      customBodyParams: {
+        thinking_enable: 'xhigh',
+        top_k: 40,
+        enable_thinking: false
+      }
+    } as OpenAICompatModelCredentials
+
+    const model = llm.getChatModel(
+      { model: 'test-model' },
+      { modelProperties: credentials } as unknown as TChatModelOptions,
+      null
+    )
+
+    const invocationParams = model.invocationParams()
+    expect(invocationParams['thinking_enable']).toBe('xhigh')
+    expect(invocationParams['top_k']).toBe(40)
+    expect(invocationParams['enable_thinking']).toBe(false)
+    expect(invocationParams['chat_template_kwargs']).toEqual({
+      enable_thinking: false
+    })
+  })
+
+  it('should not merge custom body params unless explicitly included', () => {
+    const params = toCredentialKwargs(
+      {
+        api_key: 'test-key',
+        endpoint_model_name: 'test-model',
+        mode: 'chat',
+        context_size: '4096',
+        max_tokens_to_sample: '4096',
+        vision_support: 'no_support',
+        customBodyParams: {
+          top_k: 40
+        }
+      } as OpenAICompatModelCredentials,
+      'test-model'
+    )
+
+    expect(params.modelKwargs).toEqual({})
+  })
+
+  it.each(['model', 'messages', 'stream'])('should reject reserved custom body param key %s', (key) => {
+    expect(() =>
+      toCredentialKwargs(
+        {
+          api_key: 'test-key',
+          endpoint_model_name: 'test-model',
+          mode: 'chat',
+          context_size: '4096',
+          max_tokens_to_sample: '4096',
+          vision_support: 'no_support',
+          customBodyParams: {
+            [key]: 'blocked'
+          }
+        } as OpenAICompatModelCredentials,
+        'test-model',
+        { includeCustomBodyParams: true }
+      )
+    ).toThrow(`Custom body param '${key}' is reserved`)
+  })
+
+  it('should trim and reject empty custom body param keys', () => {
+    expect(() =>
+      toCredentialKwargs(
+        {
+          api_key: 'test-key',
+          endpoint_model_name: 'test-model',
+          mode: 'chat',
+          context_size: '4096',
+          max_tokens_to_sample: '4096',
+          vision_support: 'no_support',
+          customBodyParams: {
+            '   ': 'blocked'
+          }
+        } as OpenAICompatModelCredentials,
+        'test-model',
+        { includeCustomBodyParams: true }
+      )
+    ).toThrow('Custom body param key must not be empty')
+  })
+
+  it('should reject non-object custom body params', () => {
+    expect(() =>
+      toCredentialKwargs(
+        {
+          api_key: 'test-key',
+          endpoint_model_name: 'test-model',
+          mode: 'chat',
+          context_size: '4096',
+          max_tokens_to_sample: '4096',
+          vision_support: 'no_support',
+          customBodyParams: ['bad']
+        } as unknown as OpenAICompatModelCredentials,
+        'test-model',
+        { includeCustomBodyParams: true }
+      )
+    ).toThrow('Custom body params must be an object')
+  })
+
+  it.each([
+    ['array', ['bad']],
+    ['object', { nested: true }],
+    ['null', null],
+    ['non-finite number', Number.POSITIVE_INFINITY]
+  ])('should reject custom body param value %s', (_label, value) => {
+    expect(() =>
+      toCredentialKwargs(
+        {
+          api_key: 'test-key',
+          endpoint_model_name: 'test-model',
+          mode: 'chat',
+          context_size: '4096',
+          max_tokens_to_sample: '4096',
+          vision_support: 'no_support',
+          customBodyParams: {
+            bad_param: value
+          }
+        } as OpenAICompatModelCredentials,
+        'test-model',
+        { includeCustomBodyParams: true }
+      )
+    ).toThrow("Custom body param 'bad_param' must be a string, finite number, or boolean")
   })
 })

--- a/xpertai/models/openai-compatible/src/llm/llm.ts
+++ b/xpertai/models/openai-compatible/src/llm/llm.ts
@@ -32,7 +32,7 @@ export class OAIAPICompatLargeLanguageModel extends LargeLanguageModel {
   }
 
   async validateCredentials(model: string, credentials: OpenAICompatModelCredentials): Promise<void> {
-    const params = toCredentialKwargs(credentials, model)
+    const params = toCredentialKwargs(credentials, model, { includeCustomBodyParams: true })
 
     try {
       const chatModel = this.createChatModel({
@@ -72,13 +72,18 @@ export class OAIAPICompatLargeLanguageModel extends LargeLanguageModel {
       ...(credentials ?? {}),
       ...(runtimeEnableThinking !== undefined ? { enable_thinking: toBoolean(runtimeEnableThinking) } : {})
     } as OpenAICompatModelCredentials
-    const params = toCredentialKwargs(runtimeCredentials, copilotModel.model)
+    const params = toCredentialKwargs(runtimeCredentials, copilotModel.model, { includeCustomBodyParams: true })
+    const modelOptions = copilotModel.options ?? {}
 
     return this.createChatModel({
       ...params,
-      streaming: copilotModel.options?.['streaming'] ?? this.canSteaming(params.model),
-      temperature: copilotModel.options?.['temperature'] ?? 0,
-      maxTokens: copilotModel.options?.['max_tokens'],
+      streaming: modelOptions['streaming'] ?? this.canSteaming(params.model),
+      temperature: modelOptions['temperature'] ?? 0,
+      maxTokens: modelOptions['max_tokens'],
+      topP: modelOptions['top_p'] ?? params.topP,
+      frequencyPenalty: modelOptions['frequency_penalty'],
+      presencePenalty: modelOptions['presence_penalty'],
+      maxRetries: modelOptions['maxRetries'] ?? runtimeCredentials.maxRetries,
       streamUsage: false,
       verbose: options?.verbose,
       callbacks: [...this.createHandleUsageCallbacks(copilot, params.model, runtimeCredentials, handleLLMTokens)]

--- a/xpertai/models/openai-compatible/src/openai-compatible.yaml
+++ b/xpertai/models/openai-compatible/src/openai-compatible.yaml
@@ -291,6 +291,15 @@ model_credential_schema:
           value: llm
       default: '\n\n'
       type: text-input
+    - variable: customBodyParams
+      label:
+        zh_Hans: 自定义 Body 参数
+        en_US: Custom Body Params
+      type: custom-body-params
+      required: false
+      show_on:
+        - variable: __model_type
+          value: llm
     - variable: voices
       show_on:
         - variable: __model_type

--- a/xpertai/models/openai-compatible/src/types.ts
+++ b/xpertai/models/openai-compatible/src/types.ts
@@ -15,15 +15,63 @@ export interface OpenAICompatModelCredentials extends CommonChatModelParameters 
   voices?: string
   streaming?: boolean
   enable_thinking?: boolean
+  customBodyParams?: Record<string, string | number | boolean>
 }
 
 function toBoolean(value: unknown): boolean {
   return value === true || value === 'true' || value === 1 || value === '1'
 }
 
+const ReservedCustomBodyParamKeys = new Set(['model', 'messages', 'stream'])
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function toCustomBodyParams(value: unknown): Record<string, string | number | boolean> {
+  if (value == null) {
+    return {}
+  }
+
+  if (!isPlainObject(value)) {
+    throw new Error('Custom body params must be an object')
+  }
+
+  const params: Record<string, string | number | boolean> = {}
+  for (const [rawKey, paramValue] of Object.entries(value)) {
+    const key = rawKey.trim()
+    if (!key) {
+      throw new Error('Custom body param key must not be empty')
+    }
+    if (ReservedCustomBodyParamKeys.has(key)) {
+      throw new Error(`Custom body param '${key}' is reserved`)
+    }
+    if (Object.prototype.hasOwnProperty.call(params, key)) {
+      throw new Error(`Custom body param '${key}' is duplicated`)
+    }
+    if (
+      typeof paramValue !== 'string' &&
+      typeof paramValue !== 'boolean' &&
+      !(typeof paramValue === 'number' && Number.isFinite(paramValue))
+    ) {
+      throw new Error(`Custom body param '${key}' must be a string, finite number, or boolean`)
+    }
+
+    params[key] = paramValue
+  }
+
+  return params
+}
+
 export function toCredentialKwargs(
   credentials: OpenAICompatModelCredentials,
-  model?: string
+  model?: string,
+  options?: { includeCustomBodyParams?: boolean }
 ): OpenAIBaseInput & { configuration: ClientOptions } {
   const credentialsKwargs: OpenAIBaseInput = {
     apiKey: credentials.api_key || 'no-key-required',
@@ -39,12 +87,20 @@ export function toCredentialKwargs(
     configuration.baseURL = openaiApiBase
   }
 
-  const modelKwargs = {}
+  const modelKwargs: Record<string, any> = {}
   if (credentials.enable_thinking != null) {
     const thinkingEnabled = toBoolean(credentials.enable_thinking)
     modelKwargs['enable_thinking'] = thinkingEnabled
     modelKwargs['chat_template_kwargs'] ??= {}
     modelKwargs['chat_template_kwargs']['enable_thinking'] = thinkingEnabled
+  }
+  if (options?.includeCustomBodyParams) {
+    const customBodyParams = toCustomBodyParams(credentials.customBodyParams)
+    Object.assign(modelKwargs, customBodyParams)
+    if (Object.prototype.hasOwnProperty.call(customBodyParams, 'enable_thinking')) {
+      modelKwargs['chat_template_kwargs'] ??= {}
+      modelKwargs['chat_template_kwargs']['enable_thinking'] = toBoolean(customBodyParams['enable_thinking'])
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- add LLM-only customBodyParams credential support for OpenAI-compatible models
- validate and merge custom params into modelKwargs while protecting model/messages/stream
- forward runtime sampling options and add focused coverage

## Validation
- pnpm -C /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai exec nx build @xpert-ai/plugin-openai-compatible --skip-nx-cache
- NODE_PATH="/Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/node_modules/.pnpm/node_modules" node /Users/jiangyimin/Documents/Git/xpert-plugins/plugin-dev-harness/dist/index.js --workspace /Users/jiangyimin/Documents/Git/xpert-plugins/xpertai --plugin @xpert-ai/plugin-openai-compatible