### PR TITLE
[codex] Sync xpertai pnpm lock overrides

### DIFF
--- a/xpertai/pnpm-lock.yaml
+++ b/xpertai/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@xpert-ai/plugin-sdk@3.12.1>@xpert-ai/contracts': 3.12.1
+  i18next: 25.6.0
+  i18next-fs-backend: 2.6.0
 
 importers:
 


### PR DESCRIPTION
## Summary
- Update `xpertai/pnpm-lock.yaml` so its top-level `overrides` snapshot matches `xpertai/package.json`.
- Keep the fix scoped to the lockfile configuration mismatch that blocked the `Version Or Publish (xpertai)` workflow.

## Root Cause
`xpertai/package.json` now declares overrides for `i18next` and `i18next-fs-backend`, but `xpertai/pnpm-lock.yaml` still recorded the older `@xpert-ai/plugin-sdk@3.12.1>@xpert-ai/contracts` override. The release workflow runs `pnpm -C xpertai install --frozen-lockfile`, and pnpm 9 rejects that mismatch before later release steps can run.

## Validation
- Red check: local overrides consistency assertion failed before the lockfile update with the same package-vs-lock mismatch.
- Green check: local overrides consistency assertion passes after the lockfile update.
- `git diff --check -- xpertai/pnpm-lock.yaml`
- `pnpm -C xpertai install --frozen-lockfile --ignore-scripts` with local pnpm 11.7.0 passes. Note: GitHub Actions uses pnpm 9, so the key CI-specific validation is the package-vs-lock overrides consistency check.