### PR TITLE
[codex] Mark DingTalk plugin as system level

### DIFF
--- a/xpertai/.changeset/dingtalk-system-level.md
+++ b/xpertai/.changeset/dingtalk-system-level.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-dingtalk": patch
+---
+
+Mark the DingTalk integration plugin as system-level to align its installation scope with WeCom.

--- a/xpertai/integrations/dingtalk/package.json
+++ b/xpertai/integrations/dingtalk/package.json
@@ -54,5 +54,10 @@
     "date-fns": "^3.0.4",
     "rxjs": "^7.8.1",
     "@langchain/langgraph": "0.4.7"
+  },
+  "xpert": {
+    "plugin": {
+      "level": "system"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Mark `@xpert-ai/plugin-dingtalk` as a system-level plugin, matching WeCom's plugin metadata.
- Add a patch changeset for the DingTalk plugin release metadata.

## Root Cause
DingTalk did not declare `xpert.plugin.level = "system"` in its package metadata, while WeCom already did. That meant DingTalk could be treated with the default plugin scope instead of the intended system-level scope.

## Validation
- `node -e` metadata and changeset assertion
- `git diff --check -- xpertai/integrations/dingtalk/package.json xpertai/.changeset/dingtalk-system-level.md`
- `pnpm -C plugin-dev-harness build`
- `./node_modules/.bin/nx build @xpert-ai/plugin-dingtalk`
- `node plugin-dev-harness/dist/index.js --workspace ./xpertai --plugin @xpert-ai/plugin-dingtalk`