### PR TITLE
[codex] Support direct Lark docx source

### DIFF
--- a/xpertai/.changeset/lark-direct-docx-source.md
+++ b/xpertai/.changeset/lark-direct-docx-source.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-lark": patch
+---
+
+Support loading a single Lark docx document directly from a document ID, docx token, or docx URL in the document source strategy.

--- a/xpertai/integrations/lark/src/lib/source.strategy.spec.ts
+++ b/xpertai/integrations/lark/src/lib/source.strategy.spec.ts
@@ -1,0 +1,102 @@
+import type { IIntegration } from '@metad/contracts'
+import { LarkClient } from './lark.client.js'
+import { LarkSourceStrategy, normalizeLarkDocxToken } from './source.strategy.js'
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  DocumentSourceStrategy: () => () => undefined
+}))
+
+describe('LarkSourceStrategy', () => {
+  let strategy: LarkSourceStrategy
+
+  beforeEach(() => {
+    strategy = new LarkSourceStrategy()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it.each([
+    ['XBundSI8Tobjttxe2Qec1UYwnlc', 'XBundSI8Tobjttxe2Qec1UYwnlc'],
+    ['docx/XBundSI8Tobjttxe2Qec1UYwnlc', 'XBundSI8Tobjttxe2Qec1UYwnlc'],
+    ['https://my.feishu.cn/docx/XBundSI8Tobjttxe2Qec1UYwnlc?from=from_copylink', 'XBundSI8Tobjttxe2Qec1UYwnlc']
+  ])('normalizes docx token from %s', (input, expected) => {
+    expect(normalizeLarkDocxToken(input)).toBe(expected)
+  })
+
+  it('loads a single docx document from documentId without listing folder files', async () => {
+    const listDriveFiles = jest.spyOn(LarkClient.prototype, 'listDriveFiles')
+
+    const documents = await strategy.loadDocuments(
+      {
+        documentId: 'https://my.feishu.cn/docx/XBundSI8Tobjttxe2Qec1UYwnlc?from=from_copylink',
+        types: ['docx']
+      },
+      { integration: createIntegration() }
+    )
+
+    expect(listDriveFiles).not.toHaveBeenCalled()
+    expect(documents).toHaveLength(1)
+    expect(documents[0].id).toBe('XBundSI8Tobjttxe2Qec1UYwnlc')
+    expect(documents[0].metadata).toEqual(
+      expect.objectContaining({
+        token: 'XBundSI8Tobjttxe2Qec1UYwnlc',
+        type: 'docx',
+        chunkId: 'XBundSI8Tobjttxe2Qec1UYwnlc',
+        title: 'Lark Document XBundSI8Tobjttxe2Qec1UYwnlc'
+      })
+    )
+  })
+
+  it('keeps folder loading behavior and filters by configured document types', async () => {
+    const listDriveFiles = jest.spyOn(LarkClient.prototype, 'listDriveFiles').mockResolvedValue([
+      {
+        token: 'docx-token',
+        name: 'Docx file',
+        type: 'docx',
+        url: 'https://my.feishu.cn/docx/docx-token',
+        created_time: '1710000000'
+      },
+      {
+        token: 'sheet-token',
+        name: 'Sheet file',
+        type: 'sheet'
+      }
+    ])
+
+    const documents = await strategy.loadDocuments(
+      {
+        folderToken: 'folder-token',
+        types: ['docx']
+      },
+      { integration: createIntegration() }
+    )
+
+    expect(listDriveFiles).toHaveBeenCalledWith('folder-token')
+    expect(documents).toHaveLength(1)
+    expect(documents[0].id).toBe('docx-token')
+    expect(documents[0].metadata).toEqual(
+      expect.objectContaining({
+        token: 'docx-token',
+        title: 'Docx file',
+        url: 'https://my.feishu.cn/docx/docx-token',
+        createdAt: '1710000000'
+      })
+    )
+  })
+
+  it('requires either documentId or folderToken', async () => {
+    await expect(strategy.validateConfig({})).rejects.toThrow('Document ID or Folder Token is required')
+  })
+})
+
+function createIntegration(): IIntegration {
+  return {
+    options: {
+      appId: 'app-id',
+      appSecret: 'app-secret',
+      isLark: false
+    }
+  } as IIntegration
+}

--- a/xpertai/integrations/lark/src/lib/source.strategy.ts
+++ b/xpertai/integrations/lark/src/lib/source.strategy.ts
@@ -1,10 +1,27 @@
 import type { I18nObject, IDocumentSourceProvider, IIntegration } from '@metad/contracts'
 import { Injectable } from '@nestjs/common'
-import { DocumentSourceStrategy, IDocumentSourceStrategy, IntegrationPermission } from '@xpert-ai/plugin-sdk'
+import { DocumentSourceStrategy } from '@xpert-ai/plugin-sdk'
+import type { IDocumentSourceStrategy, IntegrationPermission } from '@xpert-ai/plugin-sdk'
 import { Document } from '@langchain/core/documents'
 import { DocumentSourceProviderCategoryEnum } from './contracts-compat.js'
 import { LarkClient } from './lark.client.js'
-import { iconImage, LarkDocumentsParams, LarkName } from './types.js'
+import { iconImage, LarkName } from './types.js'
+import type { LarkDocumentsParams, LarkFile } from './types.js'
+
+export function normalizeLarkDocxToken(value?: string): string | undefined {
+  const trimmed = value?.trim()
+  if (!trimmed) {
+    return undefined
+  }
+
+  const withoutQuery = trimmed.split(/[?#]/)[0]
+  const docxMatch = withoutQuery.match(/(?:^|\/)docx\/([^/]+)/)
+  if (docxMatch?.[1]) {
+    return docxMatch[1]
+  }
+
+  return withoutQuery
+}
 
 @DocumentSourceStrategy(LarkName)
 @Injectable()
@@ -38,6 +55,17 @@ export class LarkSourceStrategy implements IDocumentSourceStrategy<LarkDocuments
             zh_Hans: '从中获取文档的文件夹 Token。'
           } as I18nObject
         },
+        documentId: {
+          type: 'string',
+          title: {
+            en_US: 'Document ID / Docx Token',
+            zh_Hans: '文档 ID / Docx Token'
+          } as I18nObject,
+          description: {
+            en_US: 'A single Lark document ID, docx token, docx/<token>, or full docx URL.',
+            zh_Hans: '单个飞书文档 ID、Docx Token、docx/<token> 或完整 docx 链接。'
+          } as I18nObject
+        },
         /**
          * 文件类型。可选值有：
           doc：旧版文档
@@ -68,7 +96,7 @@ export class LarkSourceStrategy implements IDocumentSourceStrategy<LarkDocuments
           minItems: 0
         }
       },
-      required: ['folderToken']
+      required: []
     },
     icon: {
       type: 'image',
@@ -78,8 +106,8 @@ export class LarkSourceStrategy implements IDocumentSourceStrategy<LarkDocuments
   }
 
   async validateConfig(config: LarkDocumentsParams): Promise<void> {
-    if (!config.folderToken) {
-      throw new Error('Folder Token is required')
+    if (!normalizeLarkDocxToken(config.documentId) && !config.folderToken?.trim()) {
+      throw new Error('Document ID or Folder Token is required')
     }
   }
 
@@ -95,26 +123,42 @@ export class LarkSourceStrategy implements IDocumentSourceStrategy<LarkDocuments
 
     await this.validateConfig(config)
 
+    const documentId = normalizeLarkDocxToken(config.documentId)
+    if (documentId) {
+      return [this.createDocument({
+        token: documentId,
+        name: `Lark Document ${documentId}`,
+        type: 'docx'
+      })]
+    }
+
+    const folderToken = config.folderToken?.trim()
+    if (!folderToken) {
+      throw new Error('Folder Token is required')
+    }
+
     const client = new LarkClient(integration)
-    const children = await client.listDriveFiles(config.folderToken)
+    const children = await client.listDriveFiles(folderToken)
 
     const documents: Document[] = children
       .filter((item) => config.types ? config.types.includes(item.type) : true)
-      .map((item) => {
-        return new Document({
-          id: item.token,
-          pageContent: `${item.name}\n${item.url}`,
-          metadata: {
-            ...item,
-            chunkId: item.token,
-            title: item.name,
-            url: item.url,
-            createdAt: item.created_time
-          }
-        })
-      })
+      .map((item) => this.createDocument(item))
 
     return documents
+  }
+
+  private createDocument(item: LarkFile): Document {
+    return new Document({
+      id: item.token,
+      pageContent: `${item.name}\n${item.url ?? ''}`,
+      metadata: {
+        ...item,
+        chunkId: item.token,
+        title: item.name,
+        url: item.url,
+        createdAt: item.created_time
+      }
+    })
   }
 
   async loadDocument?(document: Document, context: { integration?: IIntegration }): Promise<Document> {

--- a/xpertai/integrations/lark/src/lib/types.ts
+++ b/xpertai/integrations/lark/src/lib/types.ts
@@ -1,5 +1,5 @@
 import type { ITenant, TChatConversationStatus } from '@metad/contracts'
-import { TDocumentAsset } from '@xpert-ai/plugin-sdk'
+import type { TDocumentAsset } from '@xpert-ai/plugin-sdk'
 import { AxiosError } from 'axios'
 
 export const INTEGRATION_LARK = 'lark'
@@ -19,8 +19,9 @@ export type TLarkIntegrationConfig = {
 }
 
 export type LarkDocumentsParams = {
-  folderToken: string
-  types: string[]
+  folderToken?: string
+  documentId?: string
+  types?: string[]
 }
 
 export type LarkDocumentMetadata = LarkFile & {


### PR DESCRIPTION
## Summary

Adds direct single-document input support to the Lark document source strategy. The source can now accept a raw document ID, a `docx/<token>` value, or a full Feishu/Lark docx URL, while preserving the existing folder-token ingestion path.

## Root Cause

The previous Lark source schema required `folderToken` and always called the drive folder listing API. That made single Feishu document imports fail when users only had a docx document token or URL and did not want to place the document in a folder first.

## Changes

- Add optional `documentId` source configuration.
- Normalize direct docx inputs from token, `docx/<token>`, or full docx URL forms.
- Use direct document mode when `documentId` is present; otherwise keep the existing `folderToken` listing behavior.
- Update `LarkDocumentsParams` to reflect the two supported input modes.
- Add focused tests for token normalization, direct document loading, folder compatibility, and missing config validation.
- Add a patch changeset for `@xpert-ai/plugin-lark`.

## Validation

- `git diff --check`
- `pnpm -C xpertai exec nx test @xpert-ai/plugin-lark --runTestsByPath src/lib/source.strategy.spec.ts`
- `pnpm -C xpertai exec nx build @xpert-ai/plugin-lark --skipSync`

Note: plain `nx build` without `--skipSync` is blocked by an existing workspace sync issue where `tsconfig.json` is missing an `apps/office-editor/tsconfig.json` reference. That is unrelated to this PR.