### PR TITLE
[codex] Sync SiliconFlow model metadata

### DIFF
--- a/xpertai/.changeset/lark-docx-image-assets.md
+++ b/xpertai/.changeset/lark-docx-image-assets.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-lark": patch
+---
+
+Download docx image blocks into document assets during Lark document processing.

--- a/xpertai/.changeset/siliconflow-dify-model-refresh.md
+++ b/xpertai/.changeset/siliconflow-dify-model-refresh.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-siliconflow": patch
+---
+
+Sync SiliconFlow LLM metadata with the latest Dify model list.

--- a/xpertai/integrations/lark/src/lib/lark.client.image.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark.client.image.spec.ts
@@ -1,0 +1,171 @@
+import { Readable } from 'node:stream'
+import type { IIntegration } from '@metad/contracts'
+import type { XpFileSystem } from '@xpert-ai/plugin-sdk'
+import { LarkClient } from './lark.client.js'
+import type { TLarkIntegrationConfig } from './types.js'
+
+type LarkClientWithImages = LarkClient & {
+  getDocumentImages: (
+    docToken: string,
+    fileSystem?: XpFileSystem,
+    baseFolder?: string
+  ) => Promise<
+    Array<{
+      type: 'image'
+      url: string
+      filePath: string
+      token: string
+      caption?: string
+      width?: number
+      height?: number
+    }>
+  >
+}
+
+describe('LarkClient document images', () => {
+  it('downloads docx image blocks into the provided file system', async () => {
+    const client = new LarkClient(createIntegration()) as LarkClientWithImages
+    const sdkClient = {
+      docx: {
+        documentBlock: {
+          list: jest.fn().mockResolvedValue({
+            code: 0,
+            data: {
+              items: [
+                {
+                  block_id: 'block-image',
+                  image: {
+                    token: 'img-token',
+                    width: 640,
+                    height: 480,
+                    caption: {
+                      content: '报错截图'
+                    }
+                  }
+                }
+              ],
+              has_more: false
+            }
+          })
+        }
+      },
+      drive: {
+        media: {
+          batchGetTmpDownloadUrl: jest.fn().mockResolvedValue({
+            code: 0,
+            data: {
+              tmp_download_urls: [
+                {
+                  file_token: 'img-token',
+                  tmp_download_url: 'https://tmp.example/img-token'
+                }
+              ]
+            }
+          }),
+          download: jest.fn().mockResolvedValue({
+            getReadableStream: () => Readable.from([new Uint8Array(Buffer.from('image-bytes'))]),
+            headers: {
+              'content-type': 'image/png'
+            }
+          })
+        }
+      }
+    }
+    Reflect.set(client, 'client', sdkClient)
+
+    const fileSystem = {
+      writeFile: jest.fn().mockResolvedValue('http://localhost/files/kb/doc-1/images/img-token.png')
+    } as unknown as XpFileSystem
+
+    const images = await client.getDocumentImages('doc-token', fileSystem, 'kb/doc-1')
+
+    expect(sdkClient.docx.documentBlock.list).toHaveBeenCalledWith({
+      path: { document_id: 'doc-token' },
+      params: { page_size: 500 }
+    })
+    expect(sdkClient.drive.media.batchGetTmpDownloadUrl).not.toHaveBeenCalled()
+    expect(sdkClient.drive.media.download).toHaveBeenCalledWith({
+      path: { file_token: 'img-token' }
+    })
+    expect(fileSystem.writeFile).toHaveBeenCalledWith('kb/doc-1/images/img-token.png', Buffer.from('image-bytes'))
+    expect(images).toEqual([
+      {
+        type: 'image',
+        url: 'http://localhost/files/kb/doc-1/images/img-token.png',
+        filePath: 'kb/doc-1/images/img-token.png',
+        token: 'img-token',
+        sourceUrl: undefined,
+        blockId: 'block-image',
+        caption: '报错截图',
+        width: 640,
+        height: 480,
+        mimeType: 'image/png'
+      }
+    ])
+  })
+
+  it('uses temporary media URLs when no file system is provided', async () => {
+    const client = new LarkClient(createIntegration()) as LarkClientWithImages
+    const sdkClient = {
+      docx: {
+        documentBlock: {
+          list: jest.fn().mockResolvedValue({
+            code: 0,
+            data: {
+              items: [
+                {
+                  block_id: 'block-image',
+                  image: {
+                    token: 'img-token'
+                  }
+                }
+              ],
+              has_more: false
+            }
+          })
+        }
+      },
+      drive: {
+        media: {
+          batchGetTmpDownloadUrl: jest.fn().mockResolvedValue({
+            code: 0,
+            data: {
+              tmp_download_urls: [
+                {
+                  file_token: 'img-token',
+                  tmp_download_url: 'https://tmp.example/img-token'
+                }
+              ]
+            }
+          }),
+          download: jest.fn()
+        }
+      }
+    }
+    Reflect.set(client, 'client', sdkClient)
+
+    const images = await client.getDocumentImages('doc-token')
+
+    expect(sdkClient.drive.media.batchGetTmpDownloadUrl).toHaveBeenCalledWith({
+      params: { file_tokens: ['img-token'] }
+    })
+    expect(sdkClient.drive.media.download).not.toHaveBeenCalled()
+    expect(images).toEqual([
+      expect.objectContaining({
+        url: 'https://tmp.example/img-token',
+        filePath: 'https://tmp.example/img-token',
+        sourceUrl: 'https://tmp.example/img-token'
+      })
+    ])
+  })
+})
+
+function createIntegration(): IIntegration<TLarkIntegrationConfig> {
+  return {
+    options: {
+      appId: 'app-id',
+      appSecret: 'app-secret',
+      isLark: false
+    }
+  } as IIntegration<TLarkIntegrationConfig>
+}

--- a/xpertai/integrations/lark/src/lib/lark.client.ts
+++ b/xpertai/integrations/lark/src/lib/lark.client.ts
@@ -1,6 +1,43 @@
 import * as lark from '@larksuiteoapi/node-sdk'
 import type { IIntegration } from '@metad/contracts'
+import type { TDocumentAsset, XpFileSystem } from '@xpert-ai/plugin-sdk'
+import path from 'node:path'
 import { formatLarkErrorToMarkdown, LarkFile, parseLarkClientError } from './types.js'
+
+export type LarkDocumentImageAsset = TDocumentAsset & {
+  token: string
+  sourceUrl?: string
+  blockId?: string
+  caption?: string
+  width?: number
+  height?: number
+  mimeType?: string
+}
+
+type LarkDocumentBlock = {
+  block_id?: string
+  image?: {
+    token?: string
+    width?: number
+    height?: number
+    caption?: {
+      content?: string
+    }
+  }
+}
+
+type LarkTmpDownloadUrl = {
+  file_token: string
+  tmp_download_url: string
+}
+
+type LarkDocumentImageBlock = {
+  token: string
+  blockId?: string
+  caption?: string
+  width?: number
+  height?: number
+}
 
 /**
  * Common Lark Methods
@@ -88,6 +125,124 @@ export class LarkClient {
     }
   }
 
+  async getDocumentImages(
+    docToken: string,
+    fileSystem?: XpFileSystem,
+    baseFolder?: string
+  ): Promise<LarkDocumentImageAsset[]> {
+    try {
+      const imageBlocks = (await this.listDocumentBlocks(docToken))
+        .map((block): LarkDocumentImageBlock | null => ({
+          blockId: block.block_id,
+          token: block.image?.token ?? '',
+          width: block.image?.width,
+          height: block.image?.height,
+          caption: block.image?.caption?.content
+        }))
+        .filter((image): image is LarkDocumentImageBlock => !!image && image.token.trim().length > 0)
+
+      if (!imageBlocks.length) {
+        return []
+      }
+
+      const sourceUrls = fileSystem
+        ? new Map<string, string>()
+        : await this.getMediaTmpDownloadUrls(imageBlocks.map((image) => image.token))
+      const assets: LarkDocumentImageAsset[] = []
+      for (const image of imageBlocks) {
+        const downloaded = fileSystem
+          ? await this.downloadMediaToFileSystem(image.token, fileSystem, baseFolder ?? path.posix.join('lark', docToken))
+          : null
+        const sourceUrl = sourceUrls.get(image.token)
+        const fallbackPath = sourceUrl ?? image.token
+        assets.push({
+          type: 'image',
+          url: downloaded?.url ?? fallbackPath,
+          filePath: downloaded?.filePath ?? fallbackPath,
+          token: image.token,
+          sourceUrl,
+          blockId: image.blockId,
+          caption: image.caption,
+          width: image.width,
+          height: image.height,
+          mimeType: downloaded?.mimeType
+        })
+      }
+
+      return assets
+    } catch (error: unknown) {
+      throw formatLarkErrorToMarkdown(parseLarkClientError(error))
+    }
+  }
+
+  private async listDocumentBlocks(docToken: string): Promise<LarkDocumentBlock[]> {
+    const blocks: LarkDocumentBlock[] = []
+    let pageToken: string | undefined
+    let hasMore = false
+    do {
+      const params: { page_size: number; page_token?: string } = { page_size: 500 }
+      if (pageToken) {
+        params.page_token = pageToken
+      }
+      const res = await this.client.docx.documentBlock.list({
+        path: {
+          document_id: docToken
+        },
+        params
+      })
+
+      if (res.code !== 0) {
+        throw new Error(`Get document blocks failed: ${res.msg}`)
+      }
+
+      blocks.push(...((res.data?.items ?? []) as LarkDocumentBlock[]))
+      hasMore = Boolean(res.data?.has_more)
+      pageToken = res.data?.page_token
+    } while (hasMore && pageToken)
+
+    return blocks
+  }
+
+  private async getMediaTmpDownloadUrls(fileTokens: string[]): Promise<Map<string, string>> {
+    const res = await this.client.drive.media.batchGetTmpDownloadUrl({
+      params: {
+        file_tokens: fileTokens
+      }
+    })
+
+    if (res.code !== 0) {
+      throw new Error(`Get media download URLs failed: ${res.msg}`)
+    }
+
+    return new Map(
+      ((res.data?.tmp_download_urls ?? []) as LarkTmpDownloadUrl[]).map((item) => [
+        item.file_token,
+        item.tmp_download_url
+      ])
+    )
+  }
+
+  private async downloadMediaToFileSystem(
+    fileToken: string,
+    fileSystem: XpFileSystem,
+    baseFolder: string
+  ): Promise<{ url: string; filePath: string; mimeType?: string }> {
+    const media = await this.client.drive.media.download({
+      path: {
+        file_token: fileToken
+      }
+    })
+    const mimeType = getHeaderValue(media.headers, 'content-type')
+    const filePath = path.posix.join(baseFolder, 'images', `${safeFileNameSegment(fileToken)}.${imageExtension(mimeType)}`)
+    const url = await fileSystem.writeFile(filePath, await readableToBuffer(media.getReadableStream()))
+
+    return {
+      url,
+      filePath,
+      mimeType
+    }
+  }
+
   /**
    * Recursively retrieve all documents in a folder
    */
@@ -107,4 +262,64 @@ export class LarkClient {
 
     return result
   }
+}
+
+async function readableToBuffer(stream: AsyncIterable<unknown>): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) {
+    if (Buffer.isBuffer(chunk)) {
+      chunks.push(chunk)
+    } else if (typeof chunk === 'string') {
+      chunks.push(Buffer.from(chunk))
+    } else if (ArrayBuffer.isView(chunk)) {
+      chunks.push(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength))
+    } else {
+      chunks.push(Buffer.from(String(chunk)))
+    }
+  }
+  return Buffer.concat(chunks)
+}
+
+function getHeaderValue(headers: unknown, key: string): string | undefined {
+  if (!headers || typeof headers !== 'object') {
+    return undefined
+  }
+
+  const lowerKey = key.toLowerCase()
+  const value =
+    Reflect.get(headers, key) ??
+    Reflect.get(headers, lowerKey) ??
+    Reflect.ownKeys(headers).reduce<unknown>((match, headerKey) => {
+      if (match !== undefined || typeof headerKey !== 'string' || headerKey.toLowerCase() !== lowerKey) {
+        return match
+      }
+      return Reflect.get(headers, headerKey)
+    }, undefined)
+  if (typeof value === 'string') {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.find((item) => typeof item === 'string')
+  }
+  return undefined
+}
+
+function imageExtension(mimeType: string | undefined) {
+  switch (mimeType?.split(';')[0]?.trim().toLowerCase()) {
+    case 'image/jpeg':
+      return 'jpg'
+    case 'image/gif':
+      return 'gif'
+    case 'image/webp':
+      return 'webp'
+    case 'image/svg+xml':
+      return 'svg'
+    case 'image/png':
+    default:
+      return 'png'
+  }
+}
+
+function safeFileNameSegment(value: string) {
+  return value.replace(/[^a-zA-Z0-9._-]+/g, '_') || 'image'
 }

--- a/xpertai/integrations/lark/src/lib/transformer.strategy.spec.ts
+++ b/xpertai/integrations/lark/src/lib/transformer.strategy.spec.ts
@@ -1,0 +1,138 @@
+import type { IIntegration, IKnowledgeDocument } from '@metad/contracts'
+import type { TDocumentTransformerConfig } from '@xpert-ai/plugin-sdk'
+import { LarkClient } from './lark.client.js'
+import { LarkDocTransformerStrategy } from './transformer.strategy.js'
+import type { LarkDocumentMetadata, TLarkIntegrationConfig } from './types.js'
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  DocumentTransformerStrategy: () => () => undefined
+}))
+
+type FileSystemPermissionStub = NonNullable<TDocumentTransformerConfig['permissions']>['fileSystem']
+
+describe('LarkDocTransformerStrategy', () => {
+  let strategy: LarkDocTransformerStrategy
+
+  beforeEach(() => {
+    strategy = new LarkDocTransformerStrategy()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    Reflect.deleteProperty(LarkClient.prototype, 'getDocumentImages')
+  })
+
+  it('replaces docx image placeholders with downloaded images in order', async () => {
+    const fileSystem = {
+      writeFile: jest.fn()
+    } as unknown as FileSystemPermissionStub
+    const imageAssets = [
+      {
+        type: 'image' as const,
+        url: 'http://localhost/files/kb/doc-1/images/img-token-1.png',
+        filePath: 'kb/doc-1/images/img-token-1.png',
+        token: 'img-token-1',
+        caption: '报错截图'
+      },
+      {
+        type: 'image' as const,
+        url: 'http://localhost/files/kb/doc-1/images/img-token-2.png',
+        filePath: 'kb/doc-1/images/img-token-2.png',
+        token: 'img-token-2',
+        caption: '处理结果'
+      },
+      {
+        type: 'image' as const,
+        url: 'http://localhost/files/kb/doc-1/images/img-token-3.png',
+        filePath: 'kb/doc-1/images/img-token-3.png',
+        token: 'img-token-3'
+      }
+    ]
+    const getDocumentImages = jest.fn().mockResolvedValue(imageAssets)
+
+    Object.defineProperty(LarkClient.prototype, 'getDocumentImages', {
+      configurable: true,
+      value: getDocumentImages
+    })
+    jest.spyOn(LarkClient.prototype, 'getDocumentContent').mockResolvedValue(
+      '报错界面\nimage.png\n报错原因\nimage.png\n处理方案'
+    )
+
+    const [result] = await strategy.transformDocuments(
+      [
+        {
+          id: 'doc-1',
+          folder: 'kb/doc-1',
+          metadata: {
+            token: 'doc-token'
+          }
+        } as Partial<IKnowledgeDocument<LarkDocumentMetadata>>
+      ],
+      {
+        stage: 'prod',
+        permissions: {
+          integration: createIntegration(),
+          fileSystem
+        }
+      }
+    )
+
+    expect(getDocumentImages).toHaveBeenCalledWith('doc-token', fileSystem, 'kb/doc-1')
+    expect(result.chunks?.[0].pageContent).toBe(
+      [
+        '报错界面',
+        '![报错截图](http://localhost/files/kb/doc-1/images/img-token-1.png)',
+        '报错原因',
+        '![处理结果](http://localhost/files/kb/doc-1/images/img-token-2.png)',
+        '处理方案',
+        '![image](http://localhost/files/kb/doc-1/images/img-token-3.png)'
+      ].join('\n')
+    )
+    expect(result.metadata?.assets).toEqual(imageAssets)
+    expect(result.chunks?.[0].metadata.assets).toEqual(imageAssets)
+  })
+
+  it('keeps text content when docx image extraction fails', async () => {
+    const getDocumentImages = jest.fn().mockRejectedValue('### Lark API Error: params error')
+
+    Object.defineProperty(LarkClient.prototype, 'getDocumentImages', {
+      configurable: true,
+      value: getDocumentImages
+    })
+    jest.spyOn(LarkClient.prototype, 'getDocumentContent').mockResolvedValue('报错界面\n报错原因')
+
+    const [result] = await strategy.transformDocuments(
+      [
+        {
+          id: 'doc-1',
+          folder: 'kb/doc-1',
+          metadata: {
+            token: 'doc-token'
+          }
+        } as Partial<IKnowledgeDocument<LarkDocumentMetadata>>
+      ],
+      {
+        stage: 'prod',
+        permissions: {
+          integration: createIntegration()
+        }
+      }
+    )
+
+    expect(getDocumentImages).toHaveBeenCalledWith('doc-token', undefined, 'kb/doc-1')
+    expect(result.chunks?.[0].pageContent).toBe('报错界面\n报错原因')
+    expect(result.metadata?.assets).toEqual([])
+    expect(result.metadata?.imageAssetError).toContain('params error')
+    expect(result.chunks?.[0].metadata.imageAssetError).toContain('params error')
+  })
+})
+
+function createIntegration(): IIntegration<TLarkIntegrationConfig> {
+  return {
+    options: {
+      appId: 'app-id',
+      appSecret: 'app-secret',
+      isLark: false
+    }
+  } as IIntegration<TLarkIntegrationConfig>
+}

--- a/xpertai/integrations/lark/src/lib/transformer.strategy.ts
+++ b/xpertai/integrations/lark/src/lib/transformer.strategy.ts
@@ -3,6 +3,7 @@ import { Document } from '@langchain/core/documents'
 import {
   ChunkMetadata,
   DocumentTransformerStrategy,
+  FileSystemPermission,
   IDocumentTransformerStrategy,
   IntegrationPermission,
   TDocumentTransformerConfig,
@@ -21,6 +22,11 @@ export class LarkDocTransformerStrategy implements IDocumentTransformerStrategy<
       service: LarkName,
       description: 'Access to Lark system integrations'
     } as IntegrationPermission,
+    {
+      type: 'filesystem',
+      operations: ['write'],
+      scope: []
+    } as FileSystemPermission
   ]
 
   readonly meta = {
@@ -64,14 +70,25 @@ export class LarkDocTransformerStrategy implements IDocumentTransformerStrategy<
     
     const results: Partial<IKnowledgeDocument<ChunkMetadata>>[] = []
     for await (const file of files) {
-      const content = await client.getDocumentContent(file.metadata?.token || '')
+      const docToken = file.metadata?.token || file.id || ''
+      const content = await client.getDocumentContent(docToken)
+      let assets: ChunkMetadata['assets'] = []
+      let imageAssetError: string | undefined
+      try {
+        assets = await client.getDocumentImages(docToken, config.permissions?.fileSystem, file.folder)
+      } catch (error: unknown) {
+        imageAssetError = toErrorMessage(error)
+      }
+      const pageContent = placeImageReferences(content, assets)
       results.push({
         id: file.id,
         chunks: [
           new Document({
             id: file.id,
-            pageContent: content,
+            pageContent,
             metadata: {
+              assets,
+              imageAssetError,
               chunkId: file.id,
               source: LarkName,
               sourceId: file.id,
@@ -80,10 +97,56 @@ export class LarkDocTransformerStrategy implements IDocumentTransformerStrategy<
           })
         ],
         metadata: {
+          ...(file.metadata ?? {}),
+          assets,
+          imageAssetError,
           type: 'parent' as const
         } as ChunkMetadata
       })
     }
     return results
+  }
+}
+
+const standaloneImagePlaceholderPattern = /(^|\r?\n)[^\S\r\n]*[^/\s\\]+\.(?:png|jpe?g|gif|webp|bmp)[^\S\r\n]*(?=\r?\n|$)/gi
+
+function placeImageReferences(content: string, assets: ChunkMetadata['assets'] = []) {
+  if (!assets.length) {
+    return content
+  }
+
+  const imageReferences = assets.map((asset) => {
+    const caption = Reflect.get(asset, 'caption')
+    return `![${typeof caption === 'string' ? caption : 'image'}](${asset.url})`
+  })
+  let imageIndex = 0
+  const contentWithInlineImages = content.replace(standaloneImagePlaceholderPattern, (match, lineStart: string) => {
+    if (imageIndex >= imageReferences.length) {
+      return match
+    }
+    const reference = imageReferences[imageIndex]
+    imageIndex += 1
+    return `${lineStart}${reference}`
+  })
+  const remainingReferences = imageReferences.slice(imageIndex)
+
+  if (!remainingReferences.length) {
+    return contentWithInlineImages
+  }
+
+  return [contentWithInlineImages, ...remainingReferences].join('\n')
+}
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
   }
 }

--- a/xpertai/models/siliconflow/src/llm/_position.yaml
+++ b/xpertai/models/siliconflow/src/llm/_position.yaml
@@ -1,4 +1,5 @@
 - Pro/moonshotai/Kimi-K2.5
+- Pro/moonshotai/Kimi-K2.6
 - moonshotai/Kimi-K2-Thinking
 - Pro/moonshotai/Kimi-K2-Thinking
 - Pro/moonshotai/Kimi-K2-Instruct
@@ -11,6 +12,8 @@
 - Pro/deepseek-ai/DeepSeek-V3.1
 - Pro/deepseek-ai/DeepSeek-V3.1-Terminus
 - Pro/deepseek-ai/DeepSeek-V3.2
+- deepseek-ai/DeepSeek-V4-Pro
+- deepseek-ai/DeepSeek-V4-Flash
 - deepseek-ai/DeepSeek-V3.2
 - deepseek-ai/DeepSeek-OCR
 - deepseek-ai/DeepSeek-R1
@@ -22,6 +25,8 @@
 - deepseek-ai/DeepSeek-R1-Distill-Qwen-7B
 - deepseek-ai/DeepSeek-R1-Distill-Llama-70B
 - deepseek-ai/DeepSeek-R1-Distill-Llama-8B
+- Qwen/Qwen3.6-27B
+- Qwen/Qwen3.6-35B-A3B
 - Qwen/Qwen3.5-397B-A17B
 - Qwen/Qwen3.5-122B-A10B
 - Qwen/Qwen3.5-35B-A3B
@@ -56,3 +61,5 @@
 - zai-org/GLM-4.6V
 - Pro/zai-org/GLM-4.7
 - Pro/zai-org/GLM-5
+- Pro/zai-org/GLM-5.1
+- stepfun-ai/Step-3.5-Flash

--- a/xpertai/models/siliconflow/src/llm/deepseek-v4-flash.yaml
+++ b/xpertai/models/siliconflow/src/llm/deepseek-v4-flash.yaml
@@ -1,21 +1,24 @@
-model: Qwen/Qwen2.5-14B-Instruct
+model: deepseek-ai/DeepSeek-V4-Flash
 label:
-  en_US: Qwen/Qwen2.5-14B-Instruct
+  en_US: deepseek-ai/DeepSeek-V4-Flash
+  zh_Hans: deepseek-ai/DeepSeek-V4-Flash
 model_type: llm
 features:
   - agent-thought
+  - tool-call
+  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 32768
+  context_size: 1048576
 parameter_rules:
   - name: temperature
     use_template: temperature
   - name: max_tokens
     use_template: max_tokens
     type: int
-    default: 512
+    default: 32768
     min: 1
-    max: 8192
+    max: 393216
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -44,9 +47,18 @@ parameter_rules:
     options:
       - text
       - json_object
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
 pricing:
-  input: '0.7'
-  output: '0.7'
-  unit: '0.000001'
+  input: "1"
+  output: "2"
+  unit: "0.000001"
   currency: RMB
-deprecated: true

--- a/xpertai/models/siliconflow/src/llm/deepseek-v4-pro.yaml
+++ b/xpertai/models/siliconflow/src/llm/deepseek-v4-pro.yaml
@@ -1,21 +1,24 @@
-model: Qwen/Qwen2.5-14B-Instruct
+model: deepseek-ai/DeepSeek-V4-Pro
 label:
-  en_US: Qwen/Qwen2.5-14B-Instruct
+  en_US: deepseek-ai/DeepSeek-V4-Pro
+  zh_Hans: deepseek-ai/DeepSeek-V4-Pro
 model_type: llm
 features:
   - agent-thought
+  - tool-call
+  - stream-tool-call
 model_properties:
   mode: chat
-  context_size: 32768
+  context_size: 1048576
 parameter_rules:
   - name: temperature
     use_template: temperature
   - name: max_tokens
     use_template: max_tokens
     type: int
-    default: 512
+    default: 32768
     min: 1
-    max: 8192
+    max: 393216
     help:
       zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
       en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
@@ -44,9 +47,18 @@ parameter_rules:
     options:
       - text
       - json_object
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
 pricing:
-  input: '0.7'
-  output: '0.7'
-  unit: '0.000001'
+  input: "3"
+  output: "6"
+  unit: "0.000001"
   currency: RMB
-deprecated: true

--- a/xpertai/models/siliconflow/src/llm/glm-41v-9b-thinking.yaml
+++ b/xpertai/models/siliconflow/src/llm/glm-41v-9b-thinking.yaml
@@ -52,3 +52,4 @@ pricing:
   output: '0'
   unit: '0'
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/glm46.yaml
+++ b/xpertai/models/siliconflow/src/llm/glm46.yaml
@@ -74,3 +74,4 @@ pricing:
   output: '14'
   unit: '0.000001'
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/glm51-pro.yaml
+++ b/xpertai/models/siliconflow/src/llm/glm51-pro.yaml
@@ -1,41 +1,17 @@
-model: zai-org/GLM-4.6V
+model: Pro/zai-org/GLM-5.1
 label:
-  zh_Hans: zai-org/GLM-4.6V
-  en_US: zai-org/GLM-4.6V
+  zh_Hans: Pro/zai-org/GLM-5.1
+  en_US: Pro/zai-org/GLM-5.1
 model_type: llm
 features:
+  - tool-call
   - agent-thought
   - multi-tool-call
   - stream-tool-call
-  - vision
 model_properties:
   mode: chat
-  context_size: 128000
+  context_size: 204800
 parameter_rules:
-  - name: temperature
-    use_template: temperature
-  - name: max_tokens
-    use_template: max_tokens
-    type: int
-    default: 16384
-    min: 1
-    max: 32768
-    help:
-      zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
-      en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
-  - name: top_p
-    use_template: top_p
-  - name: top_k
-    label:
-      zh_Hans: 取样数量
-      en_US: Top k
-    type: int
-    help:
-      zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
-      en_US: Only sample from the top K options for each subsequent token.
-    required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
   - name: response_format
     label:
       zh_Hans: 回复格式
@@ -61,9 +37,9 @@ parameter_rules:
   - name: thinking_budget
     required: false
     type: int
-    default: 512
+    default: 4096
     min: 1
-    max: 8192
+    max: 204800
     label:
       zh_Hans: 思考长度限制
       en_US: Thinking budget
@@ -71,8 +47,7 @@ parameter_rules:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
 pricing:
-  input: '1'
-  output: '3'
-  unit: '0.000001'
+  input: "6"
+  output: "24"
+  unit: "0.000001"
   currency: RMB
-deprecated: true

--- a/xpertai/models/siliconflow/src/llm/kimi-k2-instruct-pro.yaml
+++ b/xpertai/models/siliconflow/src/llm/kimi-k2-instruct-pro.yaml
@@ -33,3 +33,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/kimi-k2-instruct.yaml
+++ b/xpertai/models/siliconflow/src/llm/kimi-k2-instruct.yaml
@@ -33,3 +33,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/kimi-k2-thinking-pro.yaml
+++ b/xpertai/models/siliconflow/src/llm/kimi-k2-thinking-pro.yaml
@@ -48,3 +48,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/kimi-k2-thinking.yaml
+++ b/xpertai/models/siliconflow/src/llm/kimi-k2-thinking.yaml
@@ -48,3 +48,4 @@ pricing:
   output: "16"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/kimi-k2.6-pro.yaml
+++ b/xpertai/models/siliconflow/src/llm/kimi-k2.6-pro.yaml
@@ -1,28 +1,22 @@
-model: zai-org/GLM-4.6V
+model: Pro/moonshotai/Kimi-K2.6
 label:
-  zh_Hans: zai-org/GLM-4.6V
-  en_US: zai-org/GLM-4.6V
+  zh_Hans: Pro/moonshotai/Kimi-K2.6
+  en_US: Pro/moonshotai/Kimi-K2.6
 model_type: llm
 features:
-  - agent-thought
+  - tool-call
   - multi-tool-call
-  - stream-tool-call
+  - agent-thought
   - vision
+  - stream-tool-call
+  - video
 model_properties:
   mode: chat
-  context_size: 128000
+  context_size: 256000
 parameter_rules:
   - name: temperature
     use_template: temperature
-  - name: max_tokens
-    use_template: max_tokens
-    type: int
-    default: 16384
-    min: 1
-    max: 32768
-    help:
-      zh_Hans: 指定生成结果长度的上限。如果生成结果截断，可以调大该参数。
-      en_US: Specifies the upper limit on the length of generated results. If the generated results are truncated, you can increase this parameter.
+    default: 1.0
   - name: top_p
     use_template: top_p
   - name: top_k
@@ -34,24 +28,15 @@ parameter_rules:
       zh_Hans: 仅从每个后续标记的前 K 个选项中采样。
       en_US: Only sample from the top K options for each subsequent token.
     required: false
-  - name: frequency_penalty
-    use_template: frequency_penalty
-  - name: response_format
-    label:
-      zh_Hans: 回复格式
-      en_US: Response Format
-    type: string
-    help:
-      zh_Hans: 指定模型必须输出的格式
-      en_US: specifying the format that the model must output
-    required: false
-    options:
-      - text
-      - json_object
+  - name: max_tokens
+    use_template: max_tokens
+    min: 1
+    max: 262144
+    default: 8192
   - name: enable_thinking
     required: false
     type: boolean
-    default: true
+    default: false
     label:
       zh_Hans: 思考模式
       en_US: Thinking mode
@@ -61,9 +46,9 @@ parameter_rules:
   - name: thinking_budget
     required: false
     type: int
-    default: 512
+    default: 4096
     min: 1
-    max: 8192
+    max: 262144
     label:
       zh_Hans: 思考长度限制
       en_US: Thinking budget
@@ -71,8 +56,7 @@ parameter_rules:
       zh_Hans: 思考过程的最大长度，只在思考模式为true时生效。
       en_US: The maximum length of the thinking process, only effective when thinking mode is true.
 pricing:
-  input: '1'
-  output: '3'
-  unit: '0.000001'
+  input: "6.5"
+  output: "27"
+  unit: "0.000001"
   currency: RMB
-deprecated: true

--- a/xpertai/models/siliconflow/src/llm/qwen3-235b-a22b-instruct-2507.yaml
+++ b/xpertai/models/siliconflow/src/llm/qwen3-235b-a22b-instruct-2507.yaml
@@ -27,3 +27,4 @@ pricing:
   output: "10"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/qwen3-235b-a22b-thinking-2507.yaml
+++ b/xpertai/models/siliconflow/src/llm/qwen3-235b-a22b-thinking-2507.yaml
@@ -27,3 +27,4 @@ pricing:
   output: "10"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/qwen3-235b-a22b.yaml
+++ b/xpertai/models/siliconflow/src/llm/qwen3-235b-a22b.yaml
@@ -49,3 +49,4 @@ pricing:
   output: "10"
   unit: "0.000001"
   currency: RMB
+deprecated: true

--- a/xpertai/models/siliconflow/src/llm/qwen3.6-27b.yaml
+++ b/xpertai/models/siliconflow/src/llm/qwen3.6-27b.yaml
@@ -1,0 +1,40 @@
+model: Qwen/Qwen3.6-27B
+label:
+  en_US: Qwen/Qwen3.6-27B
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
+pricing:
+  input: "0.6"
+  output: "4.8"
+  unit: "0.000001"
+  currency: RMB

--- a/xpertai/models/siliconflow/src/llm/qwen3.6-35b-a3b.yaml
+++ b/xpertai/models/siliconflow/src/llm/qwen3.6-35b-a3b.yaml
@@ -1,0 +1,40 @@
+model: Qwen/Qwen3.6-35B-A3B
+label:
+  en_US: Qwen/Qwen3.6-35B-A3B
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+  - vision
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+  - name: enable_thinking
+    required: false
+    type: boolean
+    default: false
+    label:
+      zh_Hans: 思考模式
+      en_US: Thinking mode
+    help:
+      zh_Hans: 是否开启思考模式。
+      en_US: Whether to enable thinking mode.
+pricing:
+  input: "0.4"
+  output: "3.2"
+  unit: "0.000001"
+  currency: RMB

--- a/xpertai/models/siliconflow/src/llm/step-3.5-flash.yaml
+++ b/xpertai/models/siliconflow/src/llm/step-3.5-flash.yaml
@@ -1,0 +1,29 @@
+model: stepfun-ai/Step-3.5-Flash
+label:
+  en_US: stepfun-ai/Step-3.5-Flash
+model_type: llm
+features:
+  - agent-thought
+  - tool-call
+  - stream-tool-call
+model_properties:
+  mode: chat
+  context_size: 262144
+parameter_rules:
+  - name: response_format
+    label:
+      zh_Hans: 回复格式
+      en_US: Response Format
+    type: string
+    help:
+      zh_Hans: 指定模型必须输出的格式
+      en_US: specifying the format that the model must output
+    required: false
+    options:
+      - text
+      - json_object
+pricing:
+  input: "0.7"
+  output: "2.1"
+  unit: "0.000001"
+  currency: RMB


### PR DESCRIPTION
## Summary

- Sync SiliconFlow LLM metadata with the latest Dify model list.
- Add 7 new SiliconFlow LLM YAML definitions and update `_position.yaml` ordering.
- Mark 11 older SiliconFlow model definitions as deprecated.
- Add a patch changeset for `@xpert-ai/plugin-siliconflow`.

## Validation

- Parsed all SiliconFlow LLM YAML files successfully.
- Ran `NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-siliconflow --skipSync --skip-nx-cache` successfully in the source checkout before isolating the PR branch.
- Ran `pnpm -C xpertai/models/siliconflow run prepack` successfully.
- Ran `pnpm -C plugin-dev-harness build` successfully.
- Ran `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-siliconflow` successfully.

Note: the isolated PR worktree could not install its own dependency tree because npm registry fetches failed with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`; the branch diff itself was validated for scope with GitHub compare and YAML parsing.