### PR TITLE
[codex] Add pnpm 9 overrides config for xpertai

### DIFF
--- a/xpertai/package.json
+++ b/xpertai/package.json
@@ -95,6 +95,12 @@
     "i18next": "25.6.0",
     "i18next-fs-backend": "2.6.0"
   },
+  "pnpm": {
+    "overrides": {
+      "i18next": "25.6.0",
+      "i18next-fs-backend": "2.6.0"
+    }
+  },
   "nx": {
     "includedScripts": [],
     "targets": {


### PR DESCRIPTION
## Summary
- Add `pnpm.overrides` in `xpertai/package.json` with the same override values as the top-level `overrides` field.
- Keep `xpertai/pnpm-lock.yaml` unchanged from PR #350, where its lockfile override snapshot was already updated.

## Root Cause
The release workflow still installs xpertai with pnpm 9: `pnpm -C xpertai install --frozen-lockfile`. pnpm 9 reads `pnpm.overrides`, not the top-level `overrides` field used by newer pnpm versions. After PR #350, the lockfile recorded the top-level override values, but pnpm 9 still saw no current overrides and continued to fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`.

## Validation
- Reproduced the failure locally with `CI=true pnpm dlx pnpm@9.15.9 -C xpertai install --frozen-lockfile --ignore-scripts` before this patch.
- Verified the pnpm 9 lockfile/config check passes with `CI=true pnpm dlx pnpm@9.15.9 -C xpertai install --frozen-lockfile --ignore-scripts --lockfile-only`.
- Verified top-level `overrides`, `pnpm.overrides`, and `pnpm-lock.yaml` overrides are identical with a local Node assertion.
- `git diff --check -- xpertai/package.json`