### PR TITLE
[codex] add Seedream AIGC tools for Volcengine

### DIFF
--- a/xpertai/.changeset/volcengine-seedream-aigc.md
+++ b/xpertai/.changeset/volcengine-seedream-aigc.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-volcengine": patch
+---
+
+Add Seedream AIGC image and video generation tools for Volcengine.

--- a/xpertai/models/volcengine/package.json
+++ b/xpertai/models/volcengine/package.json
@@ -31,12 +31,14 @@
     "!**/*.tsbuildinfo"
   ],
   "scripts": {
+    "build": "tsc --build tsconfig.lib.json && node ./scripts/copy-assets.mjs",
     "prepack": "node ./scripts/copy-assets.mjs"
   },
   "dependencies": {
     "tslib": "^2.3.0"
   },
   "peerDependencies": {
+    "@langchain/core": "0.3.72",
     "@langchain/openai": "0.6.9",
     "@metad/contracts": "^3.6.1",
     "@nestjs/common": "^11.1.6",

--- a/xpertai/models/volcengine/src/seedream-aigc/assets.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/assets.ts
@@ -1,0 +1,131 @@
+import { readFile } from 'fs/promises'
+import { basename } from 'path'
+import { extensionFromMimeType } from './workspace-upload.js'
+
+type FileLike = {
+  blob?: Buffer | Uint8Array | ArrayBuffer | string
+  content?: Buffer | Uint8Array | ArrayBuffer | string
+  fileUrl?: string
+  url?: string
+  filePath?: string
+  path?: string
+  fileName?: string
+  name?: string
+  mimeType?: string
+  mimetype?: string
+  type?: string
+}
+
+export async function inputToDataUrl(input: unknown, fetchImpl: typeof fetch, defaultMimeType = 'image/png') {
+  if (typeof input === 'string' && input.startsWith('data:')) {
+    return input
+  }
+  const { buffer, mimeType } = await inputToBuffer(input, fetchImpl, defaultMimeType)
+  return `data:${mimeType};base64,${buffer.toString('base64')}`
+}
+
+export async function inputToBuffer(input: unknown, fetchImpl: typeof fetch, defaultMimeType = 'application/octet-stream') {
+  if (Buffer.isBuffer(input)) {
+    return { buffer: input, mimeType: defaultMimeType }
+  }
+  if (input instanceof Uint8Array) {
+    return { buffer: Buffer.from(input), mimeType: defaultMimeType }
+  }
+  if (input instanceof ArrayBuffer) {
+    return { buffer: Buffer.from(input), mimeType: defaultMimeType }
+  }
+  if (typeof input === 'string') {
+    if (input.startsWith('data:')) {
+      return dataUrlToBuffer(input)
+    }
+    if (isHttpUrl(input)) {
+      return downloadInput(input, fetchImpl, defaultMimeType)
+    }
+    return { buffer: await readFile(input), mimeType: inferMimeType(input, defaultMimeType) }
+  }
+  if (isObject(input)) {
+    const file = input as FileLike
+    const inline = file.blob ?? file.content
+    if (inline !== undefined) {
+      return inputToBuffer(inline, fetchImpl, normalizeMimeType(file) ?? defaultMimeType)
+    }
+    const url = file.fileUrl ?? file.url
+    if (url) {
+      return downloadInput(url, fetchImpl, normalizeMimeType(file) ?? defaultMimeType)
+    }
+    const filePath = file.filePath ?? file.path
+    if (filePath) {
+      return { buffer: await readFile(filePath), mimeType: normalizeMimeType(file) ?? inferMimeType(filePath, defaultMimeType) }
+    }
+  }
+  throw new Error('Unsupported file input')
+}
+
+export function enforceMaxBytes(buffer: Buffer, maxBytes: number, label: string) {
+  if (buffer.length > maxBytes) {
+    throw new Error(`${label} exceeds ${Math.round(maxBytes / 1024 / 1024)}MB limit`)
+  }
+}
+
+export function createGeneratedFileName(prefix: string, index: number, mimeType: string, forcedName?: string) {
+  if (forcedName) {
+    return forcedName
+  }
+  const suffix = index > 0 ? `-${index + 1}` : ''
+  return `${prefix}${suffix}.${extensionFromMimeType(mimeType)}`
+}
+
+export function basenameFromUrl(url: string, fallback: string) {
+  try {
+    return basename(new URL(url).pathname) || fallback
+  } catch {
+    return fallback
+  }
+}
+
+function dataUrlToBuffer(dataUrl: string) {
+  const match = /^data:([^;,]+)?(;base64)?,(.*)$/s.exec(dataUrl)
+  if (!match) {
+    throw new Error('Invalid data URL')
+  }
+  const mimeType = match[1] || 'application/octet-stream'
+  const body = match[3] ?? ''
+  const buffer = match[2] ? Buffer.from(body, 'base64') : Buffer.from(decodeURIComponent(body))
+  return { buffer, mimeType }
+}
+
+async function downloadInput(url: string, fetchImpl: typeof fetch, defaultMimeType: string) {
+  const response = await fetchImpl(url, { method: 'GET' })
+  if (!response.ok) {
+    throw new Error(`Failed to download input file: ${response.status} ${response.statusText}`)
+  }
+  const arrayBuffer = await response.arrayBuffer()
+  return {
+    buffer: Buffer.from(arrayBuffer),
+    mimeType: response.headers.get('content-type')?.split(';')[0]?.trim() || defaultMimeType
+  }
+}
+
+function normalizeMimeType(file: FileLike) {
+  return file.mimeType ?? file.mimetype ?? file.type
+}
+
+function inferMimeType(fileName: string, fallback: string) {
+  const ext = fileName.split('.').pop()?.toLowerCase()
+  if (ext === 'jpg' || ext === 'jpeg') return 'image/jpeg'
+  if (ext === 'png') return 'image/png'
+  if (ext === 'webp') return 'image/webp'
+  if (ext === 'gif') return 'image/gif'
+  if (ext === 'mp4') return 'video/mp4'
+  if (ext === 'mp3') return 'audio/mpeg'
+  if (ext === 'wav') return 'audio/wav'
+  return fallback
+}
+
+function isHttpUrl(value: string) {
+  return /^https?:\/\//i.test(value)
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object'
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/assets.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/assets.ts
@@ -1,5 +1,4 @@
-import { readFile } from 'fs/promises'
-import { basename } from 'path'
+import type { SeedreamWorkspaceScope, WorkspaceFilesApi } from './types.js'
 import { extensionFromMimeType } from './workspace-upload.js'
 
 type FileLike = {
@@ -8,6 +7,7 @@ type FileLike = {
   fileUrl?: string
   url?: string
   filePath?: string
+  workspacePath?: string
   path?: string
   fileName?: string
   name?: string
@@ -16,46 +16,49 @@ type FileLike = {
   type?: string
 }
 
-export async function inputToDataUrl(input: unknown, fetchImpl: typeof fetch, defaultMimeType = 'image/png') {
-  if (typeof input === 'string' && input.startsWith('data:')) {
-    return input
-  }
-  const { buffer, mimeType } = await inputToBuffer(input, fetchImpl, defaultMimeType)
+export type InputReadOptions = {
+  fetchImpl: typeof fetch
+  workspaceFiles: WorkspaceFilesApi
+  workspaceScope?: SeedreamWorkspaceScope
+  defaultMimeType: string
+}
+
+export function bufferToDataUrl(buffer: Buffer, mimeType: string) {
   return `data:${mimeType};base64,${buffer.toString('base64')}`
 }
 
-export async function inputToBuffer(input: unknown, fetchImpl: typeof fetch, defaultMimeType = 'application/octet-stream') {
+export async function inputToBuffer(input: unknown, options: InputReadOptions) {
   if (Buffer.isBuffer(input)) {
-    return { buffer: input, mimeType: defaultMimeType }
+    return { buffer: input, mimeType: options.defaultMimeType }
   }
   if (input instanceof Uint8Array) {
-    return { buffer: Buffer.from(input), mimeType: defaultMimeType }
+    return { buffer: Buffer.from(input), mimeType: options.defaultMimeType }
   }
   if (input instanceof ArrayBuffer) {
-    return { buffer: Buffer.from(input), mimeType: defaultMimeType }
+    return { buffer: Buffer.from(input), mimeType: options.defaultMimeType }
   }
   if (typeof input === 'string') {
     if (input.startsWith('data:')) {
       return dataUrlToBuffer(input)
     }
     if (isHttpUrl(input)) {
-      return downloadInput(input, fetchImpl, defaultMimeType)
+      return downloadInput(input, options.fetchImpl, options.defaultMimeType)
     }
-    return { buffer: await readFile(input), mimeType: inferMimeType(input, defaultMimeType) }
+    return readWorkspaceInput(input, options)
   }
   if (isObject(input)) {
     const file = input as FileLike
     const inline = file.blob ?? file.content
     if (inline !== undefined) {
-      return inputToBuffer(inline, fetchImpl, normalizeMimeType(file) ?? defaultMimeType)
+      return inputToBuffer(inline, { ...options, defaultMimeType: normalizeMimeType(file) ?? options.defaultMimeType })
     }
     const url = file.fileUrl ?? file.url
     if (url) {
-      return downloadInput(url, fetchImpl, normalizeMimeType(file) ?? defaultMimeType)
+      return downloadInput(url, options.fetchImpl, normalizeMimeType(file) ?? options.defaultMimeType)
     }
-    const filePath = file.filePath ?? file.path
+    const filePath = file.filePath ?? file.path ?? file.workspacePath
     if (filePath) {
-      return { buffer: await readFile(filePath), mimeType: normalizeMimeType(file) ?? inferMimeType(filePath, defaultMimeType) }
+      return readWorkspaceInput(filePath, options, normalizeMimeType(file))
     }
   }
   throw new Error('Unsupported file input')
@@ -75,14 +78,6 @@ export function createGeneratedFileName(prefix: string, index: number, mimeType:
   return `${prefix}${suffix}.${extensionFromMimeType(mimeType)}`
 }
 
-export function basenameFromUrl(url: string, fallback: string) {
-  try {
-    return basename(new URL(url).pathname) || fallback
-  } catch {
-    return fallback
-  }
-}
-
 function dataUrlToBuffer(dataUrl: string) {
   const match = /^data:([^;,]+)?(;base64)?,(.*)$/s.exec(dataUrl)
   if (!match) {
@@ -92,6 +87,19 @@ function dataUrlToBuffer(dataUrl: string) {
   const body = match[3] ?? ''
   const buffer = match[2] ? Buffer.from(body, 'base64') : Buffer.from(decodeURIComponent(body))
   return { buffer, mimeType }
+}
+
+async function readWorkspaceInput(filePath: string, options: InputReadOptions, mimeType?: string) {
+  const file = await options.workspaceFiles.readBuffer({
+    ...options.workspaceScope,
+    filePath
+  })
+  const resolvedMimeType =
+    mimeType ?? file.mimeType ?? inferMimeType(file.name ?? file.filePath ?? filePath, options.defaultMimeType)
+  return {
+    buffer: Buffer.from(file.buffer),
+    mimeType: resolvedMimeType
+  }
 }
 
 async function downloadInput(url: string, fetchImpl: typeof fetch, defaultMimeType: string) {

--- a/xpertai/models/volcengine/src/seedream-aigc/client.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/client.ts
@@ -1,0 +1,65 @@
+import { SeedreamAigcDefaultBaseUrl, type SeedreamAigcCredentials } from './types.js'
+
+export class SeedreamArkClient {
+  private readonly baseUrl: string
+  private readonly apiKey: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(credentials: SeedreamAigcCredentials, fetchImpl: typeof fetch = fetch) {
+    if (!credentials.ark_api_key) {
+      throw new Error('Ark API key is missing')
+    }
+    this.apiKey = credentials.ark_api_key
+    this.baseUrl = (credentials.api_endpoint_host || SeedreamAigcDefaultBaseUrl).replace(/\/$/, '')
+    this.fetchImpl = fetchImpl
+  }
+
+  async generateImages(payload: Record<string, unknown>): Promise<any> {
+    return this.postJson(`${this.baseUrl}/images/generations`, payload)
+  }
+
+  async createVideoTask(payload: Record<string, unknown>): Promise<any> {
+    return this.postJson(`${this.baseUrl}/contents/generations/tasks`, payload)
+  }
+
+  async getVideoTask(taskId: string): Promise<any> {
+    return this.requestJson(`${this.baseUrl}/contents/generations/tasks/${encodeURIComponent(taskId)}`, {
+      method: 'GET'
+    })
+  }
+
+  async downloadBuffer(url: string): Promise<{ buffer: Buffer; mimeType?: string }> {
+    const response = await this.fetchImpl(url, { method: 'GET' })
+    if (!response.ok) {
+      throw new Error(`Failed to download generated asset: ${response.status} ${response.statusText}`)
+    }
+    const arrayBuffer = await response.arrayBuffer()
+    return {
+      buffer: Buffer.from(arrayBuffer),
+      mimeType: response.headers.get('content-type')?.split(';')[0]?.trim() || undefined
+    }
+  }
+
+  private async postJson(url: string, payload: Record<string, unknown>): Promise<any> {
+    return this.requestJson(url, {
+      method: 'POST',
+      body: JSON.stringify(payload)
+    })
+  }
+
+  private async requestJson(url: string, init: RequestInit): Promise<any> {
+    const response = await this.fetchImpl(url, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+        ...(init.headers ?? {})
+      }
+    })
+    if (!response.ok) {
+      const text = await response.text().catch(() => '')
+      throw new Error(`Ark API error ${response.status}: ${text || response.statusText}`)
+    }
+    return response.json()
+  }
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/rules.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/rules.ts
@@ -1,0 +1,148 @@
+export const SEEDANCE_2_MODELS = new Set(['doubao-seedance-2-0-260128', 'doubao-seedance-2-0-fast-260128'])
+export const MODEL_ALIASES: Record<string, string> = {
+  'doubao-seedance-2-0-fast-250428': 'doubao-seedance-2-0-fast-260128'
+}
+
+export type VideoGenerationInput = {
+  model?: string | null
+  prompt?: string | null
+  resolution?: string | null
+  ratio?: string | null
+  duration?: string | number | null
+  seed?: string | number | null
+  camera_fixed?: string | boolean | null
+  watermark?: string | boolean | null
+  generate_audio?: string | boolean | null
+  draft?: string | boolean | null
+  return_last_frame?: string | boolean | null
+  service_tier?: string | null
+}
+
+export type NormalizedVideoGenerationOptions = {
+  model: string
+  prompt: string
+  resolution: string
+  ratio: string
+  duration: number
+  seed: number
+  camera_fixed: boolean
+  watermark: boolean
+  generate_audio: boolean
+  draft: boolean
+  return_last_frame: boolean
+  service_tier: string
+  isSeedance2: boolean
+  isSeedance15: boolean
+}
+
+export function normalizeVideoGenerationOptions(input: VideoGenerationInput): NormalizedVideoGenerationOptions {
+  const model = MODEL_ALIASES[normalizeString(input.model) || ''] || normalizeString(input.model) || 'doubao-seedance-1-5-pro-251215'
+  const isSeedance2 = isSeedance2Model(model)
+  const isSeedance15 = model.includes('seedance-1-5')
+  let prompt = normalizeString(input.prompt) || ''
+  if (prompt.length > 500) {
+    prompt = prompt.slice(0, 500)
+  }
+
+  let resolution = normalizeString(input.resolution) || '720p'
+  if (isSeedance2 && resolution === '1080p') {
+    resolution = '720p'
+  }
+
+  let duration = normalizeNumber(input.duration, 5)
+  if (duration === -1 && !(isSeedance2 || isSeedance15)) {
+    duration = 5
+  } else if (duration !== -1) {
+    const [minDuration, maxDuration] = getDurationRange(isSeedance2, isSeedance15)
+    duration = clamp(duration, minDuration, maxDuration)
+  }
+
+  const seed = clamp(normalizeNumber(input.seed, -1), -1, 4294967295)
+  let draft = normalizeBoolean(input.draft, false)
+  const returnLastFrame = normalizeBoolean(input.return_last_frame, false)
+  if (draft && !isSeedance15) {
+    draft = false
+  }
+  if (draft && returnLastFrame) {
+    return {
+      model,
+      prompt,
+      resolution,
+      ratio: normalizeString(input.ratio) || '16:9',
+      duration,
+      seed,
+      camera_fixed: normalizeBoolean(input.camera_fixed, false),
+      watermark: normalizeBoolean(input.watermark, true),
+      generate_audio: normalizeBoolean(input.generate_audio, true),
+      draft,
+      return_last_frame: false,
+      service_tier: normalizeServiceTier(input.service_tier, isSeedance2),
+      isSeedance2,
+      isSeedance15
+    }
+  }
+
+  return {
+    model,
+    prompt,
+    resolution,
+    ratio: normalizeString(input.ratio) || '16:9',
+    duration,
+    seed,
+    camera_fixed: normalizeBoolean(input.camera_fixed, false),
+    watermark: normalizeBoolean(input.watermark, true),
+    generate_audio: normalizeBoolean(input.generate_audio, true),
+    draft,
+    return_last_frame: returnLastFrame,
+    service_tier: normalizeServiceTier(input.service_tier, isSeedance2),
+    isSeedance2,
+    isSeedance15
+  }
+}
+
+export function isSeedance2Model(model: string) {
+  const normalized = model.toLowerCase()
+  return SEEDANCE_2_MODELS.has(normalized) || normalized.includes('seedance-2-0')
+}
+
+export function normalizeBoolean(value: string | boolean | null | undefined, fallback: boolean) {
+  if (typeof value === 'boolean') {
+    return value
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized === 'true') return true
+    if (normalized === 'false') return false
+  }
+  return fallback
+}
+
+export function normalizeString(value: unknown) {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function normalizeNumber(value: unknown, fallback: number) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) return parsed
+  }
+  return fallback
+}
+
+function normalizeServiceTier(value: unknown, isSeedance2: boolean) {
+  const serviceTier = normalizeString(value) || 'default'
+  return isSeedance2 && serviceTier === 'flex' ? 'default' : serviceTier
+}
+
+function getDurationRange(isSeedance2: boolean, isSeedance15: boolean) {
+  if (isSeedance2) return [4, 15] as const
+  if (isSeedance15) return [4, 12] as const
+  return [2, 12] as const
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/seedream-aigc.spec.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/seedream-aigc.spec.ts
@@ -1,0 +1,552 @@
+import { buildSeedreamTools } from './tools.js'
+import { normalizeVideoGenerationOptions } from './rules.js'
+import { SeedreamAigcStrategy } from './strategy.js'
+import { SeedreamAigcToolset } from './toolset.js'
+import { SeedreamAigc, type SeedreamAigcCredentials, type SeedreamToolResult, type WorkspaceFilesApi } from './types.js'
+
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  BuiltinToolset: class {
+    tools: any[] = []
+
+    constructor(
+      public providerName: string,
+      protected toolset?: any,
+      protected params?: any
+    ) {}
+
+    get xpertId() {
+      return this.params?.xpertId
+    }
+
+    getCredentials() {
+      return this.toolset?.credentials
+    }
+  },
+  ToolsetStrategy: () => (target: any) => target
+}))
+
+describe('Seedream AIGC tools', () => {
+  const credentials: SeedreamAigcCredentials = {
+    ark_api_key: 'test-api-key',
+    api_endpoint_host: 'https://ark.test/api/v3'
+  }
+
+  let fetchMock: jest.Mock
+  let workspaceFiles: WorkspaceFilesApi
+
+  beforeEach(() => {
+    fetchMock = jest.fn()
+    workspaceFiles = {
+      uploadBuffer: jest.fn(async (input) => ({
+        name: input.fileName ?? input.originalName,
+        filePath: `${input.folder}/${input.fileName}`,
+        workspacePath: `${input.folder}/${input.fileName}`,
+        fileUrl: `https://workspace.example/${input.folder}/${input.fileName}`,
+        url: `https://workspace.example/${input.folder}/${input.fileName}`,
+        mimeType: input.mimeType ?? undefined,
+        size: input.size ?? input.buffer.length,
+        catalog: input.catalog ?? 'xperts',
+        scopeId: input.scopeId
+      })),
+      readBuffer: jest.fn(),
+      deleteFile: jest.fn()
+    }
+  })
+
+  it('uploads text-to-image URL output to the workspace', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        data: [{ url: 'https://ark.test/generated/image.png', size: '2048x2048' }]
+      }))
+      .mockResolvedValueOnce(binaryResponse(Buffer.from('generated-image'), 'image/png'))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedream_text_to_image'
+    )
+
+    const result = await tool?.invoke({
+      id: 'call-1',
+      name: 'seedream_text_to_image',
+      type: 'tool_call',
+      args: {
+        prompt: 'a clean product render',
+        watermark: 'false'
+      }
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://ark.test/api/v3/images/generations',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer test-api-key'
+        })
+      })
+    )
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual(
+      expect.objectContaining({
+        prompt: 'a clean product render',
+        response_format: 'url',
+        watermark: false
+      })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://ark.test/generated/image.png', expect.any(Object))
+    expect(workspaceFiles.uploadBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from('generated-image'),
+        folder: 'files/seedream-aigc/images',
+        mimeType: 'image/png',
+        metadata: expect.objectContaining({
+          provider: 'seedream_aigc',
+          source: 'ark_image_generation'
+        })
+      })
+    )
+    const [content, artifact] = result as SeedreamToolResult
+    expect(artifact.files[0]).toEqual(
+      expect.objectContaining({
+        fileUrl: expect.stringContaining('https://workspace.example/files/seedream-aigc/images/'),
+        workspacePath: expect.stringContaining('files/seedream-aigc/images/')
+      })
+    )
+    expect(content).toContain('https://workspace.example/files/seedream-aigc/images/')
+    expect(content).toContain('![')
+    expect(JSON.stringify(result)).not.toContain('Z2VuZXJhdGVkLWltYWdl')
+  })
+
+  it('exposes localized defaults and select options for image tool schemas', () => {
+    const tools = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock })
+    const textToImageSchema = tools.find((_) => _.name === 'seedream_text_to_image')?.schema as any
+    const multiImagesSchema = tools.find((_) => _.name === 'seedream_multi_images_to_multi_images')?.schema as any
+
+    expect(textToImageSchema.properties.prompt['x-ui'].title.zh_Hans).toBe('提示词')
+    expect(textToImageSchema.properties.prompt['x-ui'].component).toBeUndefined()
+    expect(textToImageSchema.properties.size.default).toBe('2048x2048')
+    expect(textToImageSchema.properties.size.enum).toEqual([
+      '2048x2048',
+      '2304x1728',
+      '1728x2304',
+      '2560x1440',
+      '1440x2560',
+      '2496x1664',
+      '1664x2496',
+      '3024x1296'
+    ])
+    expect(textToImageSchema.properties.size['x-ui'].enumLabels['2048x2048']).toBe('1:1 (2048x2048)')
+    expect(textToImageSchema.properties.watermark.default).toBe('true')
+    expect(textToImageSchema.properties.watermark.enum).toEqual(['true', 'false'])
+    expect(textToImageSchema.properties.watermark['x-ui'].enumLabels['true'].zh_Hans).toBe('启用')
+    expect(textToImageSchema.properties.model.default).toBe('doubao-seedream-4-5-251128')
+    expect(textToImageSchema.properties.model.enum).toEqual([
+      'doubao-seedream-4-0-250828',
+      'doubao-seedream-4-5-251128',
+      'doubao-seedream-5-0-lite-260128'
+    ])
+    expect(textToImageSchema.properties.sequential_image_generation).toBeUndefined()
+
+    expect(multiImagesSchema.properties.input_image_files['x-ui'].title.zh_Hans).toBe('参考图片列表')
+    expect(multiImagesSchema.properties.input_image_files.anyOf[0].type).toBe('array')
+    expect(multiImagesSchema.properties.input_image_files.anyOf[0].minItems).toBe(2)
+    expect(multiImagesSchema.properties.input_image_files.anyOf[0].maxItems).toBe(14)
+    expect(multiImagesSchema.properties.input_image_files.anyOf[1].type).toBe('string')
+    expect(multiImagesSchema.properties.max_images.default).toBe(3)
+    expect(multiImagesSchema.properties.max_images['x-ui'].title.zh_Hans).toBe('最大生成张数')
+  })
+
+  it('exposes host-facing tool schemas through the Seedream strategy', () => {
+    const strategy = new SeedreamAigcStrategy()
+    const tools = strategy.createTools()
+    const toolNames = tools.map((_) => _.name)
+    const textToImageSchema = tools.find((_) => _.name === 'seedream_text_to_image')?.schema as any
+    const videoQuerySchema = tools.find((_) => _.name === 'seedance_video_query')?.schema as any
+
+    expect(strategy.meta.name).toBe(SeedreamAigc)
+    expect(toolNames).toEqual(
+      expect.arrayContaining([
+        'seedream_text_to_image',
+        'seedream_image_to_image',
+        'seedream_multi_images_to_multi_images',
+        'seedance_text_to_video',
+        'seedance_video_query'
+      ])
+    )
+    expect(textToImageSchema.properties.prompt['x-ui'].title.zh_Hans).toBe('提示词')
+    expect(textToImageSchema.properties.size.default).toBe('2048x2048')
+    expect(textToImageSchema.properties.model.default).toBe('doubao-seedream-4-5-251128')
+    expect(videoQuerySchema.properties.task_id['x-ui'].title.zh_Hans).toBe('任务 ID')
+    expect(videoQuerySchema.properties.download_video.default).toBe('true')
+    expect(videoQuerySchema.required).toEqual(['task_id'])
+  })
+
+  it('exposes localized defaults and select options for video tool schemas', () => {
+    const tools = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock })
+    const textToVideoSchema = tools.find((_) => _.name === 'seedance_text_to_video')?.schema as any
+    const imageToVideoSchema = tools.find((_) => _.name === 'seedance_image_to_video')?.schema as any
+    const multimodalSchema = tools.find((_) => _.name === 'seedance_multimodal_reference_to_video')?.schema as any
+    const videoQuerySchema = tools.find((_) => _.name === 'seedance_video_query')?.schema as any
+
+    expect(textToVideoSchema.properties.prompt['x-ui'].title.zh_Hans).toBe('提示词')
+    expect(textToVideoSchema.properties.model.default).toBe('doubao-seedance-1-5-pro-251215')
+    expect(textToVideoSchema.properties.model.enum).toEqual([
+      'doubao-seedance-1-5-pro-251215',
+      'doubao-seedance-2-0-260128',
+      'doubao-seedance-2-0-fast-260128'
+    ])
+    expect(textToVideoSchema.properties.resolution.default).toBe('720p')
+    expect(textToVideoSchema.properties.resolution.enum).toEqual(['480p', '720p', '1080p'])
+    expect(textToVideoSchema.properties.ratio.default).toBe('16:9')
+    expect(textToVideoSchema.properties.ratio.enum).toContain('adaptive')
+    expect(textToVideoSchema.properties.duration.default).toBe(5)
+    expect(textToVideoSchema.properties.watermark.default).toBe('true')
+    expect(textToVideoSchema.properties.watermark['x-ui'].enumLabels.true.zh_Hans).toBe('启用')
+    expect(textToVideoSchema.required).toEqual(['prompt'])
+
+    expect(imageToVideoSchema.properties.input_image_file['x-ui'].title.zh_Hans).toBe('参考图片')
+    expect(imageToVideoSchema.required).toEqual(['prompt', 'input_image_file'])
+
+    expect(multimodalSchema.properties.model.default).toBe('doubao-seedance-2-0-260128')
+    expect(multimodalSchema.properties.model.enum).toEqual([
+      'doubao-seedance-2-0-260128',
+      'doubao-seedance-2-0-fast-260128'
+    ])
+    expect(multimodalSchema.properties.ratio.default).toBe('adaptive')
+    expect(multimodalSchema.properties.input_mode.default).toBe('text_image_video')
+    expect(multimodalSchema.properties.input_mode['x-ui'].enumLabels.text_image_video.zh_Hans).toBe('文本(可选)+图片+视频')
+
+    expect(videoQuerySchema.properties.task_id['x-ui'].title.zh_Hans).toBe('任务 ID')
+    expect(videoQuerySchema.properties.download_video.default).toBe('true')
+    expect(videoQuerySchema.properties.download_video.enum).toEqual(['true', 'false'])
+    expect(videoQuerySchema.properties.download_video['x-ui'].enumLabels.true.zh_Hans).toBe('启用')
+    expect(videoQuerySchema.required).toEqual(['task_id'])
+  })
+
+  it('uses the xpert runtime context as workspace upload scope', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        data: [{ url: 'https://ark.test/generated/image.png', size: '2048x2048' }]
+      }))
+      .mockResolvedValueOnce(binaryResponse(Buffer.from('generated-image'), 'image/png'))
+
+    const toolset = new (SeedreamAigcToolset as any)(
+      { credentials },
+      { get: jest.fn().mockReturnValue(workspaceFiles) },
+      { xpertId: 'xpert-1' }
+    )
+    const tools = await toolset.initTools()
+    const tool = tools.find((_) => _.name === 'seedream_text_to_image')
+    const originalFetch = global.fetch
+    global.fetch = fetchMock as typeof fetch
+
+    try {
+      await tool?.invoke({
+        id: 'call-context',
+        name: 'seedream_text_to_image',
+        type: 'tool_call',
+        args: {
+          prompt: 'a clean product render'
+        }
+      })
+    } finally {
+      global.fetch = originalFetch
+    }
+
+    expect(workspaceFiles.uploadBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        catalog: 'xperts',
+        scopeId: 'xpert-1',
+        xpertId: 'xpert-1'
+      })
+    )
+  })
+
+  it('uploads b64 image output to the workspace', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      data: [{ b64_json: Buffer.from('generated-image-b64').toString('base64'), size: '2048x2048' }]
+    }))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedream_image_to_image'
+    )
+
+    const result = await tool?.invoke({
+      id: 'call-2',
+      name: 'seedream_image_to_image',
+      type: 'tool_call',
+      args: {
+        prompt: 'make it cinematic',
+        input_image_file: `data:image/png;base64,${Buffer.from('input-image').toString('base64')}`
+      }
+    })
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual(
+      expect.objectContaining({
+        image: expect.stringMatching(/^data:image\/png;base64,/),
+        response_format: 'b64_json'
+      })
+    )
+    expect(workspaceFiles.uploadBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from('generated-image-b64'),
+        folder: 'files/seedream-aigc/images',
+        mimeType: 'image/png'
+      })
+    )
+    const [, artifact] = result as SeedreamToolResult
+    expect(artifact.files[0].fileUrl).toContain('https://workspace.example/')
+    expect(JSON.stringify(result)).not.toContain(Buffer.from('generated-image-b64').toString('base64'))
+  })
+
+  it('accepts JSON string arrays for multi-image inputs', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      data: [{ b64_json: Buffer.from('generated-image-b64').toString('base64'), size: '2048x2048' }]
+    }))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedream_multi_images_to_multi_images'
+    )
+    const inputImages = [
+      `data:image/png;base64,${Buffer.from('first-image').toString('base64')}`,
+      `data:image/png;base64,${Buffer.from('second-image').toString('base64')}`
+    ]
+
+    await tool?.invoke({
+      id: 'call-json-images',
+      name: 'seedream_multi_images_to_multi_images',
+      type: 'tool_call',
+      args: {
+        prompt: 'make two cats take a selfie',
+        input_image_files: JSON.stringify(inputImages),
+        max_images: 2
+      }
+    })
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(payload.image).toHaveLength(2)
+    expect(payload.sequential_image_generation_options).toEqual({ max_images: 2 })
+    expect(workspaceFiles.uploadBuffer).toHaveBeenCalled()
+  })
+
+  it('accepts numeric strings for Seedance video duration', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      id: 'task-1',
+      status: 'submitted',
+      model: 'doubao-seedance-1-5-pro-251215'
+    }))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedance_text_to_video'
+    )
+
+    await tool?.invoke({
+      id: 'call-video-duration',
+      name: 'seedance_text_to_video',
+      type: 'tool_call',
+      args: {
+        prompt: 'a small black cat in the rain',
+        duration: '3',
+        seed: '42'
+      }
+    })
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(payload.duration).toBe(4)
+    expect(payload.seed).toBe(42)
+  })
+
+  it('returns the task id and query instruction for Seedance video submissions', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      id: 'task-1',
+      status: 'submitted',
+      model: 'doubao-seedance-1-5-pro-251215'
+    }))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedance_text_to_video'
+    )
+
+    const result = await tool?.invoke({
+      id: 'call-video-submit',
+      name: 'seedance_text_to_video',
+      type: 'tool_call',
+      args: {
+        prompt: 'a small black cat looking for its mother'
+      }
+    })
+
+    const [content, artifact] = result as SeedreamToolResult
+    expect(content).toContain('Task ID: task-1')
+    expect(content).toContain('Call seedance_video_query once')
+    expect(content).toContain('Do not repeat the same query in this turn')
+    expect(artifact.data).toEqual(
+      expect.objectContaining({
+        task_id: 'task-1',
+        status: 'submitted',
+        model: 'doubao-seedance-1-5-pro-251215'
+      })
+    )
+  })
+
+  it('tells the assistant to stop when a video query has no downloadable video yet', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      id: 'task-1',
+      status: 'running',
+      model: 'doubao-seedance-1-5-pro-251215',
+      content: {}
+    }))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedance_video_query'
+    )
+
+    const result = await tool?.invoke({
+      id: 'call-video-query-pending',
+      name: 'seedance_video_query',
+      type: 'tool_call',
+      args: {
+        task_id: 'task-1',
+        download_video: 'true'
+      }
+    })
+
+    const [content] = result as SeedreamToolResult
+    expect(content).toContain('Video task task-1 status: running.')
+    expect(content).toContain('No video_url is available yet')
+    expect(content).toContain('Do not repeat seedance_video_query with the same task_id in this turn')
+    expect(workspaceFiles.uploadBuffer).not.toHaveBeenCalled()
+  })
+
+  it('uploads completed video query output to the workspace', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'task-1',
+        status: 'succeeded',
+        model: 'doubao-seedance-1-5-pro-251215',
+        content: {
+          video_url: 'https://ark.test/generated/video.mp4',
+          last_frame_url: 'https://ark.test/generated/last.png'
+        }
+      }))
+      .mockResolvedValueOnce(binaryResponse(Buffer.from('generated-video'), 'video/mp4'))
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedance_video_query'
+    )
+
+    const result = await tool?.invoke({
+      id: 'call-3',
+      name: 'seedance_video_query',
+      type: 'tool_call',
+      args: {
+        task_id: 'task-1',
+        download_video: 'true'
+      }
+    })
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://ark.test/api/v3/contents/generations/tasks/task-1',
+      expect.objectContaining({ method: 'GET' })
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://ark.test/generated/video.mp4', expect.any(Object))
+    expect(workspaceFiles.uploadBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from('generated-video'),
+        folder: 'files/seedream-aigc/videos',
+        fileName: 'task-1.mp4',
+        mimeType: 'video/mp4'
+      })
+    )
+    const [, artifact] = result as SeedreamToolResult
+    expect(artifact.files[0]).toEqual(
+      expect.objectContaining({
+        fileName: 'task-1.mp4',
+        fileUrl: expect.stringContaining('https://workspace.example/files/seedream-aigc/videos/task-1.mp4')
+      })
+    )
+  })
+
+  it('requires at least two reference images for multi-image tools', async () => {
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedream_multi_images_to_image'
+    )
+
+    await expect(
+      tool?.invoke({
+        id: 'call-4',
+        name: 'seedream_multi_images_to_image',
+        type: 'tool_call',
+        args: {
+          prompt: 'merge references',
+          input_image_files: [`data:image/png;base64,${Buffer.from('one-image').toString('base64')}`]
+        }
+      })
+    ).rejects.toThrow()
+  })
+
+  it('enforces multimodal input mode requirements', async () => {
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedance_multimodal_reference_to_video'
+    )
+
+    await expect(
+      tool?.invoke({
+        id: 'call-5',
+        name: 'seedance_multimodal_reference_to_video',
+        type: 'tool_call',
+        args: {
+          input_mode: 'text_image_video',
+          reference_video_urls: 'https://ark.test/reference/video.mp4'
+        }
+      })
+    ).rejects.toThrow('text(optional)+image+video requires at least one reference image')
+  })
+
+  it('normalizes Seedance 2.0 video options', () => {
+    expect(
+      normalizeVideoGenerationOptions({
+        model: 'doubao-seedance-2-0-fast-250428',
+        prompt: 'x'.repeat(600),
+        resolution: '1080p',
+        duration: '2',
+        seed: '5000000000',
+        service_tier: 'flex',
+        draft: 'true',
+        return_last_frame: 'true'
+      })
+    ).toEqual(
+      expect.objectContaining({
+        model: 'doubao-seedance-2-0-fast-260128',
+        prompt: 'x'.repeat(500),
+        resolution: '720p',
+        duration: 4,
+        seed: 4294967295,
+        service_tier: 'default',
+        draft: false,
+        return_last_frame: true,
+        isSeedance2: true
+      })
+    )
+  })
+})
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => data,
+    text: async () => JSON.stringify(data)
+  } as Response
+}
+
+function binaryResponse(buffer: Buffer, mimeType: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers({ 'content-type': mimeType }),
+    arrayBuffer: async () => buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength)
+  } as Response
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/seedream-aigc.spec.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/seedream-aigc.spec.ts
@@ -297,6 +297,47 @@ describe('Seedream AIGC tools', () => {
     expect(JSON.stringify(result)).not.toContain(Buffer.from('generated-image-b64').toString('base64'))
   })
 
+  it('reads workspace image inputs through the workspace files API', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({
+      data: [{ b64_json: Buffer.from('generated-image-b64').toString('base64'), size: '2048x2048' }]
+    }))
+    const readBufferMock = workspaceFiles.readBuffer as jest.Mock
+    readBufferMock.mockResolvedValueOnce({
+      name: 'input.png',
+      filePath: 'files/source/input.png',
+      workspacePath: 'files/source/input.png',
+      buffer: Buffer.from('workspace-image'),
+      mimeType: 'image/png',
+      catalog: 'xperts'
+    })
+
+    const tool = buildSeedreamTools({ credentials, workspaceFiles, fetch: fetchMock }).find(
+      (_) => _.name === 'seedream_image_to_image'
+    )
+
+    await tool?.invoke({
+      id: 'call-workspace-input',
+      name: 'seedream_image_to_image',
+      type: 'tool_call',
+      args: {
+        prompt: 'make it cinematic',
+        input_image_file: { filePath: 'files/source/input.png', mimeType: 'image/png' }
+      }
+    })
+
+    expect(workspaceFiles.readBuffer).toHaveBeenCalledTimes(1)
+    expect(workspaceFiles.readBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: 'files/source/input.png'
+      })
+    )
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual(
+      expect.objectContaining({
+        image: `data:image/png;base64,${Buffer.from('workspace-image').toString('base64')}`
+      })
+    )
+  })
+
   it('accepts JSON string arrays for multi-image inputs', async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({
       data: [{ b64_json: Buffer.from('generated-image-b64').toString('base64'), size: '2048x2048' }]

--- a/xpertai/models/volcengine/src/seedream-aigc/strategy.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/strategy.ts
@@ -1,0 +1,81 @@
+import { Inject, Injectable, Optional } from '@nestjs/common'
+import { BuiltinToolset, IToolsetStrategy, ToolsetStrategy, type TBuiltinToolsetParams } from '@xpert-ai/plugin-sdk'
+import { SvgIcon } from '../types.js'
+import { buildSeedreamTools } from './tools.js'
+import { SeedreamAigc, type RuntimeCapabilityRegistryLike } from './types.js'
+import { SeedreamAigcToolset } from './toolset.js'
+
+const XPERT_RUNTIME_CAPABILITIES_TOKEN = 'XPERT_RUNTIME_CAPABILITIES'
+
+@Injectable()
+@ToolsetStrategy(SeedreamAigc)
+export class SeedreamAigcStrategy implements IToolsetStrategy<any> {
+  meta = {
+    author: 'Xpert AI',
+    tags: ['image', 'video', 'aigc', 'seedream', 'seedance', 'volcengine'],
+    name: SeedreamAigc,
+    label: {
+      en_US: 'Seedream AIGC',
+      zh_Hans: '即梦 AIGC'
+    },
+    description: {
+      en_US: 'Generate and edit images and videos with Volcengine Ark Seedream and Seedance models.',
+      zh_Hans: '通过火山方舟即梦 Seedream 和 Seedance 模型生成、编辑图片和视频。'
+    },
+    icon: {
+      type: 'svg' as any,
+      value: SvgIcon,
+      color: '#006EFF'
+    },
+    configSchema: {
+      type: 'object',
+      properties: {
+        ark_api_key: {
+          type: 'string',
+          title: 'Volcengine API Key',
+          secret: true
+        },
+        api_endpoint_host: {
+          type: 'string',
+          title: 'API endpoint host',
+          default: 'https://ark.cn-beijing.volces.com/api/v3'
+        }
+      },
+      required: ['ark_api_key']
+    }
+  }
+
+  constructor(
+    @Optional()
+    @Inject(XPERT_RUNTIME_CAPABILITIES_TOKEN)
+    private readonly runtimeCapabilities?: RuntimeCapabilityRegistryLike
+  ) {}
+
+  async validateConfig(config: any): Promise<void> {
+    if (!config?.ark_api_key) {
+      throw new Error('Ark API key is missing')
+    }
+  }
+
+  async create(config: any, params?: TBuiltinToolsetParams): Promise<BuiltinToolset> {
+    return new SeedreamAigcToolset(config, this.runtimeCapabilities, params)
+  }
+
+  createTools(): any {
+    // plugin-sdk 3.9.1 still types tool schemas as Zod-only; Seedream image tools use LangChain-supported JSON Schema.
+    return buildSeedreamTools({
+      credentials: {},
+      workspaceFiles: {
+        uploadBuffer: async () => {
+          throw new Error('Xpert workspace file runtime capability is required for Seedream AIGC outputs.')
+        },
+        readBuffer: async () => {
+          throw new Error('Not implemented')
+        },
+        deleteFile: async () => {
+          throw new Error('Not implemented')
+        }
+      }
+    })
+  }
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/tools.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/tools.ts
@@ -1,0 +1,1035 @@
+import { tool } from '@langchain/core/tools'
+import { SeedreamArkClient } from './client.js'
+import { inputToBuffer, inputToDataUrl, enforceMaxBytes, createGeneratedFileName } from './assets.js'
+import { normalizeBoolean, normalizeString, normalizeVideoGenerationOptions, isSeedance2Model } from './rules.js'
+import { uploadGeneratedAsset } from './workspace-upload.js'
+import type { SeedreamArtifactFile, SeedreamToolDependencies, SeedreamToolResult } from './types.js'
+
+const IMAGE_FOLDER = 'files/seedream-aigc/images'
+const VIDEO_FOLDER = 'files/seedream-aigc/videos'
+const IMAGE_LIMIT_BYTES = 10 * 1024 * 1024
+const MULTIMODAL_IMAGE_LIMIT_BYTES = 30 * 1024 * 1024
+const AUDIO_LIMIT_BYTES = 15 * 1024 * 1024
+const MULTIMODAL_MODE_RULES: Record<string, { label: string; needImage: boolean; needVideo: boolean; needAudio: boolean }> = {
+  text_video: {
+    label: 'text(optional)+video',
+    needImage: false,
+    needVideo: true,
+    needAudio: false
+  },
+  text_image_audio: {
+    label: 'text(optional)+image+audio',
+    needImage: true,
+    needVideo: false,
+    needAudio: true
+  },
+  text_image_video: {
+    label: 'text(optional)+image+video',
+    needImage: true,
+    needVideo: true,
+    needAudio: false
+  },
+  text_video_audio: {
+    label: 'text(optional)+video+audio',
+    needImage: false,
+    needVideo: true,
+    needAudio: true
+  },
+  text_image_video_audio: {
+    label: 'text(optional)+image+video+audio',
+    needImage: true,
+    needVideo: true,
+    needAudio: true
+  }
+}
+
+export function buildSeedreamTools(deps: SeedreamToolDependencies) {
+  return [
+    buildTextToImageTool(deps),
+    buildImageToImageTool(deps),
+    buildMultiImagesToImageTool(deps),
+    buildMultiImagesToMultiImagesTool(deps),
+    buildTextToVideoTool(deps),
+    buildImageToVideoTool(deps),
+    buildFirstLastFrameToVideoTool(deps),
+    buildMultimodalReferenceToVideoTool(deps),
+    buildVideoQueryTool(deps)
+  ]
+}
+
+function buildTextToImageTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const prompt = requireString(input.prompt, 'Prompt is required')
+      const client = createClient(deps)
+      const response = await client.generateImages({
+        model: normalizeString(input.model) ?? 'doubao-seedream-4-5-251128',
+        prompt,
+        size: normalizeString(input.size) ?? '2048x2048',
+        sequential_image_generation: normalizeString(input.sequential_image_generation) ?? 'disabled',
+        stream: false,
+        response_format: 'url',
+        watermark: normalizeBoolean(input.watermark, true)
+      })
+      const files = await uploadImageOutputs(response, client, deps, 'seedream-text-to-image', 'url')
+      return result(`Generated ${files.length} image(s).`, files, { usage: response?.usage })
+    },
+    {
+      name: 'seedream_text_to_image',
+      description: 'Generate images from text descriptions using Volcengine Doubao Seedream models.',
+      schema: textToImageSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildImageToImageTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const prompt = requireString(input.prompt, 'Prompt is required')
+      const image = await encodeImageInput(input.input_image_file, deps, IMAGE_LIMIT_BYTES, 'input image')
+      const client = createClient(deps)
+      const response = await client.generateImages({
+        model: normalizeString(input.model) ?? 'doubao-seedream-4-5-251128',
+        prompt,
+        image,
+        size: normalizeString(input.size) ?? '2048x2048',
+        sequential_image_generation: normalizeString(input.sequential_image_generation) ?? 'disabled',
+        stream: false,
+        response_format: 'b64_json',
+        watermark: normalizeBoolean(input.watermark, true)
+      })
+      const files = await uploadImageOutputs(response, client, deps, 'seedream-image-to-image', 'b64_json')
+      return result(`Generated ${files.length} image(s).`, files, { usage: response?.usage })
+    },
+    {
+      name: 'seedream_image_to_image',
+      description: 'Generate images from text and one reference image using Volcengine Doubao Seedream models.',
+      schema: imageToImageSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildMultiImagesToImageTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const prompt = requireString(input.prompt, 'Prompt is required')
+      const images = await encodeImageInputs(input.input_image_files, deps, IMAGE_LIMIT_BYTES, 2, 14)
+      const client = createClient(deps)
+      const response = await client.generateImages({
+        model: normalizeString(input.model) ?? 'doubao-seedream-4-5-251128',
+        prompt,
+        image: images,
+        size: normalizeString(input.size) ?? '2048x2048',
+        sequential_image_generation: normalizeString(input.sequential_image_generation) ?? 'disabled',
+        response_format: 'b64_json',
+        watermark: normalizeBoolean(input.watermark, true)
+      })
+      const files = await uploadImageOutputs(response, client, deps, 'seedream-multi-images-to-image', 'b64_json')
+      return result(`Generated ${files.length} image(s).`, files, { usage: response?.usage })
+    },
+    {
+      name: 'seedream_multi_images_to_image',
+      description: 'Generate an image from text and multiple reference images using Volcengine Doubao Seedream models.',
+      schema: multiImagesToImageSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildMultiImagesToMultiImagesTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const prompt = requireString(input.prompt, 'Prompt is required')
+      const images = await encodeImageInputs(input.input_image_files, deps, IMAGE_LIMIT_BYTES, 2, 14)
+      const maxImages = clampNumber(input.max_images, 3, 1, 15)
+      const client = createClient(deps)
+      const response = await client.generateImages({
+        model: normalizeString(input.model) ?? 'doubao-seedream-4-5-251128',
+        prompt,
+        image: images,
+        size: normalizeString(input.size) ?? '2048x2048',
+        sequential_image_generation: 'auto',
+        sequential_image_generation_options: { max_images: maxImages },
+        response_format: 'b64_json',
+        watermark: normalizeBoolean(input.watermark, true)
+      })
+      const files = await uploadImageOutputs(response, client, deps, 'seedream-multi-images-to-multi-images', 'b64_json')
+      return result(`Generated ${files.length} image(s).`, files, { usage: response?.usage })
+    },
+    {
+      name: 'seedream_multi_images_to_multi_images',
+      description: 'Generate a group of images from text and multiple reference images using Volcengine Doubao Seedream models.',
+      schema: multiImagesToMultiImagesSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildTextToVideoTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const options = normalizeVideoGenerationOptions(input)
+      if (!options.prompt) throw new Error('Prompt is required')
+      const task = await createClient(deps).createVideoTask(createVideoPayload(options, [{ type: 'text', text: options.prompt }]))
+      return videoSubmittedResult(task, 'Text-to-video task submitted.')
+    },
+    {
+      name: 'seedance_text_to_video',
+      description: 'Submit a Seedance text-to-video generation task and return the task id.',
+      schema: textToVideoSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildImageToVideoTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const options = normalizeVideoGenerationOptions(input)
+      if (!options.prompt) throw new Error('Prompt is required')
+      const image = await encodeImageInput(input.input_image_file, deps, IMAGE_LIMIT_BYTES, 'input image')
+      const task = await createClient(deps).createVideoTask(
+        createVideoPayload(options, [
+          { type: 'text', text: options.prompt },
+          { type: 'image_url', image_url: { url: image } }
+        ])
+      )
+      return videoSubmittedResult(task, 'Image-to-video task submitted.')
+    },
+    {
+      name: 'seedance_image_to_video',
+      description: 'Submit a Seedance image-to-video generation task and return the task id.',
+      schema: imageToVideoSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildFirstLastFrameToVideoTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const options = normalizeVideoGenerationOptions(input)
+      if (!options.prompt) throw new Error('Prompt is required')
+      const firstFrame = await encodeImageInput(input.first_frame_file, deps, IMAGE_LIMIT_BYTES, 'first frame')
+      const lastFrame = await encodeImageInput(input.last_frame_file, deps, IMAGE_LIMIT_BYTES, 'last frame')
+      const task = await createClient(deps).createVideoTask(
+        createVideoPayload(options, [
+          { type: 'text', text: options.prompt },
+          { type: 'image_url', image_url: { url: firstFrame }, role: 'first_frame' },
+          { type: 'image_url', image_url: { url: lastFrame }, role: 'last_frame' }
+        ])
+      )
+      return videoSubmittedResult(task, 'First-last-frame video task submitted.')
+    },
+    {
+      name: 'seedance_first_last_frame_to_video',
+      description: 'Submit a Seedance video task from first and last frame images and return the task id.',
+      schema: firstLastFrameToVideoSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildMultimodalReferenceToVideoTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const options = normalizeVideoGenerationOptions({
+        ...input,
+        model: input.model ?? 'doubao-seedance-2-0-260128',
+        ratio: input.ratio ?? 'adaptive'
+      })
+      if (!isSeedance2Model(options.model)) {
+        throw new Error('Multimodal reference video only supports Seedance 2.0 models')
+      }
+      const mode = normalizeString(input.input_mode) ?? 'text_image_video'
+      const modeRule = MULTIMODAL_MODE_RULES[mode]
+      if (!modeRule) {
+        throw new Error('Invalid multimodal input mode')
+      }
+      const imageInputs = toArray(input.reference_image_files)
+      const videoUrls = parseUrlList(input.reference_video_urls)
+      const audioInputs = toArray(input.reference_audio_files)
+      validateMultimodalInputs(modeRule, imageInputs, videoUrls, audioInputs)
+      const content: Record<string, unknown>[] = []
+      if (options.prompt) {
+        content.push({ type: 'text', text: options.prompt })
+      }
+      for (const image of imageInputs) {
+        content.push({
+          type: 'image_url',
+          image_url: { url: await encodeImageInput(image, deps, MULTIMODAL_IMAGE_LIMIT_BYTES, 'reference image') },
+          role: 'reference_image'
+        })
+      }
+      for (const videoUrl of videoUrls) {
+        content.push({ type: 'video_url', video_url: { url: videoUrl }, role: 'reference_video' })
+      }
+      for (const audio of audioInputs) {
+        const dataUrl = await encodeAudioInput(audio, deps)
+        content.push({ type: 'audio_url', audio_url: { url: dataUrl }, role: 'reference_audio' })
+      }
+      const task = await createClient(deps).createVideoTask(createVideoPayload(options, content))
+      return videoSubmittedResult(task, 'Multimodal reference video task submitted.')
+    },
+    {
+      name: 'seedance_multimodal_reference_to_video',
+      description: 'Submit a Seedance 2.0 multimodal reference video task and return the task id.',
+      schema: multimodalReferenceToVideoSchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+function buildVideoQueryTool(deps: SeedreamToolDependencies) {
+  return tool(
+    async (input: any): Promise<SeedreamToolResult> => {
+      const taskId = requireString(input.task_id, 'Task id is required')
+      const downloadVideo = normalizeBoolean(input.download_video, true)
+      const client = createClient(deps)
+      const task = await client.getVideoTask(taskId)
+      const files: SeedreamArtifactFile[] = []
+      const videoUrl = task?.content?.video_url
+      if (downloadVideo && typeof videoUrl === 'string' && videoUrl) {
+        const { buffer, mimeType } = await client.downloadBuffer(videoUrl)
+        const resolvedMimeType = mimeType || 'video/mp4'
+        files.push(
+          await uploadGeneratedAsset({
+            workspaceFiles: deps.workspaceFiles,
+            workspaceScope: deps.workspaceScope,
+            buffer,
+            mimeType: resolvedMimeType,
+            folder: VIDEO_FOLDER,
+            fileName: `${task?.id ?? taskId}.mp4`,
+            metadata: {
+              source: 'ark_video_generation',
+              taskId: task?.id ?? taskId,
+              arkUrl: videoUrl
+            }
+          })
+        )
+      }
+      const resolvedTaskId = task?.id ?? taskId
+      const message = videoUrl
+        ? `Video task ${resolvedTaskId} status: ${task?.status ?? 'unknown'}.`
+        : `Video task ${resolvedTaskId} status: ${task?.status ?? 'unknown'}.\nNo video_url is available yet. Do not repeat seedance_video_query with the same task_id in this turn; report the current status and Task ID to the user.`
+      return result(message, files, {
+        task_id: resolvedTaskId,
+        status: task?.status,
+        video_url: videoUrl,
+        last_frame_url: task?.content?.last_frame_url,
+        model: task?.model,
+        error: task?.error,
+        usage: task?.usage
+      })
+    },
+    {
+      name: 'seedance_video_query',
+      description: 'Query a Seedance video generation task and upload the completed video to the workspace when available.',
+      schema: videoQuerySchema,
+      responseFormat: 'content_and_artifact'
+    }
+  )
+}
+
+const IMAGE_SIZE_OPTIONS = [
+  ['2048x2048', '1:1 (2048x2048)'],
+  ['2304x1728', '4:3 (2304x1728)'],
+  ['1728x2304', '3:4 (1728x2304)'],
+  ['2560x1440', '16:9 (2560x1440)'],
+  ['1440x2560', '9:16 (1440x2560)'],
+  ['2496x1664', '3:2 (2496x1664)'],
+  ['1664x2496', '2:3 (1664x2496)'],
+  ['3024x1296', '21:9 (3024x1296)']
+] as const
+
+const SEEDREAM_MODEL_OPTIONS = [
+  ['doubao-seedream-4-0-250828', 'Seedream4.0'],
+  ['doubao-seedream-4-5-251128', 'Seedream4.5'],
+  ['doubao-seedream-5-0-lite-260128', 'Seedream5.0 Lite']
+] as const
+
+const SEEDANCE_MODEL_OPTIONS = [
+  ['doubao-seedance-1-5-pro-251215', 'Seedance1.5 Pro'],
+  ['doubao-seedance-2-0-260128', 'Seedance2.0'],
+  ['doubao-seedance-2-0-fast-260128', 'Seedance2.0 Fast']
+] as const
+
+const SEEDANCE_2_MODEL_OPTIONS = [
+  ['doubao-seedance-2-0-260128', 'Seedance2.0'],
+  ['doubao-seedance-2-0-fast-260128', 'Seedance2.0 Fast']
+] as const
+
+const VIDEO_RESOLUTION_OPTIONS = [
+  ['480p', '480p'],
+  ['720p', '720p'],
+  ['1080p', '1080p']
+] as const
+
+const VIDEO_RATIO_OPTIONS = [
+  ['16:9', '16:9'],
+  ['9:16', '9:16'],
+  ['1:1', '1:1'],
+  ['4:3', '4:3'],
+  ['3:4', '3:4'],
+  ['adaptive', 'Adaptive']
+] as const
+
+const MULTIMODAL_INPUT_MODE_OPTIONS = [
+  ['text_video', 'text(optional)+video'],
+  ['text_image_audio', 'text(optional)+image+audio'],
+  ['text_image_video', 'text(optional)+image+video'],
+  ['text_video_audio', 'text(optional)+video+audio'],
+  ['text_image_video_audio', 'text(optional)+image+video+audio']
+] as const
+
+const SERVICE_TIER_OPTIONS = [
+  ['default', 'Default'],
+  ['flex', 'Flex']
+] as const
+
+function i18n(en_US: string, zh_Hans: string) {
+  return { en_US, zh_Hans }
+}
+
+function enumLabels(options: readonly (readonly [string, string])[]) {
+  return Object.fromEntries(options.map(([value, label]) => [value, label]))
+}
+
+const promptProperty = {
+  type: 'string',
+  title: 'Prompt',
+  description: 'Text description for image generation.',
+  'x-ui': {
+    title: i18n('Prompt', '提示词'),
+    description: i18n('Text description for image generation.', '您想要生成的图像文本描述')
+  }
+} as const
+
+const singleReferenceImageProperty = {
+  title: 'Reference image',
+  description: 'Reference image file, URL, path, Buffer, or data URL.',
+  'x-ui': {
+    title: i18n('Reference image', '参考图片'),
+    description: i18n(
+      'Reference image file, URL, path, Buffer, or data URL.',
+      '用于图像生成的参考图片文件、URL、路径、Buffer 或 data URL。'
+    )
+  }
+} as const
+
+const referenceImagesProperty = {
+  anyOf: [
+    {
+      type: 'array',
+      minItems: 2,
+      maxItems: 14,
+      items: {
+        anyOf: [
+          { type: 'string' },
+          { type: 'object' }
+        ]
+      }
+    },
+    { type: 'string' }
+  ],
+  title: 'Reference images',
+  description: 'Reference image files, URLs, paths, Buffers, or data URLs. Pass as an array, not a JSON string.',
+  'x-ui': {
+    title: i18n('Reference images', '参考图片列表'),
+    description: i18n(
+      'Reference image files, URLs, paths, Buffers, or data URLs. Pass as an array, not a JSON string.',
+      '用于图像生成的一组参考图片文件、URL、路径、Buffer 或 data URL。必须传数组，不要传 JSON 字符串。'
+    )
+  }
+} as const
+
+const sizeProperty = {
+  type: 'string',
+  title: 'Image size',
+  description: 'Generated image size.',
+  enum: IMAGE_SIZE_OPTIONS.map(([value]) => value),
+  default: '2048x2048',
+  'x-ui': {
+    title: i18n('Image size', '图像尺寸'),
+    description: i18n('Generated image size.', '生成图片的尺寸。'),
+    enumLabels: enumLabels(IMAGE_SIZE_OPTIONS)
+  }
+} as const
+
+const maxImagesProperty = {
+  type: 'integer',
+  title: 'Maximum generated images',
+  description: 'Maximum number of generated images, 1-15.',
+  minimum: 1,
+  maximum: 15,
+  default: 3,
+  'x-ui': {
+    title: i18n('Maximum generated images', '最大生成张数'),
+    description: i18n('Maximum number of generated images, 1-15.', '最多生成的图片数量，范围 1-15。')
+  }
+} as const
+
+const watermarkProperty = {
+  type: 'string',
+  title: 'Watermark',
+  description: 'Whether to add watermark.',
+  enum: ['true', 'false'],
+  default: 'true',
+  'x-ui': {
+    title: i18n('Watermark', '水印'),
+    description: i18n('Whether to add watermark.', '是否添加水印。'),
+    enumLabels: {
+      true: i18n('Enabled', '启用'),
+      false: i18n('Disabled', '禁用')
+    }
+  }
+} as const
+
+const modelProperty = {
+  type: 'string',
+  title: 'Model version',
+  description: 'Seedream model version.',
+  enum: SEEDREAM_MODEL_OPTIONS.map(([value]) => value),
+  default: 'doubao-seedream-4-5-251128',
+  'x-ui': {
+    title: i18n('Model version', '模型版本'),
+    description: i18n('Seedream model version.', '使用的 Seedream 模型版本。'),
+    enumLabels: enumLabels(SEEDREAM_MODEL_OPTIONS)
+  }
+} as const
+
+function imageSchema(properties: Record<string, unknown>, required = ['prompt']) {
+  return {
+    type: 'object',
+    properties,
+    required
+  } as const
+}
+
+const imageSettingsProperties = {
+  size: sizeProperty,
+  watermark: watermarkProperty,
+  model: modelProperty
+}
+
+const textToImageSchema = imageSchema({
+  prompt: promptProperty,
+  ...imageSettingsProperties
+})
+
+const imageToImageSchema = imageSchema({
+  prompt: promptProperty,
+  input_image_file: singleReferenceImageProperty,
+  ...imageSettingsProperties
+}, ['prompt', 'input_image_file'])
+
+const multiImagesToImageSchema = imageSchema({
+  prompt: promptProperty,
+  input_image_files: referenceImagesProperty,
+  ...imageSettingsProperties
+}, ['prompt', 'input_image_files'])
+
+const multiImagesToMultiImagesSchema = imageSchema({
+  prompt: promptProperty,
+  input_image_files: referenceImagesProperty,
+  size: sizeProperty,
+  max_images: maxImagesProperty,
+  watermark: watermarkProperty,
+  model: modelProperty
+}, ['prompt', 'input_image_files'])
+
+const videoPromptProperty = {
+  type: 'string',
+  title: 'Prompt',
+  description: 'Prompt for video generation, max 500 chars.',
+  'x-ui': {
+    title: i18n('Prompt', '提示词'),
+    description: i18n('Prompt for video generation, max 500 chars.', '视频生成提示词，最多 500 个字符。')
+  }
+} as const
+
+const seedanceModelProperty = {
+  type: 'string',
+  title: 'Model version',
+  description: 'Seedance model version.',
+  enum: SEEDANCE_MODEL_OPTIONS.map(([value]) => value),
+  default: 'doubao-seedance-1-5-pro-251215',
+  'x-ui': {
+    title: i18n('Model version', '模型版本'),
+    description: i18n('Seedance model version.', '使用的 Seedance 模型版本。'),
+    enumLabels: enumLabels(SEEDANCE_MODEL_OPTIONS)
+  }
+} as const
+
+const seedance2ModelProperty = {
+  ...seedanceModelProperty,
+  enum: SEEDANCE_2_MODEL_OPTIONS.map(([value]) => value),
+  default: 'doubao-seedance-2-0-260128',
+  'x-ui': {
+    ...seedanceModelProperty['x-ui'],
+    enumLabels: enumLabels(SEEDANCE_2_MODEL_OPTIONS)
+  }
+} as const
+
+const videoResolutionProperty = {
+  type: 'string',
+  title: 'Video resolution',
+  description: 'Video resolution.',
+  enum: VIDEO_RESOLUTION_OPTIONS.map(([value]) => value),
+  default: '720p',
+  'x-ui': {
+    title: i18n('Video resolution', '视频分辨率'),
+    description: i18n('Video resolution.', '生成视频的分辨率。'),
+    enumLabels: enumLabels(VIDEO_RESOLUTION_OPTIONS)
+  }
+} as const
+
+const videoRatioProperty = {
+  type: 'string',
+  title: 'Aspect ratio',
+  description: 'Video aspect ratio.',
+  enum: VIDEO_RATIO_OPTIONS.map(([value]) => value),
+  default: '16:9',
+  'x-ui': {
+    title: i18n('Aspect ratio', '画面比例'),
+    description: i18n('Video aspect ratio.', '生成视频的画面比例。'),
+    enumLabels: enumLabels(VIDEO_RATIO_OPTIONS)
+  }
+} as const
+
+const multimodalVideoRatioProperty = {
+  ...videoRatioProperty,
+  default: 'adaptive'
+} as const
+
+const videoDurationProperty = {
+  type: 'integer',
+  title: 'Duration',
+  description: 'Video duration in seconds.',
+  minimum: 2,
+  maximum: 15,
+  default: 5,
+  'x-ui': {
+    title: i18n('Duration', '视频时长'),
+    description: i18n('Video duration in seconds.', '生成视频的时长，单位为秒。')
+  }
+} as const
+
+const videoSeedProperty = {
+  type: 'integer',
+  title: 'Seed',
+  description: 'Random seed. Use -1 for a random seed.',
+  minimum: -1,
+  maximum: 4294967295,
+  'x-ui': {
+    title: i18n('Seed', '随机种子'),
+    description: i18n('Random seed. Use -1 for a random seed.', '随机种子。填写 -1 表示随机。')
+  }
+} as const
+
+function booleanSelectProperty(
+  title: string,
+  titleZh: string,
+  description: string,
+  descriptionZh: string,
+  defaultValue: 'true' | 'false'
+) {
+  return {
+    type: 'string',
+    title,
+    description,
+    enum: ['true', 'false'],
+    default: defaultValue,
+    'x-ui': {
+      title: i18n(title, titleZh),
+      description: i18n(description, descriptionZh),
+      enumLabels: {
+        true: i18n('Enabled', '启用'),
+        false: i18n('Disabled', '禁用')
+      }
+    }
+  } as const
+}
+
+const videoCommonProperties = {
+  prompt: videoPromptProperty,
+  model: seedanceModelProperty,
+  resolution: videoResolutionProperty,
+  ratio: videoRatioProperty,
+  duration: videoDurationProperty,
+  seed: videoSeedProperty,
+  camera_fixed: booleanSelectProperty('Fixed camera', '固定镜头', 'Whether to fix camera position.', '是否固定镜头位置。', 'false'),
+  watermark: booleanSelectProperty('Watermark', '水印', 'Whether to add watermark.', '是否添加水印。', 'true'),
+  generate_audio: booleanSelectProperty('Generate audio', '生成音频', 'Whether to generate synchronized audio.', '是否生成同步音频。', 'true'),
+  draft: booleanSelectProperty('Draft mode', '草稿模式', 'Whether to use draft mode.', '是否使用草稿模式。', 'false'),
+  return_last_frame: booleanSelectProperty('Return last frame', '返回尾帧', 'Whether to return last frame.', '是否返回尾帧。', 'false'),
+  service_tier: {
+    type: 'string',
+    title: 'Service tier',
+    description: 'Service tier.',
+    enum: SERVICE_TIER_OPTIONS.map(([value]) => value),
+    default: 'default',
+    'x-ui': {
+      title: i18n('Service tier', '服务档位'),
+      description: i18n('Service tier.', '视频生成服务档位。'),
+      enumLabels: enumLabels(SERVICE_TIER_OPTIONS)
+    }
+  }
+} as const
+
+const videoReferenceImageProperty = {
+  title: 'Reference image',
+  description: 'Reference image file, URL, path, Buffer, or data URL.',
+  'x-ui': {
+    title: i18n('Reference image', '参考图片'),
+    description: i18n(
+      'Reference image file, URL, path, Buffer, or data URL.',
+      '用于视频生成的参考图片文件、URL、路径、Buffer 或 data URL。'
+    )
+  }
+} as const
+
+const firstFrameProperty = {
+  title: 'First frame image',
+  description: 'First frame image file, URL, path, Buffer, or data URL.',
+  'x-ui': {
+    title: i18n('First frame image', '首帧图片'),
+    description: i18n(
+      'First frame image file, URL, path, Buffer, or data URL.',
+      '视频首帧图片文件、URL、路径、Buffer 或 data URL。'
+    )
+  }
+} as const
+
+const lastFrameProperty = {
+  title: 'Last frame image',
+  description: 'Last frame image file, URL, path, Buffer, or data URL.',
+  'x-ui': {
+    title: i18n('Last frame image', '尾帧图片'),
+    description: i18n(
+      'Last frame image file, URL, path, Buffer, or data URL.',
+      '视频尾帧图片文件、URL、路径、Buffer 或 data URL。'
+    )
+  }
+} as const
+
+const multimodalInputModeProperty = {
+  type: 'string',
+  title: 'Input mode',
+  description: 'Multimodal input combination.',
+  enum: MULTIMODAL_INPUT_MODE_OPTIONS.map(([value]) => value),
+  default: 'text_image_video',
+  'x-ui': {
+    title: i18n('Input mode', '输入模式'),
+    description: i18n('Multimodal input combination.', '多模态参考素材组合方式。'),
+    enumLabels: {
+      text_video: i18n('text(optional)+video', '文本(可选)+视频'),
+      text_image_audio: i18n('text(optional)+image+audio', '文本(可选)+图片+音频'),
+      text_image_video: i18n('text(optional)+image+video', '文本(可选)+图片+视频'),
+      text_video_audio: i18n('text(optional)+video+audio', '文本(可选)+视频+音频'),
+      text_image_video_audio: i18n('text(optional)+image+video+audio', '文本(可选)+图片+视频+音频')
+    }
+  }
+} as const
+
+const multimodalReferenceImagesProperty = {
+  type: 'array',
+  maxItems: 9,
+  items: {},
+  title: 'Reference images',
+  description: 'Reference images.',
+  'x-ui': {
+    title: i18n('Reference images', '参考图片'),
+    description: i18n('Reference images.', '视频生成参考图片，最多 9 张。')
+  }
+} as const
+
+const multimodalReferenceVideoUrlsProperty = {
+  type: 'string',
+  title: 'Reference video URLs',
+  description: 'Reference video URLs separated by comma or newline.',
+  'x-ui': {
+    title: i18n('Reference video URLs', '参考视频 URL'),
+    description: i18n(
+      'Reference video URLs separated by comma or newline.',
+      '参考视频 URL，可用英文逗号或换行分隔。'
+    )
+  }
+} as const
+
+const multimodalReferenceAudioFilesProperty = {
+  type: 'array',
+  maxItems: 3,
+  items: {},
+  title: 'Reference audio files',
+  description: 'Reference audio files.',
+  'x-ui': {
+    title: i18n('Reference audio files', '参考音频'),
+    description: i18n('Reference audio files.', '视频生成参考音频文件，最多 3 个。')
+  }
+} as const
+
+function videoObjectSchema(properties: Record<string, unknown>, required = ['prompt']) {
+  return {
+    type: 'object',
+    properties,
+    required
+  } as const
+}
+
+const textToVideoSchema = videoObjectSchema(videoCommonProperties)
+
+const imageToVideoSchema = videoObjectSchema({
+  ...videoCommonProperties,
+  input_image_file: videoReferenceImageProperty
+}, ['prompt', 'input_image_file'])
+
+const firstLastFrameToVideoSchema = videoObjectSchema({
+  ...videoCommonProperties,
+  first_frame_file: firstFrameProperty,
+  last_frame_file: lastFrameProperty
+}, ['prompt', 'first_frame_file', 'last_frame_file'])
+
+const multimodalReferenceToVideoSchema = videoObjectSchema({
+  ...videoCommonProperties,
+  model: seedance2ModelProperty,
+  ratio: multimodalVideoRatioProperty,
+  input_mode: multimodalInputModeProperty,
+  reference_image_files: multimodalReferenceImagesProperty,
+  reference_video_urls: multimodalReferenceVideoUrlsProperty,
+  reference_audio_files: multimodalReferenceAudioFilesProperty
+}, [])
+
+const videoTaskIdProperty = {
+  type: 'string',
+  title: 'Task ID',
+  description: 'The video generation task id.',
+  'x-ui': {
+    title: i18n('Task ID', '任务 ID'),
+    description: i18n('The video generation task id.', '视频生成任务 ID。')
+  }
+} as const
+
+const videoQuerySchema = videoObjectSchema({
+  task_id: videoTaskIdProperty,
+  download_video: booleanSelectProperty(
+    'Download video',
+    '下载视频',
+    'Whether to download and upload the video.',
+    '是否下载并上传视频。',
+    'true'
+  )
+}, ['task_id'])
+
+async function encodeImageInput(input: unknown, deps: SeedreamToolDependencies, limitBytes: number, label: string) {
+  const fetchImpl = deps.fetch ?? fetch
+  const { buffer } = await inputToBuffer(input, fetchImpl, 'image/png')
+  enforceMaxBytes(buffer, limitBytes, label)
+  return inputToDataUrl(input, fetchImpl, 'image/png')
+}
+
+async function encodeImageInputs(
+  input: unknown,
+  deps: SeedreamToolDependencies,
+  limitBytes: number,
+  minItems = 1,
+  maxItems = Number.MAX_SAFE_INTEGER
+) {
+  const items = toArray(input)
+  if (items.length < minItems) {
+    throw new Error(`At least ${minItems} input images are required`)
+  }
+  if (items.length > maxItems) {
+    throw new Error(`At most ${maxItems} input images are supported`)
+  }
+  return Promise.all(items.map((item, index) => encodeImageInput(item, deps, limitBytes, `input image ${index + 1}`)))
+}
+
+async function encodeAudioInput(input: unknown, deps: SeedreamToolDependencies) {
+  const fetchImpl = deps.fetch ?? fetch
+  const { buffer } = await inputToBuffer(input, fetchImpl, 'audio/mpeg')
+  enforceMaxBytes(buffer, AUDIO_LIMIT_BYTES, 'reference audio')
+  return inputToDataUrl(input, fetchImpl, 'audio/mpeg')
+}
+
+async function uploadImageOutputs(
+  response: any,
+  client: SeedreamArkClient,
+  deps: SeedreamToolDependencies,
+  filePrefix: string,
+  expectedFormat: 'url' | 'b64_json'
+) {
+  const data = Array.isArray(response?.data) ? response.data : []
+  if (!data.length) {
+    throw new Error('Ark API did not return generated image data')
+  }
+  const files: SeedreamArtifactFile[] = []
+  for (const [index, item] of data.entries()) {
+    let buffer: Buffer
+    let mimeType = 'image/png'
+    if (expectedFormat === 'url' && item?.url) {
+      const downloaded = await client.downloadBuffer(item.url)
+      buffer = downloaded.buffer
+      mimeType = downloaded.mimeType || mimeType
+    } else if (item?.b64_json) {
+      buffer = Buffer.from(item.b64_json, 'base64')
+    } else {
+      throw new Error(`Generated image ${index + 1} is missing ${expectedFormat}`)
+    }
+    const fileName = createGeneratedFileName(filePrefix, index, mimeType)
+    files.push(
+      await uploadGeneratedAsset({
+        workspaceFiles: deps.workspaceFiles,
+        workspaceScope: deps.workspaceScope,
+        buffer,
+        mimeType,
+        folder: IMAGE_FOLDER,
+        fileName,
+        metadata: {
+          source: 'ark_image_generation',
+          arkUrl: item?.url,
+          arkSize: item?.size
+        }
+      })
+    )
+  }
+  return files
+}
+
+function createVideoPayload(options: ReturnType<typeof normalizeVideoGenerationOptions>, content: Record<string, unknown>[]) {
+  const payload: Record<string, unknown> = {
+    model: options.model,
+    content,
+    resolution: options.resolution,
+    ratio: options.ratio,
+    duration: options.duration,
+    seed: options.seed,
+    watermark: options.watermark,
+    generate_audio: options.generate_audio,
+    draft: options.draft,
+    return_last_frame: options.return_last_frame
+  }
+  if (!options.isSeedance2) {
+    payload.camera_fixed = options.camera_fixed
+    payload.service_tier = options.service_tier
+  }
+  return payload
+}
+
+function videoSubmittedResult(task: any, message: string): SeedreamToolResult {
+  const taskId = task?.id
+  const content = taskId
+    ? `${message}\nTask ID: ${taskId}\nCall seedance_video_query once with this task_id to check completion and download the generated video.\nIf the task is not completed or no video_url is returned, stop and tell the user the task is still processing. Do not repeat the same query in this turn.`
+    : message
+  return result(content, [], {
+    task_id: task?.id,
+    status: task?.status ?? 'submitted',
+    model: task?.model
+  })
+}
+
+function result(message: string, files: SeedreamArtifactFile[], data?: Record<string, unknown>): SeedreamToolResult {
+  return [formatResultContent(message, files), { files, ...(data ? { data } : {}) }]
+}
+
+function formatResultContent(message: string, files: SeedreamArtifactFile[]) {
+  if (!files.length) {
+    return message
+  }
+
+  const fileLines = files
+    .map((file, index) => {
+      const url = file.fileUrl ?? file.url
+      if (!url) {
+        return `${index + 1}. ${file.fileName}`
+      }
+      return isImageFile(file)
+        ? `${index + 1}. ${file.fileName}: ${url}\n![${file.fileName}](${url})`
+        : `${index + 1}. ${file.fileName}: ${url}`
+    })
+    .join('\n')
+
+  return `${message}\n\nGenerated files:\n${fileLines}`
+}
+
+function isImageFile(file: SeedreamArtifactFile) {
+  return file.mimeType?.startsWith('image/')
+}
+
+function createClient(deps: SeedreamToolDependencies) {
+  return new SeedreamArkClient(deps.credentials, deps.fetch ?? fetch)
+}
+
+function requireString(value: unknown, message: string) {
+  const normalized = normalizeString(value)
+  if (!normalized) {
+    throw new Error(message)
+  }
+  return normalized
+}
+
+function clampNumber(value: unknown, fallback: number, min: number, max: number) {
+  const number = typeof value === 'number' && Number.isFinite(value) ? value : fallback
+  return Math.min(Math.max(number, min), max)
+}
+
+function toArray(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value
+  if (value === undefined || value === null || value === '') return []
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        if (Array.isArray(parsed)) return parsed
+      } catch {
+        // Treat invalid JSON strings as a single input below.
+      }
+    }
+  }
+  return [value]
+}
+
+function parseUrlList(value: unknown) {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && !!item.trim()).map((item) => item.trim())
+  }
+  if (typeof value !== 'string') {
+    return []
+  }
+  return value
+    .split(/[,\n]/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function validateMultimodalInputs(
+  modeRule: { label: string; needImage: boolean; needVideo: boolean; needAudio: boolean },
+  imageInputs: unknown[],
+  videoUrls: string[],
+  audioInputs: unknown[]
+) {
+  if (modeRule.needImage && !imageInputs.length) {
+    throw new Error(`${modeRule.label} requires at least one reference image`)
+  }
+  if (modeRule.needVideo && !videoUrls.length) {
+    throw new Error(`${modeRule.label} requires at least one reference video URL`)
+  }
+  if (modeRule.needAudio && !audioInputs.length) {
+    throw new Error(`${modeRule.label} requires at least one reference audio`)
+  }
+  if (imageInputs.length > 9) {
+    throw new Error('Reference images support at most 9 files')
+  }
+  if (videoUrls.length > 3) {
+    throw new Error('Reference video URLs support at most 3 values')
+  }
+  if (audioInputs.length > 3) {
+    throw new Error('Reference audios support at most 3 files')
+  }
+  if (modeRule.needAudio && !imageInputs.length && !videoUrls.length) {
+    throw new Error('Audio cannot be used alone; at least one image or video reference is required')
+  }
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/tools.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/tools.ts
@@ -1,6 +1,6 @@
 import { tool } from '@langchain/core/tools'
 import { SeedreamArkClient } from './client.js'
-import { inputToBuffer, inputToDataUrl, enforceMaxBytes, createGeneratedFileName } from './assets.js'
+import { inputToBuffer, bufferToDataUrl, enforceMaxBytes, createGeneratedFileName } from './assets.js'
 import { normalizeBoolean, normalizeString, normalizeVideoGenerationOptions, isSeedance2Model } from './rules.js'
 import { uploadGeneratedAsset } from './workspace-upload.js'
 import type { SeedreamArtifactFile, SeedreamToolDependencies, SeedreamToolResult } from './types.js'
@@ -825,9 +825,14 @@ const videoQuerySchema = videoObjectSchema({
 
 async function encodeImageInput(input: unknown, deps: SeedreamToolDependencies, limitBytes: number, label: string) {
   const fetchImpl = deps.fetch ?? fetch
-  const { buffer } = await inputToBuffer(input, fetchImpl, 'image/png')
+  const { buffer, mimeType } = await inputToBuffer(input, {
+    fetchImpl,
+    workspaceFiles: deps.workspaceFiles,
+    workspaceScope: deps.workspaceScope,
+    defaultMimeType: 'image/png'
+  })
   enforceMaxBytes(buffer, limitBytes, label)
-  return inputToDataUrl(input, fetchImpl, 'image/png')
+  return bufferToDataUrl(buffer, mimeType)
 }
 
 async function encodeImageInputs(
@@ -849,9 +854,14 @@ async function encodeImageInputs(
 
 async function encodeAudioInput(input: unknown, deps: SeedreamToolDependencies) {
   const fetchImpl = deps.fetch ?? fetch
-  const { buffer } = await inputToBuffer(input, fetchImpl, 'audio/mpeg')
+  const { buffer, mimeType } = await inputToBuffer(input, {
+    fetchImpl,
+    workspaceFiles: deps.workspaceFiles,
+    workspaceScope: deps.workspaceScope,
+    defaultMimeType: 'audio/mpeg'
+  })
   enforceMaxBytes(buffer, AUDIO_LIMIT_BYTES, 'reference audio')
-  return inputToDataUrl(input, fetchImpl, 'audio/mpeg')
+  return bufferToDataUrl(buffer, mimeType)
 }
 
 async function uploadImageOutputs(

--- a/xpertai/models/volcengine/src/seedream-aigc/toolset.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/toolset.ts
@@ -1,0 +1,55 @@
+import type { StructuredToolInterface, ToolSchemaBase } from '@langchain/core/tools'
+import { BuiltinToolset, type TBuiltinToolsetParams } from '@xpert-ai/plugin-sdk'
+import { buildSeedreamTools } from './tools.js'
+import {
+  SeedreamAigc,
+  SeedreamAigcWorkspaceCapability,
+  type RuntimeCapabilityRegistryLike,
+  type SeedreamAigcCredentials,
+  type WorkspaceFilesApi
+} from './types.js'
+
+export class SeedreamAigcToolset extends BuiltinToolset<StructuredToolInterface, SeedreamAigcCredentials> {
+  constructor(
+    toolset?: any,
+    private readonly runtimeCapabilities?: RuntimeCapabilityRegistryLike,
+    params?: TBuiltinToolsetParams
+  ) {
+    super(SeedreamAigc, toolset, params)
+  }
+
+  override async _validateCredentials(credentials: SeedreamAigcCredentials): Promise<void> {
+    if (!credentials?.ark_api_key) {
+      throw new Error('Ark API key is missing')
+    }
+  }
+
+  override async initTools(): Promise<StructuredToolInterface<ToolSchemaBase, any, any>[]> {
+    this.tools = buildSeedreamTools({
+      credentials: this.getCredentials() ?? {},
+      workspaceFiles: this.getWorkspaceFiles(),
+      workspaceScope: this.createWorkspaceScope()
+    })
+    return this.tools
+  }
+
+  private getWorkspaceFiles() {
+    const workspaceFiles = this.runtimeCapabilities?.get<WorkspaceFilesApi>(SeedreamAigcWorkspaceCapability)
+    if (!workspaceFiles) {
+      throw new Error('Xpert workspace file runtime capability is required for Seedream AIGC outputs.')
+    }
+    return workspaceFiles
+  }
+
+  private createWorkspaceScope() {
+    if (!this.xpertId) {
+      return undefined
+    }
+    return {
+      catalog: 'xperts' as const,
+      scopeId: this.xpertId,
+      xpertId: this.xpertId,
+      isolateByUser: false
+    }
+  }
+}

--- a/xpertai/models/volcengine/src/seedream-aigc/types.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/types.ts
@@ -1,0 +1,83 @@
+export const SeedreamAigc = 'seedream_aigc'
+export const SeedreamAigcWorkspaceCapability = 'platform.workspace.files'
+export const SeedreamAigcDefaultBaseUrl = 'https://ark.cn-beijing.volces.com/api/v3'
+
+export type SeedreamAigcCredentials = {
+  ark_api_key?: string
+  api_endpoint_host?: string
+}
+
+export type WorkspaceFileCatalog = 'projects' | 'users' | 'knowledges' | 'skills' | 'xperts'
+
+export type WorkspaceUploadBufferInput = {
+  tenantId?: string | null
+  userId?: string | null
+  catalog?: WorkspaceFileCatalog | null
+  scopeId?: string | null
+  projectId?: string | null
+  knowledgeId?: string | null
+  rootId?: string | null
+  xpertId?: string | null
+  isolateByUser?: boolean | null
+  buffer: Buffer
+  originalName: string
+  mimeType?: string | null
+  size?: number | null
+  folder?: string | null
+  fileName?: string | null
+  metadata?: Record<string, unknown>
+}
+
+export type WorkspaceFile = {
+  name: string
+  filePath: string
+  workspacePath: string
+  fileUrl?: string
+  url?: string
+  mimeType?: string
+  size?: number
+  catalog: WorkspaceFileCatalog
+  scopeId?: string
+  metadata?: Record<string, unknown>
+}
+
+export type WorkspaceFilesApi = {
+  uploadBuffer(input: WorkspaceUploadBufferInput): Promise<WorkspaceFile>
+  readBuffer(input: { filePath: string } & Record<string, unknown>): Promise<WorkspaceFile & { buffer: Buffer }>
+  deleteFile(input: { filePath: string } & Record<string, unknown>): Promise<void>
+}
+
+export type RuntimeCapabilityRegistryLike = {
+  get<T>(key: string): T | undefined
+  require?<T>(key: string): T
+}
+
+export type SeedreamWorkspaceScope = Omit<WorkspaceUploadBufferInput, 'buffer' | 'originalName'> & {
+  catalog?: WorkspaceFileCatalog | null
+}
+
+export type SeedreamToolDependencies = {
+  credentials: SeedreamAigcCredentials
+  workspaceFiles: WorkspaceFilesApi
+  workspaceScope?: SeedreamWorkspaceScope
+  fetch?: typeof fetch
+}
+
+export type SeedreamArtifactFile = {
+  fileName: string
+  filePath: string
+  workspacePath: string
+  fileUrl?: string
+  url?: string
+  mimeType: string
+  size?: number
+  extension: string
+  provider: typeof SeedreamAigc
+}
+
+export type SeedreamToolArtifact = {
+  files: SeedreamArtifactFile[]
+  data?: Record<string, unknown>
+}
+
+export type SeedreamToolResult = [string, SeedreamToolArtifact]

--- a/xpertai/models/volcengine/src/seedream-aigc/workspace-upload.ts
+++ b/xpertai/models/volcengine/src/seedream-aigc/workspace-upload.ts
@@ -1,0 +1,63 @@
+import {
+  SeedreamAigc,
+  type SeedreamArtifactFile,
+  type SeedreamWorkspaceScope,
+  type WorkspaceFile,
+  type WorkspaceFilesApi
+} from './types.js'
+
+type UploadGeneratedAssetInput = {
+  workspaceFiles: WorkspaceFilesApi
+  workspaceScope?: SeedreamWorkspaceScope
+  buffer: Buffer
+  mimeType: string
+  folder: string
+  fileName: string
+  originalName?: string
+  metadata?: Record<string, unknown>
+}
+
+export async function uploadGeneratedAsset(input: UploadGeneratedAssetInput): Promise<SeedreamArtifactFile> {
+  const uploaded = await input.workspaceFiles.uploadBuffer({
+    ...input.workspaceScope,
+    buffer: input.buffer,
+    originalName: input.originalName ?? input.fileName,
+    mimeType: input.mimeType,
+    size: input.buffer.length,
+    folder: input.folder,
+    fileName: input.fileName,
+    metadata: {
+      provider: SeedreamAigc,
+      ...input.metadata
+    }
+  })
+  return toArtifactFile(uploaded, input.fileName, input.mimeType)
+}
+
+export function toArtifactFile(file: WorkspaceFile, fileName: string, mimeType: string): SeedreamArtifactFile {
+  return {
+    fileName,
+    filePath: file.filePath,
+    workspacePath: file.workspacePath ?? file.filePath,
+    ...(file.fileUrl ? { fileUrl: file.fileUrl } : {}),
+    ...(file.url ? { url: file.url } : {}),
+    mimeType: file.mimeType ?? mimeType,
+    size: file.size,
+    extension: extensionFromFileName(fileName),
+    provider: SeedreamAigc
+  }
+}
+
+export function extensionFromMimeType(mimeType: string) {
+  if (mimeType === 'image/jpeg') return 'jpg'
+  if (mimeType === 'image/webp') return 'webp'
+  if (mimeType === 'video/mp4') return 'mp4'
+  if (mimeType === 'audio/mpeg') return 'mp3'
+  if (mimeType.startsWith('image/')) return mimeType.slice('image/'.length) || 'png'
+  if (mimeType.startsWith('video/')) return mimeType.slice('video/'.length) || 'mp4'
+  return 'bin'
+}
+
+function extensionFromFileName(fileName: string) {
+  return fileName.split('.').pop()?.toLowerCase() || 'bin'
+}

--- a/xpertai/models/volcengine/src/volcengine.spec.ts
+++ b/xpertai/models/volcengine/src/volcengine.spec.ts
@@ -1,7 +1,7 @@
-import { volcengine } from './volcengine'
+import { Volcengine } from './types.js'
 
 describe('volcengine', () => {
   it('should work', () => {
-    expect(volcengine()).toEqual('volcengine')
+    expect(Volcengine).toEqual('volcengine')
   })
 })

--- a/xpertai/models/volcengine/src/volcengine.ts
+++ b/xpertai/models/volcengine/src/volcengine.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import chalk from 'chalk';
 import { VolcengineProviderStrategy } from './provider.strategy.js';
 import { VolcengineLargeLanguageModel } from './llm/llm.js';
+import { SeedreamAigcStrategy } from './seedream-aigc/strategy.js';
 
 @XpertServerPlugin({
 	/**
@@ -12,7 +13,8 @@ import { VolcengineLargeLanguageModel } from './llm/llm.js';
 
 	providers: [
 		VolcengineProviderStrategy,
-		VolcengineLargeLanguageModel
+		VolcengineLargeLanguageModel,
+		SeedreamAigcStrategy
 	]
 })
 export class VolcenginePlugin implements IOnPluginBootstrap, IOnPluginDestroy {

--- a/xpertai/pnpm-lock.yaml
+++ b/xpertai/pnpm-lock.yaml
@@ -2177,6 +2177,9 @@ importers:
 
   models/volcengine:
     dependencies:
+      '@langchain/core':
+        specifier: 0.3.72
+        version: 0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.21.0)(zod@3.25.67))
       '@langchain/openai':
         specifier: 0.6.9
         version: 0.6.9(@langchain/core@0.3.72(@opentelemetry/api@1.9.0)(openai@5.12.2(ws@8.21.0)(zod@3.25.67)))(ws@8.21.0)


### PR DESCRIPTION
## Summary

Adds a Volcengine Seedream AIGC toolset for image and video generation workflows. The new toolset registers under the Volcengine plugin and exposes Seedream/Seedance tools for text-to-image, image-to-image, multi-image generation, text/image/reference video submission, and single-shot video task querying.

## Changes

- Register `SeedreamAigcStrategy` in the Volcengine plugin providers.
- Add Seedream Ark client, tool schemas, runtime upload helpers, model/option normalization rules, and workspace artifact formatting.
- Add localized `x-ui` metadata and defaults for host-side tool configuration rendering.
- Add tests covering schema defaults, workspace upload scope, image/video tool behavior, task id guidance, single-query pending behavior, and completed video download/upload.
- Add a patch changeset for `@xpert-ai/plugin-volcengine`.

## Validation

- `NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-volcengine --skipNxCache`
- `pnpm -C xpertai exec tsc -p models/volcengine/tsconfig.spec.json --noEmit`
- In the clean PR worktree, direct validation using the existing local toolchain:
  - `/Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/node_modules/.bin/tsc --build tsconfig.lib.json`
  - `/Users/jiangyimin/Documents/Git/xpert-plugins/xpertai/node_modules/.bin/tsc -p models/volcengine/tsconfig.spec.json --noEmit`
  - Seedream strategy schema smoke check against built `dist`
- `git diff --check`

## Notes

No `pnpm-lock.yaml` change is included. Regenerating the lockfile in a fresh worktree is currently blocked by the repository's existing workspace dependency issue: `@xpert-ai/contracts@workspace:*` is referenced but no workspace package named `@xpert-ai/contracts` is present. The new `@langchain/core` entry is a peer dependency and the repository lockfile already contains that package for existing workspace consumers.