### PR TITLE
[codex] Remove stale xpertai lockfile overrides

### DIFF
--- a/xpertai/pnpm-lock.yaml
+++ b/xpertai/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  i18next: 25.6.0
-  i18next-fs-backend: 2.6.0
-
 importers:
 
   .:


### PR DESCRIPTION
## Summary
- Remove the stale top-level `overrides` block from `xpertai/pnpm-lock.yaml`.
- Keep `xpertai/package.json`, `xpertai/pnpm-workspace.yaml`, and workflow configuration unchanged.

## Root Cause
The `Version Or Publish (xpertai)` workflow installs with pnpm 9. On the latest `main`, pnpm 9 reports no active overrides for this workspace, while `xpertai/pnpm-lock.yaml` still records an `overrides` snapshot for `i18next` and `i18next-fs-backend`. That mismatch causes `pnpm -C xpertai install --frozen-lockfile` to fail before release steps run.

## Validation
- Latest `origin/main` reproduced the failure with `CI=true pnpm dlx pnpm@9.15.9 -C xpertai install --frozen-lockfile --ignore-scripts --lockfile-only`.
- After removing the lockfile `overrides` block, the same pnpm 9 frozen lockfile-only command passes.
- `git diff --check -- xpertai/pnpm-lock.yaml` passes.
- Staged diff contains only `xpertai/pnpm-lock.yaml`.