### PR TITLE
[codex] Support Lark and WeCom inbound image files

### DIFF
--- a/xpertai/.changeset/lark-wecom-image-inputs.md
+++ b/xpertai/.changeset/lark-wecom-image-inputs.md
@@ -1,0 +1,6 @@
+---
+"@xpert-ai/plugin-lark": patch
+"@xpert-ai/plugin-wecom": patch
+---
+
+Support inbound image messages as vision files for Lark and WeCom robots.

--- a/xpertai/integrations/lark/src/lib/conversation.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.service.spec.ts
@@ -380,6 +380,20 @@ describe('LarkConversationService', () => {
 			interactiveMessage: jest.fn().mockResolvedValue({ data: { message_id: 'generated-lark-message-id' } }),
 			resolveUserNameByOpenId: jest.fn().mockResolvedValue(null)
 		}
+		const contextToolService = {
+			getMessageResource: jest.fn().mockResolvedValue({
+				item: {
+					messageId: 'om_image_1',
+					fileKey: 'img_1',
+					type: 'image',
+					name: 'photo.png',
+					mimeType: 'image/png',
+					size: 3,
+					contentEncoding: 'base64',
+					contentBase64: 'YWJj'
+				}
+			})
+		}
 		const recipientDirectoryService = {
 			buildKey: jest.fn().mockImplementation(({ integrationId, chatType, chatId, senderOpenId }) => {
 				if (!integrationId) {
@@ -401,6 +415,7 @@ describe('LarkConversationService', () => {
 			commandBus as any,
 			cache as any,
 			larkChannel as any,
+			contextToolService as any,
 			recipientDirectoryService as any,
 			groupMentionWindowService as any,
 			conversationBindingRepository as any,
@@ -412,6 +427,7 @@ describe('LarkConversationService', () => {
 			service,
 			commandBus,
 			larkChannel,
+			contextToolService,
 			integrationPermissionService,
 			larkTriggerStrategy,
 			recipientDirectoryService,
@@ -576,6 +592,47 @@ describe('LarkConversationService', () => {
 		const dispatchCommands = getExecutedDispatchCommands(commandBus as any)
 		expect(dispatchCommands).toHaveLength(1)
 		expect(dispatchCommands[0].input.options?.fromEndUserId).toBe('mapped-user-1')
+	})
+
+	it('processMessage forwards inbound image messages as vision files', async () => {
+		const { service, commandBus, contextToolService } = createFixture({
+			boundXpertId: null,
+			triggerHandled: false,
+			legacyXpertId: 'legacy-xpert'
+		})
+
+		await service.processMessage({
+			userId: 'creator-user-1',
+			senderOpenId: 'ou_sender_1',
+			integrationId: 'integration-1',
+			chatId: 'chat-1',
+			message: {
+				message: {
+					message_id: 'om_image_1',
+					message_type: 'image',
+					content: JSON.stringify({ image_key: 'img_1' })
+				}
+			}
+		} as any)
+
+		expect(contextToolService.getMessageResource).toHaveBeenCalledWith({
+			integrationId: 'integration-1',
+			messageId: 'om_image_1',
+			fileKey: 'img_1',
+			type: 'image',
+			contentMode: 'base64'
+		})
+		const dispatchCommands = getExecutedDispatchCommands(commandBus as any)
+		expect(dispatchCommands).toHaveLength(1)
+		expect(dispatchCommands[0].input.input).toBeUndefined()
+		expect(dispatchCommands[0].input.files).toEqual([
+			{
+				fileUrl: 'data:image/png;base64,YWJj',
+				mimeType: 'image/png',
+				originalName: 'photo.png',
+				fileKey: 'img_1'
+			}
+		])
 	})
 
 	it('setConversation persists to binding table and resolves latest by open_id', async () => {
@@ -1318,6 +1375,31 @@ describe('LarkConversationService', () => {
 		expect(larkTriggerStrategy.handleInboundMessage).not.toHaveBeenCalled()
 		expect(getExecutedDispatchCommands(commandBus as any)).toHaveLength(0)
 		expect(larkChannel.errorMessage).not.toHaveBeenCalled()
+	})
+
+	it('processMessage does not download image files when trigger scope rejects inbound sender', async () => {
+		const { service, contextToolService } = createFixture({
+			boundXpertId: 'trigger-xpert',
+			triggerHandled: false,
+			triggerMatches: false,
+			legacyXpertId: 'legacy-xpert'
+		})
+
+		await service.processMessage({
+			userId: 'user-1',
+			senderOpenId: 'ou_blocked_1',
+			integrationId: 'integration-1',
+			chatType: 'p2p',
+			message: {
+				message: {
+					message_id: 'om_image_1',
+					message_type: 'image',
+					content: JSON.stringify({ image_key: 'img_1' })
+				}
+			}
+		} as any)
+
+		expect(contextToolService.getMessageResource).not.toHaveBeenCalled()
 	})
 
 	it('processMessage clears typing reaction before returning on trigger mismatch', async () => {

--- a/xpertai/integrations/lark/src/lib/conversation.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.service.spec.ts
@@ -1,4 +1,9 @@
-﻿import { LarkConversationService } from './conversation.service.js'
+﻿jest.mock('@xpert-ai/plugin-sdk', () => {
+	const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+	return createLarkPluginSdkMock(jest)
+})
+
+import { LarkConversationService } from './conversation.service.js'
 import {
 	CancelConversationCommand,
 	INTEGRATION_PERMISSION_SERVICE_TOKEN,
@@ -581,13 +586,16 @@ describe('LarkConversationService', () => {
 		expect(conversationBindingRepository.upsert).toHaveBeenCalledWith(
 			expect.objectContaining({
 				userId: 'ou_sender_1',
+				scopeKey: 'open_id:ou_sender_1',
 				conversationUserKey: 'open_id:ou_sender_1',
 				xpertId: 'xpert-1',
 				conversationId: 'conversation-1'
 			}),
-			['userId']
+			['scopeKey', 'xpertId']
 		)
 		expect(await service.getLatestConversationBindingByUserId('ou_sender_1')).toEqual({
+			userId: 'ou_sender_1',
+			scopeKey: 'open_id:ou_sender_1',
 			xpertId: 'xpert-1',
 			conversationId: 'conversation-1',
 			conversationUserKey: 'open_id:ou_sender_1'
@@ -602,11 +610,12 @@ describe('LarkConversationService', () => {
 		expect(conversationBindingRepository.upsert).toHaveBeenCalledWith(
 			expect.objectContaining({
 				userId: null,
+				scopeKey: 'email:target@example.com',
 				conversationUserKey: 'email:target@example.com',
 				xpertId: 'xpert-1',
 				conversationId: 'conversation-1'
 			}),
-			['conversationUserKey', 'xpertId']
+			['scopeKey', 'xpertId']
 		)
 		expect(await service.getLatestConversationBindingByUserId('target@example.com')).toBeNull()
 		expect(await service.getConversation('email:target@example.com', 'xpert-1')).toBe('conversation-1')
@@ -706,6 +715,7 @@ describe('LarkConversationService', () => {
 			conversationBindings: [
 				{
 					userId: 'ou_sender_1',
+					scopeKey: 'open_id:ou_sender_1',
 					conversationUserKey: 'open_id:ou_sender_1',
 					xpertId: 'xpert-1',
 					conversationId: 'conversation-1',
@@ -742,6 +752,7 @@ describe('LarkConversationService', () => {
 			conversationBindings: [
 				{
 					userId: 'ou_sender_1',
+					scopeKey: 'open_id:ou_sender_1',
 					conversationUserKey: 'open_id:ou_sender_1',
 					xpertId: 'xpert-1',
 					conversationId: 'conversation-1',
@@ -814,6 +825,7 @@ describe('LarkConversationService', () => {
 			conversationBindings: [
 				{
 					userId: 'ou_sender_1',
+					scopeKey: 'open_id:ou_sender_1',
 					conversationUserKey: 'open_id:ou_sender_1',
 					xpertId: 'xpert-from-db',
 					conversationId: 'conversation-from-db'
@@ -826,7 +838,12 @@ describe('LarkConversationService', () => {
 
 		expect(first).toBe('conversation-from-db')
 		expect(second).toBe('conversation-from-db')
-		expect(conversationBindingRepository.findOne).toHaveBeenCalledTimes(1)
+		expect(conversationBindingRepository.findOne).toHaveBeenCalledWith({
+			where: {
+				scopeKey: 'open_id:ou_sender_1',
+				xpertId: 'xpert-from-db'
+			}
+		})
 	})
 
 	it('getConversation does not reuse legacy open_id binding for a new group scope', async () => {
@@ -949,11 +966,12 @@ describe('LarkConversationService', () => {
 		expect(await service.getActiveMessage(userId, xpertId)).toBeNull()
 	})
 
-	it('handleCardAction prioritizes latest binding by open_id over integration default xpert', async () => {
+	it('handleCardAction ignores stale current-integration open_id history when integration points to a different xpert', async () => {
 		const { service } = createFixture({
 			conversationBindings: [
 				{
 					userId: 'ou-action-1',
+					integrationId: 'integration-1',
 					conversationUserKey: 'open_id:ou-action-1',
 					xpertId: 'xpert-from-db',
 					conversationId: 'conversation-from-db'
@@ -992,9 +1010,11 @@ describe('LarkConversationService', () => {
 				senderOpenId: 'ou-action-1'
 			}),
 			'open_id:ou-action-1',
-			'xpert-from-db',
-			'action-message-id'
+			'xpert-from-integration',
+			'action-message-id',
+			'open_id:ou-action-1'
 		)
+		await expect(service.getConversation('open_id:ou-action-1', 'xpert-from-db')).resolves.toBeUndefined()
 	})
 
 	it('handleCardAction blocks trigger-bound users that no longer match current trigger scope', async () => {
@@ -1092,7 +1112,8 @@ describe('LarkConversationService', () => {
 			}),
 			'open_id:ou-action-1',
 			'xpert-from-integration',
-			'action-message-id'
+			'action-message-id',
+			'open_id:ou-action-1'
 		)
 	})
 
@@ -1140,7 +1161,8 @@ describe('LarkConversationService', () => {
 			}),
 			'open_id:ou-action-1',
 			'xpert-from-integration',
-			'action-message-id'
+			'action-message-id',
+			'open_id:ou-action-1'
 		)
 		await expect(service.getConversation('open_id:ou-action-1', 'xpert-from-legacy-history')).resolves.toBeUndefined()
 	})
@@ -1191,9 +1213,10 @@ describe('LarkConversationService', () => {
 				userId,
 				senderOpenId: 'ou-action-1'
 			}),
-			'lark:v2:scope:integration-1:group:chat-1',
+			'open_id:ou-action-1',
 			'xpert-from-integration',
-			'action-message-id'
+			'action-message-id',
+			'open_id:ou-action-1'
 		)
 		await expect(
 			service.getConversation('lark:v2:scope:integration-1:group:chat-1', 'xpert-from-stale-binding', {
@@ -1231,16 +1254,22 @@ describe('LarkConversationService', () => {
 		expect(onAction).not.toHaveBeenCalled()
 	})
 
-	it('processMessage prioritizes latest conversation binding and bypasses trigger routing', async () => {
+	it('processMessage dispatches directly to existing trigger conversation when trigger scope matches', async () => {
 		const { service, larkTriggerStrategy, commandBus, larkChannel } = createFixture({
 			boundXpertId: 'trigger-xpert',
 			triggerHandled: true,
+			triggerMatches: true,
 			legacyXpertId: 'legacy-xpert',
 			conversationBindings: [
 				{
 					userId: 'ou_sender_1',
+					integrationId: 'integration-1',
+					scopeKey: 'lark:v2:scope:integration-1:p2p:ou_sender_1',
+					principalKey: 'lark:v2:principal:integration-1:open_id:ou_sender_1',
+					chatType: 'p2p',
+					senderOpenId: 'ou_sender_1',
 					conversationUserKey: 'open_id:ou_sender_1',
-					xpertId: 'xpert-from-db',
+					xpertId: 'trigger-xpert',
 					conversationId: 'conversation-from-db'
 				}
 			]
@@ -1250,7 +1279,7 @@ describe('LarkConversationService', () => {
 			userId: 'user-1',
 			senderOpenId: 'ou_sender_1',
 			integrationId: 'integration-1',
-			chatId: 'chat-1',
+			chatType: 'p2p',
 			message: {
 				message: {
 					content: JSON.stringify({ text: 'hello' })
@@ -1261,7 +1290,7 @@ describe('LarkConversationService', () => {
 		expect(larkTriggerStrategy.handleInboundMessage).not.toHaveBeenCalled()
 		const dispatchCommands = getExecutedDispatchCommands(commandBus as any)
 		expect(dispatchCommands).toHaveLength(1)
-		expect(dispatchCommands[0].input.xpertId).toBe('xpert-from-db')
+		expect(dispatchCommands[0].input.xpertId).toBe('trigger-xpert')
 		expect(larkChannel.errorMessage).not.toHaveBeenCalled()
 	})
 
@@ -1368,7 +1397,7 @@ describe('LarkConversationService', () => {
 		const { service, commandBus, larkTriggerStrategy } = createFixture({
 			boundXpertId: null,
 			triggerHandled: false,
-			legacyXpertId: 'legacy-xpert',
+			legacyXpertId: 'xpert-from-db',
 			conversationBindings: [
 				{
 					userId: 'ou_sender_1',
@@ -1553,6 +1582,7 @@ describe('LarkConversationService', () => {
 		const { service, larkTriggerStrategy, commandBus, larkChannel } = createFixture({
 			boundXpertId: 'trigger-xpert',
 			triggerHandled: true,
+			triggerMatches: true,
 			legacyXpertId: 'legacy-xpert'
 		})
 
@@ -1560,7 +1590,7 @@ describe('LarkConversationService', () => {
 			userId: 'user-1',
 			senderOpenId: 'ou_sender_1',
 			integrationId: 'integration-1',
-			chatId: 'chat-1',
+			chatType: 'p2p',
 			message: {
 				message: {
 					content: JSON.stringify({ text: 'hello' })
@@ -1744,7 +1774,12 @@ describe('LarkConversationService', () => {
 		const { service, commandBus, larkTriggerStrategy, recipientDirectoryService } = createFixture({
 			boundXpertId: 'trigger-xpert',
 			triggerHandled: true,
-			legacyXpertId: 'legacy-xpert'
+			legacyXpertId: 'legacy-xpert',
+			triggerConfig: {
+				integrationId: 'integration-1',
+				...DEFAULT_TRIGGER_CONFIG,
+				groupReplyStrategy: 'all_messages'
+			}
 		})
 		recipientDirectoryService.resolveByOpenId.mockResolvedValue({
 			ref: 'u_1',

--- a/xpertai/integrations/lark/src/lib/conversation.service.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.service.ts
@@ -1551,8 +1551,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		const normalizedLegacyConversationUserKey = normalizeConversationUserKey(legacyConversationUserKey)
 		if (
 			this.shouldAllowLegacyFallbackForScope(scopeKey) &&
-			normalizedLegacyConversationUserKey &&
-			normalizedLegacyConversationUserKey !== scopeKey
+			normalizedLegacyConversationUserKey
 		) {
 			await this.conversationBindingRepository.delete({
 				conversationUserKey: normalizedLegacyConversationUserKey,
@@ -1839,7 +1838,7 @@ export class LarkConversationService implements OnModuleDestroy {
 			integrationId: ctx.integration.id,
 			senderOpenId: action.userId
 		})
-		const historicalBinding =
+		let historicalBinding =
 			(action.chatId ? await this.getLatestConversationBindingByChatId(ctx.integration.id, action.chatId) : null) ??
 			(principalKey ? await this.getLatestConversationBindingByPrincipalKey(principalKey) : null) ??
 			(await this.getLatestConversationBindingByUserId(action.userId, ctx.integration.id))
@@ -1847,6 +1846,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		const configuredXpertId = boundXpertId ?? normalizeConversationUserKey(ctx.integration.options?.xpertId)
 		if (this.shouldPurgeBindingForConfiguredXpert(historicalBinding, ctx.integration.id, configuredXpertId)) {
 			await this.purgeBindingSession(historicalBinding, historicalBinding?.scopeKey ?? legacyConversationUserKey, legacyConversationUserKey)
+			historicalBinding = null
 		}
 		const latestBinding = this.shouldPreferHistoricalBinding(
 			historicalBinding,

--- a/xpertai/integrations/lark/src/lib/conversation.service.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.service.ts
@@ -18,6 +18,7 @@ import { type Cache } from 'cache-manager'
 import { Repository } from 'typeorm'
 import { ChatLarkMessage } from './message.js'
 import { buildLarkSpeakerContextInput } from './lark-agent-prompt.js'
+import { LarkContextToolService } from './lark-context-tool.service.js'
 import { getLarkInboundIdentityMetadata } from './lark-inbound-identity.service.js'
 import {
 	normalizeConversationUserKey,
@@ -29,7 +30,7 @@ import {
 import { translate } from './i18n.js'
 import { LarkChannelStrategy } from './lark-channel.strategy.js'
 import { DispatchLarkChatCommand, DispatchLarkChatPayload } from './handoff/commands/dispatch-lark-chat.command.js'
-import { extractLarkSemanticMessage } from './lark-message-semantics.js'
+import { extractLarkSemanticMessage, unwrapLarkEventPayload } from './lark-message-semantics.js'
 import { LarkRecipientDirectoryService } from './lark-recipient-directory.service.js'
 import { LARK_PLUGIN_CONTEXT } from './tokens.js'
 import {
@@ -39,6 +40,7 @@ import {
 	isLarkCardActionValue,
 	isRejectAction,
 	LarkGroupWindow,
+	LarkInboundFile,
 	LARK_TYPING_REACTION_EMOJI_TYPE,
 	LarkSemanticMessage,
 	RecipientDirectory,
@@ -52,6 +54,11 @@ import { LarkGroupMentionWindowService } from './lark-group-mention-window.servi
 
 type LarkConversationQueueJob = ChatLarkContext<TLarkEvent> & {
 	tenantId?: string
+}
+
+type LarkInboundImageRef = {
+	messageId: string
+	fileKey: string
 }
 
 type LarkTriggerService = {
@@ -72,6 +79,7 @@ type LarkTriggerService = {
 	handleInboundMessage: (params: {
 		integrationId: string
 		input?: string
+		files?: LarkInboundFile[]
 		larkMessage: ChatLarkMessage
 		options?: {
 			confirm?: boolean
@@ -178,6 +186,7 @@ export class LarkConversationService implements OnModuleDestroy {
 
 	public static readonly prefix = 'lark:chat'
 	private static readonly cacheTtlMs = 60 * 10 * 1000
+	private static readonly maxInlineImageBytes = 10 * 1024 * 1024
 
 	private scopeQueues: Map<string, Queue<LarkConversationQueueJob>> = new Map()
 
@@ -186,6 +195,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		@Inject(CACHE_MANAGER)
 		private readonly cacheManager: Cache,
 		private readonly larkChannel: LarkChannelStrategy,
+		private readonly contextToolService: LarkContextToolService,
 		private readonly recipientDirectoryService: LarkRecipientDirectoryService,
 		private readonly groupMentionWindowService: LarkGroupMentionWindowService,
 		@InjectRepository(LarkConversationBindingEntity)
@@ -305,6 +315,80 @@ export class LarkConversationService implements OnModuleDestroy {
 
 	private withSpeakerContext(input: string | undefined, senderName: string | null, chatType?: string | null): string | undefined {
 		return buildLarkSpeakerContextInput(input, senderName, chatType)
+	}
+
+	private async resolveInboundImageFiles(params: {
+		integrationId: string
+		message?: unknown
+	}): Promise<LarkInboundFile[]> {
+		const refs = this.extractInboundImageRefs(params.message)
+		if (!refs.length) {
+			return []
+		}
+
+		const files: LarkInboundFile[] = []
+		for (const ref of refs) {
+			const result = await this.contextToolService.getMessageResource({
+				integrationId: params.integrationId,
+				messageId: ref.messageId,
+				fileKey: ref.fileKey,
+				type: 'image',
+				contentMode: 'base64'
+			})
+			const item = result.item
+			if (!item.contentBase64) {
+				throw new Error(`Lark image resource "${ref.fileKey}" did not return inline content`)
+			}
+			if (!item.mimeType?.startsWith('image/')) {
+				throw new Error(`Lark image resource "${ref.fileKey}" returned non-image mime type "${item.mimeType ?? 'unknown'}"`)
+			}
+			if (typeof item.size === 'number' && item.size > LarkConversationService.maxInlineImageBytes) {
+				throw new Error(
+					`Lark image resource "${ref.fileKey}" is too large (${item.size} bytes). Maximum size is ${LarkConversationService.maxInlineImageBytes} bytes.`
+				)
+			}
+
+			files.push({
+				fileUrl: `data:${item.mimeType};base64,${item.contentBase64}`,
+				mimeType: item.mimeType,
+				originalName: item.name ?? `${ref.fileKey}${this.resolveImageExtension(item.mimeType)}`,
+				fileKey: ref.fileKey
+			})
+		}
+
+		return files
+	}
+
+	private extractInboundImageRefs(message: unknown): LarkInboundImageRef[] {
+		const payload = unwrapLarkEventPayload(message)
+		const inboundMessage = payload?.message
+		if (!inboundMessage || inboundMessage.message_type !== 'image') {
+			return []
+		}
+
+		const messageId = normalizeNonEmptyString(inboundMessage.message_id)
+		if (!messageId) {
+			return []
+		}
+
+		const content = safeJsonRecord(inboundMessage.content)
+		const fileKey = normalizeNonEmptyString(content?.image_key)
+		return fileKey ? [{ messageId, fileKey }] : []
+	}
+
+	private resolveImageExtension(mimeType?: string): string {
+		switch (mimeType) {
+			case 'image/jpeg':
+				return '.jpg'
+			case 'image/png':
+				return '.png'
+			case 'image/webp':
+				return '.webp'
+			case 'image/gif':
+				return '.gif'
+			default:
+				return ''
+		}
 	}
 
 	private resolveReplyToMessageId(
@@ -1217,9 +1301,20 @@ export class LarkConversationService implements OnModuleDestroy {
 				senderOpenId
 			}))
 		const dispatchInput =
-			options.groupWindow && text
-				? text
-				: this.withSpeakerContext(text, senderName, options.chatType)
+			options.groupWindow && text ? text : this.withSpeakerContext(text, senderName, options.chatType)
+		let resolvedFiles: LarkInboundFile[] | undefined
+		const getDispatchFiles = async () => {
+			if (resolvedFiles) {
+				return resolvedFiles
+			}
+			resolvedFiles = options.files?.length
+				? options.files
+				: await this.resolveInboundImageFiles({
+						integrationId,
+						message
+				  })
+			return resolvedFiles
+		}
 		const fallbackXpertId = integration.options?.xpertId
 		const boundTriggerBinding = await this.getBoundTriggerBinding(integrationId)
 		const {
@@ -1332,6 +1427,7 @@ export class LarkConversationService implements OnModuleDestroy {
 			return await this.dispatchToLarkChat({
 				xpertId: targetXpertId,
 				input: dispatchInput,
+				files: await getDispatchFiles(),
 				larkMessage,
 				options: dispatchOptions
 			})
@@ -1340,6 +1436,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		const handledByTrigger = await larkTriggerStrategy.handleInboundMessage({
 			integrationId,
 			input: useDispatchInputForTrigger ? dispatchInput : text,
+			files: await getDispatchFiles(),
 			larkMessage,
 			options: {
 				...dispatchOptions,
@@ -1354,6 +1451,7 @@ export class LarkConversationService implements OnModuleDestroy {
 			return await this.dispatchToLarkChat({
 				xpertId: fallbackXpertId,
 				input: dispatchInput,
+				files: await getDispatchFiles(),
 				larkMessage,
 				options: dispatchOptions
 			})
@@ -1953,4 +2051,26 @@ function normalizeListPositiveInt(value: unknown): number | null {
 	}
 
 	return null
+}
+
+function normalizeNonEmptyString(value: unknown): string | null {
+	if (typeof value !== 'string') {
+		return null
+	}
+
+	const normalized = value.trim()
+	return normalized.length ? normalized : null
+}
+
+function safeJsonRecord(value: unknown): Record<string, unknown> | null {
+	if (typeof value !== 'string') {
+		return null
+	}
+
+	try {
+		const parsed = JSON.parse(value)
+		return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null
+	} catch {
+		return null
+	}
 }

--- a/xpertai/integrations/lark/src/lib/conversation.view-list.spec.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.view-list.spec.ts
@@ -86,6 +86,7 @@ describe('LarkConversationService listBindingsByIntegration', () => {
       { execute: jest.fn() } as unknown as CommandBus,
       { get: jest.fn(), set: jest.fn(), del: jest.fn() } as unknown as Cache,
       {} as unknown as LarkChannelStrategy,
+      { getMessageResource: jest.fn() } as any,
       {} as unknown as LarkRecipientDirectoryService,
       {} as unknown as LarkGroupMentionWindowService,
       conversationBindingRepository as unknown as Repository<LarkConversationBindingEntity>,

--- a/xpertai/integrations/lark/src/lib/handoff/commands/dispatch-lark-chat.command.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/commands/dispatch-lark-chat.command.ts
@@ -1,9 +1,10 @@
-import { LarkGroupWindow } from '../../types.js'
+import { LarkGroupWindow, LarkInboundFile } from '../../types.js'
 import { ChatLarkMessage } from '../../message.js'
 
 export type DispatchLarkChatPayload = {
 	xpertId: string
 	input?: string
+	files?: LarkInboundFile[]
 	larkMessage: ChatLarkMessage
 	options?: {
 		confirm?: boolean

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.spec.ts
@@ -1,3 +1,11 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+	const { createLarkPluginSdkMock } = require('../../../../../test-utils/larkPluginSdkMock.cjs')
+	return createLarkPluginSdkMock(jest, {
+		AGENT_CHAT_DISPATCH_MESSAGE_TYPE: 'agent.chat.dispatch',
+		HANDOFF_PERMISSION_SERVICE_TOKEN: 'HANDOFF_PERMISSION_SERVICE_TOKEN'
+	})
+})
+
 import {
 	HANDOFF_PERMISSION_SERVICE_TOKEN,
 	RequestContext
@@ -212,10 +220,12 @@ describe('LarkChatDispatchService', () => {
 			},
 			lark_conversation_context_current_chat_id: 'chat-1',
 			lark_conversation_context_current_chat_type: 'group',
+			lark_conversation_context_current_sender_name: '',
 			lark_conversation_context_current_sender_open_id: 'ou_sender_1',
 			lark_current_context: {
 				chatId: 'chat-1',
 				chatType: 'group',
+				senderName: '',
 				senderOpenId: 'ou_sender_1'
 			},
 			recipientDirectoryKey: 'lark:recipient-dir:integration-1:chat:chat-1',
@@ -266,6 +276,35 @@ describe('LarkChatDispatchService', () => {
 			'reaction-1'
 		)
 		expect(callOrder).toEqual(['delete', 'update'])
+	})
+
+	it('buildDispatchMessage forwards image files through request and human state', async () => {
+		mockRequestContext()
+		const { service } = createFixture()
+		const larkMessage = createLarkMessage()
+		const files = [
+			{
+				fileUrl: 'data:image/png;base64,YWJj',
+				mimeType: 'image/png',
+				originalName: 'photo.png',
+				fileKey: 'img_1'
+			}
+		]
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			files,
+			larkMessage: larkMessage as any
+		})
+
+		expect((message.payload as any).request.message.input).toEqual({
+			input: '',
+			files
+		})
+		expect((message.payload as any).request.state.human).toEqual({
+			input: '',
+			files
+		})
 	})
 
 	it('buildDispatchMessage continues when deleting typing reaction fails', async () => {

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.ts
@@ -167,7 +167,8 @@ export class LarkChatDispatchService {
 			activeMessageId: activeMessage?.id,
 			state,
 			options: input.options,
-			input: input.input
+			input: input.input,
+			files: input.files
 		})
 
 		return {
@@ -262,14 +263,16 @@ export class LarkChatDispatchService {
 
 	private buildChatState(input: TLarkChatDispatchInput): Record<string, any> {
 		const { larkMessage } = input
-		return {
-			...(input.input !== undefined
+		const files = Array.isArray(input.files) && input.files.length > 0 ? input.files : undefined
+		const humanInput =
+			input.input !== undefined || files
 				? {
-						[STATE_VARIABLE_HUMAN]: {
-							input: input.input
-						}
-					}
-				: {}),
+						input: input.input ?? '',
+						...(files ? { files } : {})
+				  }
+				: undefined
+		return {
+			...(humanInput ? { [STATE_VARIABLE_HUMAN]: humanInput } : {}),
 			lark_conversation_context_current_chat_id: larkMessage.chatId ?? '',
 			lark_conversation_context_current_chat_type: (larkMessage['chatType'] as string | undefined) ?? '',
 			lark_conversation_context_current_sender_open_id: larkMessage.senderOpenId ?? '',
@@ -300,6 +303,7 @@ export class LarkChatDispatchService {
 		state: Record<string, any>
 		options?: TLarkChatDispatchInput['options']
 		input?: string
+		files?: TLarkChatDispatchInput['files']
 	}): TChatRequest {
 		if (params.options?.confirm || params.options?.reject) {
 			if (!params.conversationId) {
@@ -324,7 +328,8 @@ export class LarkChatDispatchService {
 			...(params.conversationId ? { conversationId: params.conversationId } : {}),
 			message: {
 				input: {
-					input: params.input ?? ''
+					input: params.input ?? '',
+					...(params.files?.length ? { files: params.files } : {})
 				}
 			},
 			state: params.state

--- a/xpertai/integrations/lark/src/lib/types.ts
+++ b/xpertai/integrations/lark/src/lib/types.ts
@@ -475,6 +475,7 @@ export type ChatLarkContext<T = any> = {
 	legacyConversationUserKey?: string
 	message?: T
 	input?: string
+	files?: LarkInboundFile[]
 	replyToMessageId?: string
 	semanticMessage?: LarkSemanticMessage
 	recipientDirectoryKey?: string
@@ -482,6 +483,13 @@ export type ChatLarkContext<T = any> = {
 	groupWindowId?: string
 	typingReaction?: LarkMessageReactionRef
 	botMentioned?: boolean
+}
+
+export type LarkInboundFile = {
+	fileUrl: string
+	mimeType?: string
+	originalName?: string
+	fileKey?: string
 }
 
 export type TLarkEventMention = {

--- a/xpertai/integrations/lark/src/lib/workflow/lark-trigger.strategy.ts
+++ b/xpertai/integrations/lark/src/lib/workflow/lark-trigger.strategy.ts
@@ -15,7 +15,7 @@ import { LarkChannelStrategy } from '../lark-channel.strategy.js'
 import { LarkChatDispatchService } from '../handoff/lark-chat-dispatch.service.js'
 import { ChatLarkMessage } from '../message.js'
 import { LARK_PLUGIN_CONTEXT } from '../tokens.js'
-import type { LarkGroupWindow, TIntegrationLarkOptions } from '../types.js'
+import type { LarkGroupWindow, LarkInboundFile, TIntegrationLarkOptions } from '../types.js'
 import { iconImage } from '../types.js'
 import { LarkTriggerBindingEntity } from '../entities/lark-trigger-binding.entity.js'
 import {
@@ -594,6 +594,7 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 	async handleInboundMessage(params: {
 		integrationId: string
 		input?: string
+		files?: LarkInboundFile[]
 		larkMessage: ChatLarkMessage
 		options?: TLarkInboundDispatchOptions
 	}): Promise<boolean> {
@@ -630,6 +631,7 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			await this.dispatchService.enqueueDispatch({
 				xpertId: binding.xpertId,
 				input: params.input,
+				files: params.files,
 				larkMessage: params.larkMessage,
 				options: dispatchOptions
 			})
@@ -639,6 +641,7 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		const handoffMessage = await this.dispatchService.buildDispatchMessage({
 			xpertId: binding.xpertId,
 			input: params.input,
+			files: params.files,
 			larkMessage: params.larkMessage,
 			options: dispatchOptions
 		})

--- a/xpertai/integrations/wecom/src/lib/conversation.service.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/conversation.service.spec.ts
@@ -119,6 +119,7 @@ describe('WeComConversationService', () => {
 
     const service = new WeComConversationService(
       wecomChannel as any,
+      wecomTriggerStrategy as any,
       cacheManager as any,
       conversationBindingRepository as any,
       pluginContext as any
@@ -171,9 +172,49 @@ describe('WeComConversationService', () => {
       })
     )
     expect(wecomTriggerStrategy.handleInboundMessage.mock.calls[0][0].wecomMessage.reqId).toBe('req-1')
-    expect(pluginContext.resolve).toHaveBeenCalledTimes(2)
+    expect(pluginContext.resolve).toHaveBeenCalledTimes(1)
     expect(pluginContext.resolve).toHaveBeenCalledWith(INTEGRATION_PERMISSION_SERVICE_TOKEN)
-    expect(pluginContext.resolve).toHaveBeenCalledWith(WeComTriggerStrategy)
+  })
+
+  it('forwards image-only files to the trigger strategy', async () => {
+    jest.spyOn(RequestContext, 'currentUserId').mockReturnValue('request-user-id' as any)
+
+    const { service, wecomTriggerStrategy } = createFixture()
+    const files = [
+      {
+        fileUrl: 'data:image/png;base64,YWJj',
+        mimeType: 'image/png',
+        originalName: 'photo.png',
+        fileKey: 'wecom-image-0'
+      }
+    ]
+
+    await service.handleMessage(
+      {
+        content: '',
+        chatId: 'chat-1',
+        senderId: 'sender-1',
+        raw: {
+          req_id: 'req-1'
+        },
+        files
+      } as any,
+      {
+        integration: {
+          id: 'integration-1'
+        },
+        tenantId: 'tenant-1',
+        organizationId: 'organization-1'
+      } as any
+    )
+
+    expect(wecomTriggerStrategy.handleInboundMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationId: 'integration-1',
+        input: '',
+        files
+      })
+    )
   })
 
   it('starts a new session and replies with a fixed prompt for bare /new', async () => {

--- a/xpertai/integrations/wecom/src/lib/conversation.service.ts
+++ b/xpertai/integrations/wecom/src/lib/conversation.service.ts
@@ -20,6 +20,7 @@ import {
   resolveConversationUserKey
 } from './conversation-user-key.js'
 import { TIntegrationWeComOptions } from './types.js'
+import type { WeComInboundFile } from './types.js'
 import { WeComChannelStrategy } from './wecom-channel.strategy.js'
 import {
   getWeComAvailableTriggerMissingText,
@@ -36,6 +37,7 @@ type WeComTriggerService = {
   handleInboundMessage: (params: {
     integrationId: string
     input?: string
+    files?: WeComInboundFile[]
     wecomMessage: ChatWeComMessage
     conversationId?: string
     conversationUserKey?: string
@@ -337,7 +339,8 @@ export class WeComConversationService {
     }
 
     const input = this.normalizeInputText(message.content)
-    if (!input) {
+    const files = this.resolveInboundFiles(message)
+    if (!input && !files.length) {
       this.logger.debug(`Skip empty WeCom message integration=${integration.id} chatId=${message.chatId}`)
       return
     }
@@ -425,6 +428,7 @@ export class WeComConversationService {
     const handledByTrigger = await triggerStrategy.handleInboundMessage({
       integrationId: integration.id,
       input: newSessionCommand.matched ? newSessionCommand.input : input,
+      files,
       wecomMessage,
       conversationId: triggerConversationId,
       conversationUserKey: conversationUserKey || undefined,
@@ -462,6 +466,17 @@ export class WeComConversationService {
       return ''
     }
     return value.trim()
+  }
+
+  private resolveInboundFiles(message: TChatInboundMessage): WeComInboundFile[] {
+    const files = (message as unknown as { files?: unknown }).files
+    if (!Array.isArray(files)) {
+      return []
+    }
+
+    return files.filter((file): file is WeComInboundFile => {
+      return Boolean(file && typeof file === 'object' && typeof file.fileUrl === 'string' && file.fileUrl.trim())
+    })
   }
 
   private resolveResponseUrl(raw: unknown): string | undefined {

--- a/xpertai/integrations/wecom/src/lib/handoff/commands/dispatch-wecom-chat.command.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/commands/dispatch-wecom-chat.command.ts
@@ -1,8 +1,10 @@
 import { ChatWeComMessage } from '../../message.js'
+import type { WeComInboundFile } from '../../types.js'
 
 export type DispatchWeComChatPayload = {
   xpertId: string
-  input: string
+  input?: string
+  files?: WeComInboundFile[]
   wecomMessage: ChatWeComMessage
   conversationId?: string
   conversationUserKey?: string

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.spec.ts
@@ -184,6 +184,43 @@ describe('WeComChatDispatchService', () => {
     expect(runStateService.save).toHaveBeenCalledTimes(1)
   })
 
+  it('buildDispatchMessage forwards image files through the chat request', async () => {
+    mockRequestContext({
+      userId: 'request-user-id',
+      language: 'zh-Hans'
+    })
+    const { service } = createFixture()
+    const wecomMessage = createWeComMessage({
+      reqId: 'req-1'
+    })
+    const files = [
+      {
+        fileUrl: 'data:image/png;base64,YWJj',
+        mimeType: 'image/png',
+        originalName: 'photo.png',
+        fileKey: 'wecom-image-0'
+      }
+    ]
+
+    const message = await service.buildDispatchMessage({
+      xpertId: 'xpert-1',
+      input: '',
+      files,
+      wecomMessage,
+      tenantId: 'tenant-1'
+    } as any)
+
+    expect((message.payload as any).request).toEqual({
+      action: 'send',
+      message: {
+        input: {
+          input: '',
+          files
+        }
+      }
+    })
+  })
+
   it('falls back to final_text when reqId is missing', async () => {
     mockRequestContext()
     const { service, runStateService } = createFixture()

--- a/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.ts
+++ b/xpertai/integrations/wecom/src/lib/handoff/wecom-chat-dispatch.service.ts
@@ -52,6 +52,7 @@ export class WeComChatDispatchService {
       xpertId,
       wecomMessage,
       input: textInput,
+      files,
       conversationId,
       conversationUserKey,
       tenantId,
@@ -162,7 +163,8 @@ export class WeComChatDispatchService {
     )
     const request = this.buildChatRequest({
       conversationId,
-      input: textInput
+      input: textInput,
+      files
     })
 
     return {
@@ -243,13 +245,14 @@ export class WeComChatDispatchService {
     return text || undefined
   }
 
-  private buildChatRequest(params: { conversationId?: string; input?: string }): TChatRequest {
+  private buildChatRequest(params: { conversationId?: string; input?: string; files?: TWeComChatDispatchInput['files'] }): TChatRequest {
     return {
       action: 'send',
       ...(params.conversationId ? { conversationId: params.conversationId } : {}),
       message: {
         input: {
-          input: params.input ?? ''
+          input: params.input ?? '',
+          ...(params.files?.length ? { files: params.files } : {})
         }
       }
     } as unknown as TChatRequest

--- a/xpertai/integrations/wecom/src/lib/types.ts
+++ b/xpertai/integrations/wecom/src/lib/types.ts
@@ -99,10 +99,18 @@ export type TWeComEvent = {
   senderId: string
   senderName?: string
   content: string
+  files?: WeComInboundFile[]
   responseUrl?: string
   timestamp: number
   mentions?: Array<{ id: string; name?: string }>
   raw?: unknown
+}
+
+export type WeComInboundFile = {
+  fileUrl: string
+  mimeType?: string
+  originalName?: string
+  fileKey?: string
 }
 
 export function computeWeComSignature(params: {

--- a/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.spec.ts
@@ -144,6 +144,55 @@ describe('WeComChannelStrategy', () => {
     )
   })
 
+  it('parses image-only webhook events when files are present', () => {
+    const { strategy } = createFixture()
+    const files = [
+      {
+        fileUrl: 'data:image/png;base64,YWJj',
+        mimeType: 'image/png',
+        originalName: 'photo.png',
+        fileKey: 'wecom-image-0'
+      }
+    ]
+
+    const event = strategy.normalizeWebhookEvent({
+      msgtype: 'image',
+      msgid: 'msg-1',
+      chatid: 'chat-1',
+      chattype: 'single',
+      from: {
+        userid: 'sender-1'
+      },
+      files
+    } as any)
+
+    expect(event).toEqual(
+      expect.objectContaining({
+        msgType: 'image',
+        chatId: 'chat-1',
+        senderId: 'sender-1',
+        content: '',
+        files
+      })
+    )
+
+    const message = strategy.parseInboundMessage(event!, {
+      integration: {
+        id: 'integration-1'
+      }
+    } as any)
+
+    expect(message).toEqual(
+      expect.objectContaining({
+        chatId: 'chat-1',
+        senderId: 'sender-1',
+        content: '',
+        contentType: 'image',
+        files
+      })
+    )
+  })
+
   it('routes restart cards through active send using senderId for private long connections', async () => {
     const { strategy } = createFixture()
 

--- a/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-channel.strategy.ts
@@ -231,8 +231,10 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
   ): TChatInboundMessage | null {
     const senderId = this.normalizeString(event.senderId)
     const chatId = this.normalizeString(event.chatId) || senderId
+    const files = this.normalizeInboundFiles(event.files)
+    const content = typeof event.content === 'string' ? event.content : ''
 
-    if (!chatId || !senderId || !event.content) {
+    if (!chatId || !senderId || (!content && !files.length)) {
       return null
     }
 
@@ -242,12 +244,23 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
       chatType: event.chatType || 'private',
       senderId,
       senderName: event.senderName,
-      content: event.content,
-      contentType: 'text',
+      content,
+      contentType: event.msgType === 'image' ? 'image' : 'text',
       mentions: event.mentions,
       timestamp: event.timestamp || Date.now(),
-      raw: event.raw ?? event
+      raw: event.raw ?? event,
+      ...(files.length ? { files } : {})
     }
+  }
+
+  private normalizeInboundFiles(value: unknown): NonNullable<TWeComEvent['files']> {
+    if (!Array.isArray(value)) {
+      return []
+    }
+
+    return value.filter((item): item is NonNullable<TWeComEvent['files']>[number] => {
+      return Boolean(item && typeof item === 'object' && typeof item.fileUrl === 'string' && item.fileUrl.trim())
+    })
   }
 
   async sendText(ctx: TChatContext, content: string): Promise<TChatSendResult> {
@@ -864,6 +877,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
     const chatType = this.normalizeChatType(
       payloadRecord.ChatType || payloadRecord.chatType || payloadRecord.chattype || payloadRecord.conversationType
     )
+    const files = this.normalizeInboundFiles(payloadRecord.files || payloadRecord.Files)
 
     if (!content && msgType !== 'text') {
       return {
@@ -877,6 +891,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
         senderId: senderId || '',
         senderName,
         content: '',
+        ...(files.length ? { files } : {}),
         responseUrl,
         timestamp,
         mentions,
@@ -895,6 +910,7 @@ export class WeComChannelStrategy implements IChatChannel<TIntegrationWeComOptio
       senderId: senderId || '',
       senderName,
       content: content || '',
+      ...(files.length ? { files } : {}),
       responseUrl,
       timestamp,
       mentions,

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.spec.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.spec.ts
@@ -103,11 +103,31 @@ describe('WeComLongConnectionService', () => {
         throw new Error(`Unknown token: ${token}`)
       })
     }
+    const conversationService = {
+      handleMessage: jest.fn().mockResolvedValue(undefined)
+    }
+    const wecomChannel = {
+      createEventHandler: jest.fn((_ctx, handlers) => async (req, res) => {
+        const body = req.body as Record<string, any>
+        await handlers.onMessage(
+          {
+            content: body.content ?? '',
+            chatId: body.chatid,
+            chatType: body.chattype === 'single' ? 'private' : 'group',
+            senderId: body.from?.userid,
+            raw: body,
+            files: body.files
+          } as any,
+          _ctx
+        )
+        res.status(200).send('success')
+      })
+    }
 
     const service = new WeComLongConnectionService(
       pluginContext as any,
-      {} as WeComChannelStrategy,
-      {} as WeComConversationService,
+      wecomChannel as any as WeComChannelStrategy,
+      conversationService as any as WeComConversationService,
       triggerBindingRepository as any
     )
 
@@ -116,7 +136,9 @@ describe('WeComLongConnectionService', () => {
       redis,
       integrationPermissionService,
       integration,
-      triggerBindingRepository
+      triggerBindingRepository,
+      wecomChannel,
+      conversationService
     }
   }
 
@@ -515,6 +537,60 @@ describe('WeComLongConnectionService', () => {
               question: '/new'
             })
           ])
+        })
+      })
+    )
+  })
+
+  it('downloads image callback files before dispatching the inbound message', async () => {
+    const { service, integration, conversationService } = createFixture()
+    const session = (service as any).ensureSession(integration)
+    const client = {
+      downloadFile: jest.fn().mockResolvedValue({
+        buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]),
+        filename: 'photo.png'
+      })
+    }
+    session.client = client as any
+
+    await (service as any).handleClientCallbackFrame(session, client, {
+      cmd: 'aibot_msg_callback',
+      headers: {
+        req_id: 'req-image-1'
+      },
+      body: {
+        msgid: 'msg-1',
+        msgtype: 'image',
+        chattype: 'single',
+        chatid: 'chat-1',
+        from: {
+          userid: 'sender-1'
+        },
+        image: {
+          url: 'https://wecom.example/image',
+          aeskey: 'aes-key-1'
+        }
+      }
+    })
+
+    expect(client.downloadFile).toHaveBeenCalledWith('https://wecom.example/image', 'aes-key-1')
+    expect(conversationService.handleMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: '',
+        chatId: 'chat-1',
+        senderId: 'sender-1',
+        files: [
+          expect.objectContaining({
+            fileUrl: expect.stringMatching(/^data:image\/png;base64,/),
+            mimeType: 'image/png',
+            originalName: 'photo.png',
+            fileKey: 'wecom-image-0'
+          })
+        ]
+      }),
+      expect.objectContaining({
+        integration: expect.objectContaining({
+          id: 'integration-1'
         })
       })
     )

--- a/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
+++ b/xpertai/integrations/wecom/src/lib/wecom-long-connection.service.ts
@@ -33,6 +33,7 @@ import {
   TWeComLongRuntimeState,
   TWeComRuntimeStatus
 } from './types.js'
+import type { WeComInboundFile } from './types.js'
 import { WeComChannelStrategy } from './wecom-channel.strategy.js'
 import { WeComTriggerBindingEntity } from './entities/wecom-trigger-binding.entity.js'
 import {
@@ -110,6 +111,15 @@ type WeComLongCommandResult = {
   raw: Record<string, unknown>
 }
 
+type WeComInboundImageRef = {
+  url: string
+  aesKey: string
+}
+
+type WeComImageMimeType = 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+
+type WeComDownloadClient = Pick<WSClient, 'downloadFile'>
+
 export type WeComLongConnectionStatus = {
   integrationId: string
   state: 'disconnected' | 'connecting' | 'connected' | 'error'
@@ -142,6 +152,7 @@ const INITIAL_CONNECT_TIMEOUT_MS = 10_000
 export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(WeComLongConnectionService.name)
   private readonly instanceId = `${hostname()}:${process.pid}:${randomUUID().slice(0, 8)}`
+  private static readonly maxInlineImageBytes = 10 * 1024 * 1024
   private readonly sessions = new Map<string, WeComLongSession>()
   private _integrationPermissionService: IntegrationPermissionService
   private _redis: RedisLike | null | undefined
@@ -772,7 +783,7 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
 
     session.lastCallbackAt = Date.now()
     await this.writeStatus(session)
-    await this.handleCallbackFrame(session, frame as unknown as Record<string, unknown>)
+    await this.handleCallbackFrame(session, frame as unknown as Record<string, unknown>, client)
   }
 
   private async handleEnterChatEvent(session: WeComLongSession, client: WSClient, frame: WsFrame): Promise<void> {
@@ -1218,7 +1229,170 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
     }
   }
 
-  private async handleCallbackFrame(session: WeComLongSession, frame: Record<string, unknown>): Promise<void> {
+  private async resolveInboundImageFiles(
+    body: Record<string, unknown>,
+    client: WeComDownloadClient
+  ): Promise<WeComInboundFile[]> {
+    const refs = this.extractInboundImageRefs(body)
+    if (!refs.length) {
+      return []
+    }
+
+    const files: WeComInboundFile[] = []
+    for (const [index, ref] of refs.entries()) {
+      const downloaded = (await client.downloadFile(ref.url, ref.aesKey)) as {
+        buffer?: unknown
+        filename?: unknown
+      }
+      const buffer = this.normalizeBuffer(downloaded?.buffer)
+      if (!buffer?.length) {
+        throw new Error(`WeCom image file "${ref.url}" did not return content`)
+      }
+      if (buffer.length > WeComLongConnectionService.maxInlineImageBytes) {
+        throw new Error(
+          `WeCom image file "${ref.url}" is too large (${buffer.length} bytes). Maximum size is ${WeComLongConnectionService.maxInlineImageBytes} bytes.`
+        )
+      }
+
+      const mimeType = this.detectImageMimeType(buffer)
+      if (!mimeType) {
+        throw new Error(`WeCom image file "${ref.url}" returned unsupported image content`)
+      }
+
+      files.push({
+        fileUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+        mimeType,
+        originalName:
+          this.normalizeString(downloaded?.filename) ?? `wecom-image-${index}${this.resolveImageExtension(mimeType)}`,
+        fileKey: `wecom-image-${index}`
+      })
+    }
+
+    return files
+  }
+
+  private extractInboundImageRefs(body: Record<string, unknown>): WeComInboundImageRef[] {
+    const msgType = this.normalizeString(body.msgtype || body.msgType || body.MsgType)
+    const refs: WeComInboundImageRef[] = []
+
+    if (msgType === 'image') {
+      const image = this.normalizeRecord(body.image || body.Image)
+      const ref = this.extractInboundImageRef(image)
+      if (ref) {
+        refs.push(ref)
+      }
+      return refs
+    }
+
+    if (msgType !== 'mixed') {
+      return refs
+    }
+
+    const mixed = this.normalizeRecord(body.mixed || body.Mixed)
+    const rawItems =
+      (Array.isArray(mixed?.msg_item) && mixed?.msg_item) ||
+      (Array.isArray(mixed?.msgItem) && mixed?.msgItem) ||
+      (Array.isArray(mixed?.MsgItem) && mixed?.MsgItem) ||
+      []
+
+    for (const rawItem of rawItems) {
+      const item = this.normalizeRecord(rawItem)
+      const itemMsgType = this.normalizeString(item?.msgtype || item?.msgType || item?.MsgType)
+      if (itemMsgType !== 'image') {
+        continue
+      }
+
+      const image = this.normalizeRecord(item?.image || item?.Image)
+      const ref = this.extractInboundImageRef(image)
+      if (ref) {
+        refs.push(ref)
+      }
+    }
+
+    return refs
+  }
+
+  private extractInboundImageRef(image: Record<string, unknown> | null): WeComInboundImageRef | null {
+    if (!image) {
+      return null
+    }
+
+    const url = this.normalizeString(image.url)
+    const aesKey = this.normalizeString(image.aeskey) || this.normalizeString(image.aesKey)
+    if (!url || !aesKey) {
+      return null
+    }
+
+    return {
+      url,
+      aesKey
+    }
+  }
+
+  private normalizeBuffer(value: unknown): Buffer | null {
+    if (Buffer.isBuffer(value)) {
+      return value
+    }
+    if (value instanceof ArrayBuffer) {
+      return Buffer.from(value)
+    }
+    if (ArrayBuffer.isView(value)) {
+      return Buffer.from(value.buffer, value.byteOffset, value.byteLength)
+    }
+    return null
+  }
+
+  private detectImageMimeType(buffer: Buffer): WeComImageMimeType | null {
+    if (
+      buffer.length >= 8 &&
+      buffer[0] === 0x89 &&
+      buffer[1] === 0x50 &&
+      buffer[2] === 0x4e &&
+      buffer[3] === 0x47 &&
+      buffer[4] === 0x0d &&
+      buffer[5] === 0x0a &&
+      buffer[6] === 0x1a &&
+      buffer[7] === 0x0a
+    ) {
+      return 'image/png'
+    }
+    if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+      return 'image/jpeg'
+    }
+
+    const firstSixBytes = buffer.subarray(0, 6).toString('ascii')
+    if (firstSixBytes === 'GIF87a' || firstSixBytes === 'GIF89a') {
+      return 'image/gif'
+    }
+    if (
+      buffer.length >= 12 &&
+      buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+      buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+    ) {
+      return 'image/webp'
+    }
+
+    return null
+  }
+
+  private resolveImageExtension(mimeType: WeComImageMimeType): string {
+    switch (mimeType) {
+      case 'image/jpeg':
+        return '.jpg'
+      case 'image/png':
+        return '.png'
+      case 'image/webp':
+        return '.webp'
+      case 'image/gif':
+        return '.gif'
+    }
+  }
+
+  private async handleCallbackFrame(
+    session: WeComLongSession,
+    frame: Record<string, unknown>,
+    client?: WeComDownloadClient
+  ): Promise<void> {
     const integration = await this.readLongIntegration(session.integrationId)
     const contextUser = (RequestContext.currentUser() as IUser) ?? {
       id: `wecom-long:${integration.id}:system`,
@@ -1239,6 +1413,7 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
     const body = this.normalizeRecord(frame.body) || {}
     const headers = this.normalizeRecord(frame.headers)
     const reqId = this.normalizeString(headers?.req_id) || this.normalizeString(headers?.reqId)
+    const files = client ? await this.resolveInboundImageFiles(body, client) : []
 
     const eventPayload: Record<string, unknown> = {
       ...body,
@@ -1246,6 +1421,7 @@ export class WeComLongConnectionService implements OnModuleInit, OnModuleDestroy
       req_id: reqId,
       reqId,
       headers,
+      ...(files.length ? { files } : {}),
       raw_frame: frame
     }
 

--- a/xpertai/integrations/wecom/src/lib/workflow/wecom-trigger-aggregation.types.ts
+++ b/xpertai/integrations/wecom/src/lib/workflow/wecom-trigger-aggregation.types.ts
@@ -1,4 +1,5 @@
 import { defineChannelMessageType } from '@xpert-ai/plugin-sdk'
+import type { WeComInboundFile } from '../types.js'
 
 export const WECOM_TRIGGER_FLUSH_MESSAGE_TYPE = defineChannelMessageType('wecom', 'trigger_flush', 1)
 
@@ -24,6 +25,7 @@ export interface WeComTriggerAggregationState {
   xpertId: string
   version: number
   inputParts: string[]
+  files?: WeComInboundFile[]
   lastMessageAt: number
   conversationId?: string
   tenantId: string

--- a/xpertai/integrations/wecom/src/lib/workflow/wecom-trigger.strategy.ts
+++ b/xpertai/integrations/wecom/src/lib/workflow/wecom-trigger.strategy.ts
@@ -18,6 +18,7 @@ import { Repository } from 'typeorm'
 import { ChatWeComMessage } from '../message.js'
 import { WECOM_LONG_CONNECTION_SERVICE, WECOM_PLUGIN_CONTEXT } from '../tokens.js'
 import { iconImage, INTEGRATION_WECOM_LONG, TIntegrationWeComLongOptions } from '../types.js'
+import type { WeComInboundFile } from '../types.js'
 import { WeComChannelStrategy } from '../wecom-channel.strategy.js'
 import { WeComTriggerBindingEntity } from '../entities/wecom-trigger-binding.entity.js'
 import { TWeComChatDispatchInput, WeComChatDispatchService } from '../handoff/wecom-chat-dispatch.service.js'
@@ -304,6 +305,7 @@ export class WeComTriggerStrategy implements IWorkflowTriggerStrategy<TWeComTrig
   async handleInboundMessage(params: {
     integrationId: string
     input?: string
+    files?: WeComInboundFile[]
     wecomMessage: ChatWeComMessage
     conversationId?: string
     conversationUserKey?: string
@@ -336,6 +338,7 @@ export class WeComTriggerStrategy implements IWorkflowTriggerStrategy<TWeComTrig
         dispatchPayload: {
           xpertId: binding.xpertId,
           input: params.input || '',
+          files: params.files,
           wecomMessage: params.wecomMessage,
           conversationId: params.conversationId,
           conversationUserKey: aggregateKey,
@@ -359,6 +362,10 @@ export class WeComTriggerStrategy implements IWorkflowTriggerStrategy<TWeComTrig
       xpertId: binding.xpertId,
       version: nextVersion,
       inputParts: [...(sameRoutingTarget ? currentState?.inputParts ?? [] : []), params.input || ''],
+      files: [
+        ...(sameRoutingTarget ? currentState?.files ?? [] : []),
+        ...(params.files ?? [])
+      ],
       lastMessageAt: Date.now(),
       conversationId: params.conversationId ?? (sameRoutingTarget ? currentState?.conversationId : undefined),
       tenantId: params.tenantId,
@@ -406,6 +413,7 @@ export class WeComTriggerStrategy implements IWorkflowTriggerStrategy<TWeComTrig
     const dispatchPayload = {
       xpertId: state.xpertId,
       input: state.inputParts.join('\n'),
+      files: state.files,
       wecomMessage: new ChatWeComMessage(
         {
           integrationId: state.latestMessage.integrationId,

--- a/xpertai/test-utils/larkPluginSdkMock.cjs
+++ b/xpertai/test-utils/larkPluginSdkMock.cjs
@@ -1,0 +1,34 @@
+function createLarkPluginSdkMock(jestRef, overrides = {}) {
+	class CancelConversationCommand {
+		constructor(input) {
+			this.input = input
+		}
+	}
+
+	return {
+		__esModule: true,
+		CHAT_CHANNEL_TEXT_LIMITS: { lark: 1000 },
+		ChatChannel: () => (target) => target,
+		CancelConversationCommand,
+		defineChannelMessageType: (channel, type, version) =>
+			`channel.${channel}.${type}.v${version}`,
+		WorkflowTriggerStrategy: () => (target) => target,
+		INTEGRATION_PERMISSION_SERVICE_TOKEN: 'INTEGRATION_PERMISSION_SERVICE_TOKEN',
+		USER_PERMISSION_SERVICE_TOKEN: 'USER_PERMISSION_SERVICE_TOKEN',
+		RequestContext: {
+			currentUser: jestRef.fn(),
+			currentTenantId: jestRef.fn(),
+			currentUserId: jestRef.fn(),
+			getOrganizationId: jestRef.fn(),
+			getLanguageCode: jestRef.fn(),
+			currentRequest: jestRef.fn()
+		},
+		getErrorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+		runWithRequestContext: (_req, _res, next) => next(),
+		...overrides
+	}
+}
+
+module.exports = {
+	createLarkPluginSdkMock
+}


### PR DESCRIPTION
## Summary
- Add inbound image message handling for Lark robots and forward images as vision files through trigger and chat dispatch paths.
- Add inbound image callback download and image-only message handling for WeCom robots, including trigger aggregation and chat dispatch file forwarding.
- Fix stale Lark conversation binding cleanup and align the Lark conversation spec with current scope/binding semantics.
- Add a patch changeset for `@xpert-ai/plugin-lark` and `@xpert-ai/plugin-wecom`.

## Validation
- `git diff --check origin/main...HEAD`
- `NX_DAEMON=false pnpm -C xpertai exec nx test @xpert-ai/plugin-lark --runTestsByPath src/lib/conversation.service.spec.ts --runInBand` - passed, 43/43
- `NX_DAEMON=false pnpm -C xpertai exec nx test @xpert-ai/plugin-lark --runTestsByPath src/lib/handoff/lark-chat-dispatch.service.spec.ts --runInBand` - passed, 13/13
- `NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-lark --skip-nx-cache` - passed
- `NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-wecom --skip-nx-cache` - passed
- `pnpm -C plugin-dev-harness build` - passed
- `NODE_PATH="$PWD/xpertai/node_modules/.pnpm/node_modules" node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-lark` - passed
- `NODE_PATH="$PWD/xpertai/node_modules/.pnpm/node_modules" node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-wecom` - passed

## Known validation blocker
- WeCom focused Jest command does not reach the test cases because `xpertai/integrations/wecom/jest.config.ts` currently fails during config loading with `ReferenceError: __dirname is not defined in ES module scope`. The same file also has a duplicate `moduleNameMapper` key in HEAD. This PR intentionally leaves that pre-existing test config issue untouched.