### PR TITLE
fix: stabilize openai-compatible response ids

### DIFF
--- a/xpertai/.changeset/stable-openai-compatible-ids.md
+++ b/xpertai/.changeset/stable-openai-compatible-ids.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-openai-compatible": patch
+---
+
+Normalize placeholder chat completion IDs from OpenAI-compatible providers.

--- a/xpertai/models/openai-compatible/src/llm/llm.spec.ts
+++ b/xpertai/models/openai-compatible/src/llm/llm.spec.ts
@@ -1,8 +1,23 @@
-import { OAIAPICompatLargeLanguageModel } from './llm.js'
+import { OpenAIClient } from '@langchain/openai'
+import { OAIAPICompatLargeLanguageModel, StableOpenAICompatibleChatModel } from './llm.js'
 import { OpenAICompatibleProviderStrategy } from '../provider.strategy.js'
 import { ModelFeature } from '@metad/contracts'
 import { TChatModelOptions } from '@xpert-ai/plugin-sdk'
 import { OpenAICompatModelCredentials, toCredentialKwargs } from '../types.js'
+
+class TestableStableOpenAICompatibleChatModel extends StableOpenAICompatibleChatModel {
+  convertDelta(
+    delta: Record<string, unknown>,
+    rawResponse: OpenAIClient.ChatCompletionChunk,
+    defaultRole?: 'function' | 'user' | 'system' | 'developer' | 'assistant' | 'tool'
+  ) {
+    return this._convertCompletionsDeltaToBaseMessageChunk(delta, rawResponse, defaultRole)
+  }
+
+  convertMessage(message: OpenAIClient.ChatCompletionMessage, rawResponse: OpenAIClient.ChatCompletion) {
+    return this._convertCompletionsMessageToBaseMessage(message, rawResponse)
+  }
+}
 
 describe('getCustomizableModelSchemaFromCredentials', () => {
   let llm: OAIAPICompatLargeLanguageModel
@@ -11,6 +26,53 @@ describe('getCustomizableModelSchemaFromCredentials', () => {
   beforeEach(() => {
     provider = new OpenAICompatibleProviderStrategy()
     llm = new OAIAPICompatLargeLanguageModel(provider)
+  })
+
+  it('should replace placeholder chat completion ids for streaming chunks', () => {
+    const model = createTestChatModel()
+    const firstRoleChunk = model.convertDelta({ role: 'assistant' }, createChunk('chatcmpl', 1))
+    const firstToolChunk = model.convertDelta(
+      {
+        tool_calls: [
+          {
+            index: 0,
+            id: 'call-1',
+            type: 'function',
+            function: {
+              name: 'sandbox_shell',
+              arguments: '{}'
+            }
+          }
+        ]
+      },
+      createChunk('chatcmpl', 1),
+      'assistant'
+    )
+    const secondRoleChunk = model.convertDelta({ role: 'assistant' }, createChunk('chatcmpl', 2))
+
+    expect(firstRoleChunk.id).toMatch(/^chatcmpl-/)
+    expect(firstRoleChunk.id).not.toBe('chatcmpl')
+    expect(firstToolChunk.id).toBe(firstRoleChunk.id)
+    expect(secondRoleChunk.id).toMatch(/^chatcmpl-/)
+    expect(secondRoleChunk.id).not.toBe(firstRoleChunk.id)
+  })
+
+  it('should keep valid chat completion ids unchanged', () => {
+    const model = createTestChatModel()
+    const message = model.convertMessage(createAssistantMessage('call-1'), createCompletion('chatcmpl-valid-1'))
+
+    expect(message.id).toBe('chatcmpl-valid-1')
+  })
+
+  it('should replace placeholder chat completion ids for non-streaming messages', () => {
+    const model = createTestChatModel()
+    const firstMessage = model.convertMessage(createAssistantMessage('call-1'), createCompletion('chatcmpl'))
+    const secondMessage = model.convertMessage(createAssistantMessage('call-2'), createCompletion('chatcmpl'))
+
+    expect(firstMessage.id).toMatch(/^chatcmpl-/)
+    expect(firstMessage.id).not.toBe('chatcmpl')
+    expect(secondMessage.id).toMatch(/^chatcmpl-/)
+    expect(secondMessage.id).not.toBe(firstMessage.id)
   })
 
   it('should return correct schema for chat model with tool call support', () => {
@@ -331,3 +393,66 @@ describe('getCustomizableModelSchemaFromCredentials', () => {
     ).toThrow("Custom body param 'bad_param' must be a string, finite number, or boolean")
   })
 })
+
+function createTestChatModel() {
+  return new TestableStableOpenAICompatibleChatModel({
+    apiKey: 'test-key',
+    model: 'test-model',
+    configuration: {
+      baseURL: 'http://test.com'
+    }
+  })
+}
+
+function createChunk(id: string, created: number): OpenAIClient.ChatCompletionChunk {
+  return {
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: 'test-model',
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: null
+      }
+    ]
+  }
+}
+
+function createCompletion(id: string): OpenAIClient.ChatCompletion {
+  const message = createAssistantMessage('call-1')
+
+  return {
+    id,
+    object: 'chat.completion',
+    created: 1,
+    model: 'test-model',
+    choices: [
+      {
+        index: 0,
+        message,
+        finish_reason: 'tool_calls',
+        logprobs: null
+      }
+    ]
+  }
+}
+
+function createAssistantMessage(toolCallId: string): OpenAIClient.ChatCompletionMessage {
+  return {
+    role: 'assistant',
+    content: '',
+    refusal: null,
+    tool_calls: [
+      {
+        id: toolCallId,
+        type: 'function',
+        function: {
+          name: 'sandbox_shell',
+          arguments: '{}'
+        }
+      }
+    ]
+  }
+}

--- a/xpertai/models/openai-compatible/src/llm/llm.ts
+++ b/xpertai/models/openai-compatible/src/llm/llm.ts
@@ -1,4 +1,5 @@
-import { ChatOpenAIFields, ClientOptions } from '@langchain/openai'
+import { BaseMessage, BaseMessageChunk, isAIMessage, isAIMessageChunk } from '@langchain/core/messages'
+import { ChatOpenAIFields, ClientOptions, OpenAIClient } from '@langchain/openai'
 import {
   AIModelEntity,
   AiModelTypeEnum,
@@ -16,6 +17,7 @@ import {
   LargeLanguageModel,
   TChatModelOptions
 } from '@xpert-ai/plugin-sdk'
+import { randomUUID } from 'node:crypto'
 import { OpenAICompatModelCredentials, toCredentialKwargs } from '../types.js'
 import { OpenAICompatibleProviderStrategy } from '../provider.strategy.js'
 
@@ -23,6 +25,65 @@ export type TOAIAPICompatLLMParams = ChatOpenAIFields & { configuration: ClientO
 
 function toBoolean(value: unknown): boolean {
   return value === true || value === 'true' || value === 1 || value === '1'
+}
+
+export class StableOpenAICompatibleChatModel extends ChatOAICompatReasoningModel {
+  private activeStreamResponseId: string | null = null
+
+  protected override _convertCompletionsDeltaToBaseMessageChunk(
+    delta: Record<string, unknown>,
+    rawResponse: OpenAIClient.ChatCompletionChunk,
+    defaultRole?: 'function' | 'user' | 'system' | 'developer' | 'assistant' | 'tool'
+  ): BaseMessageChunk {
+    if (isPlaceholderChatCompletionId(rawResponse.id) && delta.role) {
+      this.activeStreamResponseId = this.createResponseMessageId(rawResponse.id)
+    }
+
+    const messageChunk = super._convertCompletionsDeltaToBaseMessageChunk(delta, rawResponse, defaultRole)
+    if (isAIMessageChunk(messageChunk)) {
+      messageChunk._updateId(this.getResponseMessageId(rawResponse.id))
+      if (this.isStreamFinished(rawResponse)) {
+        this.activeStreamResponseId = null
+      }
+    }
+
+    return messageChunk
+  }
+
+  protected override _convertCompletionsMessageToBaseMessage(
+    message: OpenAIClient.ChatCompletionMessage,
+    rawResponse: OpenAIClient.ChatCompletion
+  ): BaseMessage {
+    const langChainMessage = super._convertCompletionsMessageToBaseMessage(message, rawResponse)
+    if (isAIMessage(langChainMessage)) {
+      langChainMessage._updateId(
+        isPlaceholderChatCompletionId(rawResponse.id) ? this.createResponseMessageId(rawResponse.id) : rawResponse.id
+      )
+    }
+
+    return langChainMessage
+  }
+
+  private getResponseMessageId(responseId?: string | null) {
+    if (!isPlaceholderChatCompletionId(responseId)) {
+      return responseId
+    }
+
+    this.activeStreamResponseId ??= this.createResponseMessageId(responseId)
+    return this.activeStreamResponseId
+  }
+
+  private createResponseMessageId(responseId?: string | null) {
+    return `${responseId ?? 'chatcmpl'}-${randomUUID()}`
+  }
+
+  private isStreamFinished(rawResponse: OpenAIClient.ChatCompletionChunk) {
+    return rawResponse.choices.some((choice) => choice.finish_reason != null)
+  }
+}
+
+function isPlaceholderChatCompletionId(responseId?: string | null) {
+  return responseId === 'chatcmpl'
 }
 
 @Injectable()
@@ -55,7 +116,7 @@ export class OAIAPICompatLargeLanguageModel extends LargeLanguageModel {
     /**
      * @todo ChatOpenAICompletions vs ChatOpenAI
      */
-    return new ChatOAICompatReasoningModel(params)
+    return new StableOpenAICompatibleChatModel(params)
   }
 
   override getChatModel(


### PR DESCRIPTION
## Summary

- Normalize placeholder `chatcmpl` response IDs returned by OpenAI-compatible chat completion providers.
- Keep valid completion IDs unchanged while generating stable per-response IDs for placeholder IDs.
- Add regression coverage and a patch changeset for `@xpert-ai/plugin-openai-compatible`.

## Root Cause

Some OpenAI-compatible providers can return a fixed `rawResponse.id` value of `chatcmpl`. LangChain uses that value as the AI message ID, so repeated tool-call responses can overwrite earlier AI tool-call messages in LangGraph history.

## Validation

- `git diff --check`
- `pnpm exec nx build @xpert-ai/plugin-openai-compatible --skipNxCache`
- Node ESM behavior check against the built plugin verifying same-stream ID reuse, new response ID generation, valid ID preservation, and non-stream unique IDs.

## Notes

`pnpm exec nx test @xpert-ai/plugin-openai-compatible --skipNxCache` is currently blocked by duplicate Jest configs in the plugin directory (`jest.config.ts` and `jest.config.cjs`).