### PR TITLE
feat(wechat): support intermediate agent callback text

### DIFF
--- a/community/.changeset/witty-pears-brush.md
+++ b/community/.changeset/witty-pears-brush.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-community-wechat": patch
+---
+
+wechat

--- a/community/integrations/wechat/src/lib/conversation.service.spec.ts
+++ b/community/integrations/wechat/src/lib/conversation.service.spec.ts
@@ -494,7 +494,36 @@ describe('WechatConversationService fresh session history context', () => {
       expect.objectContaining({
         accountUuid: 'uuid-1',
         historyContext: '[历史上下文]',
-        currentInboundLogIds: ['inbound-log-1']
+        currentInboundLogIds: ['inbound-log-1'],
+        integrationOptions: {
+          agentCallbackIntermediateTextEnabled: false
+        }
+      })
+    )
+  })
+
+  it('passes the intermediate callback option from integration config to the trigger strategy', async () => {
+    const { service, triggerStrategy } = createFullService({
+      integration: {
+        options: {
+          agentCallbackIntermediateTextEnabled: true
+        }
+      }
+    })
+
+    await expect(
+      service.handleInboundEvent(baseEvent, {
+        integration: { id: 'integration-1' },
+        tenantId: 'tenant-1',
+        organizationId: 'org-1'
+      } as any)
+    ).resolves.toEqual({ handled: true, reason: 'dispatched' })
+
+    expect(triggerStrategy.handleInboundMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationOptions: {
+          agentCallbackIntermediateTextEnabled: true
+        }
       })
     )
   })

--- a/community/integrations/wechat/src/lib/conversation.service.ts
+++ b/community/integrations/wechat/src/lib/conversation.service.ts
@@ -584,7 +584,10 @@ export class WechatConversationService {
         currentInboundLogIds: [inboundLog.id],
         tenantId: integration.tenantId || ctx.tenantId,
         organizationId: integration.organizationId || ctx.organizationId,
-        endUserId: conversationIdentity.senderId
+        endUserId: conversationIdentity.senderId,
+        integrationOptions: {
+          agentCallbackIntermediateTextEnabled: integration.options?.agentCallbackIntermediateTextEnabled === true
+        }
       })
       const handleResult = this.normalizeInboundHandleResult(handled)
 

--- a/community/integrations/wechat/src/lib/handoff/wechat-chat-callback.processor.spec.ts
+++ b/community/integrations/wechat/src/lib/handoff/wechat-chat-callback.processor.spec.ts
@@ -142,6 +142,295 @@ describe('WechatChatCallbackProcessor', () => {
     await expect(runStateService.get(sourceMessageId)).resolves.toBeNull()
   })
 
+  it('keeps default final_text strategy from sending intermediate message text', async () => {
+    const { processor, wechatChannel } = createProcessor()
+    const sourceMessageId = 'wechat-chat-run-final-only'
+
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 1,
+          context,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'text', id: 'stream-1', text: '我先查一下。' }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 2,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'component', data: { name: 'wechat_search_chat_history' } }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process({ payload: { kind: 'complete', sourceMessageId, sequence: 3 } } as any, {} as any)
+
+    expect(wechatChannel.sendTextByIntegrationId).not.toHaveBeenCalled()
+    expect(wechatChannel.sendReplyByIntegrationId).toHaveBeenCalledWith(
+      'integration-1',
+      expect.objectContaining({
+        content: '我先查一下。'
+      })
+    )
+  })
+
+  it('sends visible assistant text before a tool boundary as an intermediate WeChat text message', async () => {
+    const { processor, wechatChannel, runStateService } = createProcessor()
+    const sourceMessageId = 'wechat-chat-run-intermediate'
+    const intermediateContext = {
+      ...context,
+      responseStrategy: 'intermediate_text' as const
+    }
+
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 1,
+          context: intermediateContext,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'text', id: 'stream-1', text: '我先查一下。' }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 2,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'component', data: { name: 'wechat_search_chat_history' } }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 3,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'text', id: 'stream-2', text: '查到了结果。' }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 4,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.EVENT,
+              event: ChatMessageEventTypeEnum.ON_MESSAGE_END,
+              data: {
+                content: '我先查一下。查到了结果。'
+              }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process({ payload: { kind: 'complete', sourceMessageId, sequence: 5 } } as any, {} as any)
+
+    expect(wechatChannel.sendTextByIntegrationId).toHaveBeenCalledTimes(1)
+    expect(wechatChannel.sendTextByIntegrationId).toHaveBeenCalledWith('integration-1', {
+      uuid: 'uuid-1',
+      contactId: 'wxid_friend',
+      content: '我先查一下。',
+      context: expect.objectContaining({
+        responseStrategy: 'intermediate_text'
+      }),
+      source: 'agent_callback',
+      idempotencyKey: `${sourceMessageId}:intermediate:1`
+    })
+    expect(wechatChannel.sendReplyByIntegrationId).toHaveBeenCalledWith('integration-1', {
+      uuid: 'uuid-1',
+      contactId: 'wxid_friend',
+      content: '查到了结果。',
+      context: expect.objectContaining({
+        responseStrategy: 'intermediate_text'
+      }),
+      source: 'agent_callback'
+    })
+    await expect(runStateService.get(sourceMessageId)).resolves.toBeNull()
+  })
+
+  it('does not resend an intermediate segment for duplicate callback sequences', async () => {
+    const { processor, wechatChannel } = createProcessor()
+    const sourceMessageId = 'wechat-chat-run-intermediate-duplicate'
+    const intermediateContext = {
+      ...context,
+      responseStrategy: 'intermediate_text' as const
+    }
+    const toolBoundaryPayload = {
+      kind: 'stream',
+      sourceMessageId,
+      sequence: 2,
+      event: {
+        data: {
+          type: ChatMessageTypeEnum.MESSAGE,
+          data: { type: 'component', data: { name: 'tool' } }
+        }
+      }
+    }
+
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 1,
+          context: intermediateContext,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'text', id: 'stream-1', text: '处理中。' }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process({ payload: toolBoundaryPayload } as any, {} as any)
+    await processor.process({ payload: toolBoundaryPayload } as any, {} as any)
+
+    expect(wechatChannel.sendTextByIntegrationId).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not send reasoning or component-only payloads as intermediate text', async () => {
+    const { processor, wechatChannel } = createProcessor()
+    const sourceMessageId = 'wechat-chat-run-intermediate-non-text'
+    const intermediateContext = {
+      ...context,
+      responseStrategy: 'intermediate_text' as const
+    }
+
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 1,
+          context: intermediateContext,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: [
+                { type: 'reasoning', id: 'reasoning-1', text: '内部推理' },
+                { type: 'component', data: { name: 'tool' } }
+              ]
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process({ payload: { kind: 'complete', sourceMessageId, sequence: 2 } } as any, {} as any)
+
+    expect(wechatChannel.sendTextByIntegrationId).not.toHaveBeenCalled()
+    expect(wechatChannel.sendReplyByIntegrationId).not.toHaveBeenCalled()
+  })
+
+  it('logs directly sent intermediate text when the queue is disabled', async () => {
+    const { processor, wechatChannel, conversationService } = createProcessor()
+    const sourceMessageId = 'wechat-chat-run-intermediate-direct'
+    const intermediateContext = {
+      ...context,
+      responseStrategy: 'intermediate_text' as const
+    }
+    ;(wechatChannel.sendTextByIntegrationId as jest.Mock).mockResolvedValueOnce({
+      success: true,
+      queued: false,
+      messageId: 'intermediate-1'
+    })
+
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 1,
+          context: intermediateContext,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.MESSAGE,
+              data: { type: 'text', id: 'stream-1', text: '马上处理。' }
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process(
+      {
+        payload: {
+          kind: 'stream',
+          sourceMessageId,
+          sequence: 2,
+          event: {
+            data: {
+              type: ChatMessageTypeEnum.EVENT,
+              event: ChatMessageEventTypeEnum.ON_TOOL_START
+            }
+          }
+        }
+      } as any,
+      {} as any
+    )
+    await processor.process({ payload: { kind: 'complete', sourceMessageId, sequence: 3 } } as any, {} as any)
+
+    expect(conversationService.logOutbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: '马上处理。',
+        status: 'sent',
+        messageId: 'intermediate-1',
+        payloadSummary: JSON.stringify({
+          type: 'text',
+          source: 'agent_callback',
+          phase: 'intermediate',
+          idempotencyKey: `${sourceMessageId}:intermediate:1`
+        })
+      })
+    )
+    expect(wechatChannel.sendReplyByIntegrationId).not.toHaveBeenCalled()
+  })
+
   it('logs every directly sent mixed reply part when the queue is disabled', async () => {
     const { processor, wechatChannel, conversationService } = createProcessor()
     const sourceMessageId = 'wechat-chat-run-2'

--- a/community/integrations/wechat/src/lib/handoff/wechat-chat-callback.processor.ts
+++ b/community/integrations/wechat/src/lib/handoff/wechat-chat-callback.processor.ts
@@ -22,6 +22,13 @@ type MessageTextContent = {
   id?: unknown
 }
 
+const TOOL_BOUNDARY_EVENTS = new Set<string>([
+  ChatMessageEventTypeEnum.ON_TOOL_START,
+  ChatMessageEventTypeEnum.ON_TOOL_END,
+  ChatMessageEventTypeEnum.ON_TOOL_ERROR,
+  ChatMessageEventTypeEnum.ON_TOOL_MESSAGE
+])
+
 function getTextStreamId(content: unknown): string | undefined {
   if (!content || typeof content !== 'object') {
     return undefined
@@ -75,6 +82,34 @@ function filterText(content: unknown): string | null {
   }
 
   return filterTextItem(content) || null
+}
+
+function isReasoningContent(content: unknown): boolean {
+  return !!content && typeof content === 'object' && (content as MessageTextContent).type === 'reasoning'
+}
+
+function isBoundaryContent(content: unknown): boolean {
+  if (!content || typeof content !== 'object') {
+    return false
+  }
+  const type = (content as MessageTextContent).type
+  return type !== 'text' && type !== 'reasoning'
+}
+
+function appendStreamText(
+  accumulator: string,
+  incoming: string,
+  previousStreamId?: string,
+  streamId?: string
+): string {
+  return appendPlainText(accumulator, incoming, !streamId || !previousStreamId || previousStreamId === streamId)
+}
+
+function removeTrailingText(value: string, suffix: string): string {
+  if (!value || !suffix) {
+    return value || ''
+  }
+  return value.endsWith(suffix) ? value.slice(0, value.length - suffix.length) : value
 }
 
 @Injectable()
@@ -169,6 +204,18 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
     if (typeof state.responseMessageContent !== 'string') {
       state.responseMessageContent = ''
     }
+    if (typeof state.pendingFinalTextContent !== 'string') {
+      state.pendingFinalTextContent = ''
+    }
+    if (typeof state.currentTextSegmentContent !== 'string') {
+      state.currentTextSegmentContent = ''
+    }
+    if (typeof state.sentIntermediateTextContent !== 'string') {
+      state.sentIntermediateTextContent = ''
+    }
+    if (!state.nextIntermediateSegmentIndex || state.nextIntermediateSegmentIndex <= 0) {
+      state.nextIntermediateSegmentIndex = 1
+    }
     if (!state.runCreatedAt || state.runCreatedAt <= 0) {
       state.runCreatedAt = Date.now()
     }
@@ -183,6 +230,11 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
       sourceMessageId,
       nextSequence: 1,
       responseMessageContent: '',
+      pendingFinalTextContent: '',
+      currentTextSegmentContent: '',
+      sentIntermediateTextContent: '',
+      nextIntermediateSegmentIndex: 1,
+      hasIntermediateTextSent: false,
       finalMessageContent: undefined,
       terminalError: undefined,
       runCreatedAt: Date.now(),
@@ -209,7 +261,7 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
 
       switch (payload.kind) {
         case 'stream': {
-          this.applyStreamEvent(state, payload.event)
+          await this.applyStreamEvent(state, payload.event)
           break
         }
         case 'complete': {
@@ -233,16 +285,20 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
     }
   }
 
-  private applyStreamEvent(state: WechatChatRunState, event: unknown): void {
+  private async applyStreamEvent(state: WechatChatRunState, event: unknown): Promise<void> {
     const eventPayload = (event as { data?: any } | undefined)?.data
     if (!eventPayload) {
       return
     }
 
     if (eventPayload.type === ChatMessageTypeEnum.MESSAGE) {
-      const text = filterText(eventPayload.data) ?? ''
-      if (text) {
-        state.responseMessageContent += text
+      if (this.isIntermediateTextStrategy(state)) {
+        await this.applyIntermediateMessageContent(state, eventPayload.data)
+      } else {
+        const text = filterText(eventPayload.data) ?? ''
+        if (text) {
+          state.responseMessageContent += text
+        }
       }
       return
     }
@@ -256,6 +312,10 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
       state.context.conversationId = conversationId
     }
 
+    if (this.isIntermediateTextStrategy(state) && TOOL_BOUNDARY_EVENTS.has(String(eventPayload.event))) {
+      await this.flushIntermediateTextSegment(state, String(eventPayload.event))
+    }
+
     if (eventPayload.event === ChatMessageEventTypeEnum.ON_MESSAGE_END) {
       const finalText = this.extractFinalMessageText(eventPayload)
       if (finalText) {
@@ -264,10 +324,124 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
     }
   }
 
+  private async applyIntermediateMessageContent(state: WechatChatRunState, content: unknown): Promise<void> {
+    if (Array.isArray(content)) {
+      for (const item of content) {
+        await this.applyIntermediateMessageContent(state, item)
+      }
+      return
+    }
+
+    if (isReasoningContent(content)) {
+      return
+    }
+
+    const text = filterTextItem(content)
+    if (text) {
+      await this.appendIntermediateText(state, text, getTextStreamId(content))
+      return
+    }
+
+    if (isBoundaryContent(content)) {
+      await this.flushIntermediateTextSegment(state, 'component')
+    }
+  }
+
+  private async appendIntermediateText(
+    state: WechatChatRunState,
+    text: string,
+    streamId?: string
+  ): Promise<void> {
+    if (
+      streamId &&
+      state.currentTextSegmentStreamId &&
+      state.currentTextSegmentStreamId !== streamId &&
+      this.normalizeFinalText(state.currentTextSegmentContent || '')
+    ) {
+      await this.flushIntermediateTextSegment(state, 'stream_switch')
+    }
+
+    state.responseMessageContent = appendStreamText(
+      state.responseMessageContent,
+      text,
+      state.responseTextStreamId,
+      streamId
+    )
+    if (streamId) {
+      state.responseTextStreamId = streamId
+    }
+
+    state.pendingFinalTextContent = appendStreamText(
+      state.pendingFinalTextContent || '',
+      text,
+      state.pendingFinalTextStreamId,
+      streamId
+    )
+    if (streamId) {
+      state.pendingFinalTextStreamId = streamId
+    }
+
+    state.currentTextSegmentContent = appendStreamText(
+      state.currentTextSegmentContent || '',
+      text,
+      state.currentTextSegmentStreamId,
+      streamId
+    )
+    if (streamId) {
+      state.currentTextSegmentStreamId = streamId
+    }
+  }
+
+  private async flushIntermediateTextSegment(state: WechatChatRunState, reason: string): Promise<void> {
+    const context = state.context
+    const rawText = state.currentTextSegmentContent || ''
+    const content = this.normalizeFinalText(rawText)
+    state.currentTextSegmentContent = ''
+    state.currentTextSegmentStreamId = undefined
+
+    if (!content) {
+      return
+    }
+
+    const segmentIndex = state.nextIntermediateSegmentIndex || 1
+    state.nextIntermediateSegmentIndex = segmentIndex + 1
+    const idempotencyKey = `${state.sourceMessageId}:intermediate:${segmentIndex}`
+
+    try {
+      const result = await this.wechatChannel.sendTextByIntegrationId(context.integrationId, {
+        uuid: context.uuid,
+        contactId: context.contactId,
+        content,
+        context,
+        source: 'agent_callback',
+        idempotencyKey
+      })
+      await this.logIntermediateTextSendResult(context, content, result, idempotencyKey)
+
+      if (!result.success) {
+        this.logger.warn(
+          `[wechat-callback] failed to send intermediate text source=${state.sourceMessageId} integration=${context.integrationId} contact=${context.contactId} reason=${reason} error=${result.error || 'unknown'}`
+        )
+        return
+      }
+
+      state.hasIntermediateTextSent = true
+      state.sentIntermediateTextContent = `${state.sentIntermediateTextContent || ''}${rawText}`
+      state.pendingFinalTextContent = removeTrailingText(state.pendingFinalTextContent || '', rawText)
+      if (!state.pendingFinalTextContent) {
+        state.pendingFinalTextStreamId = undefined
+      }
+    } catch (error) {
+      this.logger.warn(
+        `[wechat-callback] failed to send intermediate text source=${state.sourceMessageId} integration=${context.integrationId} contact=${context.contactId} reason=${reason} error=${this.describeError(error)}`
+      )
+    }
+  }
+
   private async completeRun(state: WechatChatRunState): Promise<void> {
     const context = state.context
     await this.markInboundConversationAttached(context)
-    const finalText = this.normalizeFinalText(state.finalMessageContent || state.responseMessageContent)
+    const finalText = this.resolveFinalReplyText(state)
 
     if (!finalText) {
       this.logger.debug(
@@ -300,6 +474,57 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
     if (!result.success) {
       throw new Error(result.error || 'Failed to send WeChat reply')
     }
+  }
+
+  private resolveFinalReplyText(state: WechatChatRunState): string {
+    if (!this.isIntermediateTextStrategy(state) || !state.hasIntermediateTextSent) {
+      return this.normalizeFinalText(state.finalMessageContent || state.responseMessageContent)
+    }
+
+    const remainingFinalText = this.resolveRemainingFinalMessageText(state)
+    if (remainingFinalText) {
+      return remainingFinalText
+    }
+
+    return this.normalizeFinalText(state.pendingFinalTextContent || '')
+  }
+
+  private resolveRemainingFinalMessageText(state: WechatChatRunState): string {
+    const finalText = this.normalizeFinalText(state.finalMessageContent || '')
+    const sentText = this.normalizeFinalText(state.sentIntermediateTextContent || '')
+    if (!finalText || !sentText || !finalText.startsWith(sentText)) {
+      return ''
+    }
+    return this.normalizeFinalText(finalText.slice(sentText.length))
+  }
+
+  private async logIntermediateTextSendResult(
+    context: WechatChatCallbackContext,
+    content: string,
+    result: {
+      success: boolean
+      queued?: boolean
+      messageId?: string
+      error?: string
+    },
+    idempotencyKey: string
+  ): Promise<void> {
+    if (result.queued && result.success) {
+      return
+    }
+    await this.conversationService.logOutbound({
+      context,
+      content,
+      status: result.success ? 'sent' : 'failed',
+      messageId: result.messageId,
+      error: result.error,
+      payloadSummary: JSON.stringify({
+        type: 'text',
+        source: 'agent_callback',
+        phase: 'intermediate',
+        idempotencyKey
+      })
+    })
   }
 
   private async failRun(state: WechatChatRunState, error: unknown): Promise<void> {
@@ -374,6 +599,14 @@ export class WechatChatCallbackProcessor implements IHandoffProcessor<WechatChat
 
   private normalizeFinalText(value: string): string {
     return (value || '').replace(/\n{3,}/g, '\n\n').trim()
+  }
+
+  private isIntermediateTextStrategy(state: WechatChatRunState): boolean {
+    return state.context.responseStrategy === 'intermediate_text'
+  }
+
+  private describeError(error: unknown): string {
+    return error instanceof Error ? error.message : typeof error === 'string' ? error : String(error)
   }
 
   private resolveFallbackText(language: unknown, message: string): string {

--- a/community/integrations/wechat/src/lib/handoff/wechat-chat-dispatch.service.spec.ts
+++ b/community/integrations/wechat/src/lib/handoff/wechat-chat-dispatch.service.spec.ts
@@ -105,6 +105,7 @@ describe('WechatChatDispatchService', () => {
       'inbound-log-1',
       'inbound-log-2'
     ])
+    expect((message.payload as any).callback.context.responseStrategy).toBe('final_text')
     expect((message.payload as any).callback.context.message.id).toBe('inbound-log-1')
     expect((message.payload as any).options).toEqual(
       expect.objectContaining({
@@ -204,5 +205,50 @@ describe('WechatChatDispatchService', () => {
     expect(JSON.stringify((message.payload as any).request)).not.toContain('data:')
     expect(requestFiles[0]).not.toHaveProperty('fileUrl')
     expect(requestFiles[0]).not.toHaveProperty('url')
+  })
+
+  it('enables intermediate_text callback strategy from WeChat integration options', async () => {
+    const runStateService = {
+      save: jest.fn().mockResolvedValue(undefined)
+    }
+    const service = new WechatChatDispatchService(
+      runStateService as unknown as WechatChatRunStateService,
+      { resolve: jest.fn(() => ({ enqueue: jest.fn() })) } as any
+    )
+    const wechatMessage = new WechatMessage(
+      {
+        integrationId: 'integration-1',
+        uuid: 'uuid-1',
+        contactId: 'wxid_friend',
+        senderId: 'wxid_friend',
+        wechatChannel: {} as any
+      },
+      {
+        messageId: 'msg-1',
+        status: 'thinking',
+        language: 'zh-Hans'
+      }
+    )
+
+    const message = await service.buildDispatchMessage({
+      xpertId: 'xpert-1',
+      input: '你好',
+      wechatMessage,
+      conversationUserKey: 'integration-1:uuid-1:wxid_friend:wxid_friend',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      integrationOptions: {
+        agentCallbackIntermediateTextEnabled: true
+      }
+    })
+
+    expect((message.payload as any).callback.context.responseStrategy).toBe('intermediate_text')
+    expect(runStateService.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          responseStrategy: 'intermediate_text'
+        })
+      })
+    )
   })
 })

--- a/community/integrations/wechat/src/lib/handoff/wechat-chat-dispatch.service.ts
+++ b/community/integrations/wechat/src/lib/handoff/wechat-chat-dispatch.service.ts
@@ -12,7 +12,7 @@ import {
 } from '@xpert-ai/plugin-sdk'
 import { WechatMessage } from '../message.js'
 import { WECHAT_PLUGIN_CONTEXT } from '../tokens.js'
-import type { WechatInboundFile } from '../types.js'
+import type { TIntegrationWechatOptions, WechatInboundFile } from '../types.js'
 import {
   WECHAT_CHAT_CALLBACK_MESSAGE_TYPE,
   WechatChatCallbackContext
@@ -31,6 +31,7 @@ export type WechatChatDispatchInput = {
   organizationId?: string
   endUserId?: string
   currentInboundLogIds?: string[]
+  integrationOptions?: Pick<TIntegrationWechatOptions, 'agentCallbackIntermediateTextEnabled'>
 }
 
 @Injectable()
@@ -77,6 +78,9 @@ export class WechatChatDispatchService {
     const language = (wechatMessage.language || RequestContext.getLanguageCode() || 'zh-Hans') as LanguagesEnum
     const sourceMessageLogIds = this.normalizeInboundLogIds(currentInboundLogIds) ?? []
     const runtimeContext = this.buildRuntimeContext(wechatMessage, sourceMessageLogIds, conversationUserKey)
+    const responseStrategy = input.integrationOptions?.agentCallbackIntermediateTextEnabled === true
+      ? 'intermediate_text'
+      : 'final_text'
 
     const callbackContext: WechatChatCallbackContext = withWechatChatContextLegacyAliases({
       tenantId,
@@ -94,7 +98,7 @@ export class WechatChatDispatchService {
       chatType: wechatMessage.chatType,
       senderId: wechatMessage.senderId,
       senderName: wechatMessage.senderName,
-      responseStrategy: 'final_text',
+      responseStrategy,
       preferLanguage: language,
       conversationUserKey: conversationUserKey || undefined,
       currentInboundLogIds: sourceMessageLogIds,

--- a/community/integrations/wechat/src/lib/handoff/wechat-chat-run-state.service.ts
+++ b/community/integrations/wechat/src/lib/handoff/wechat-chat-run-state.service.ts
@@ -9,6 +9,14 @@ export interface WechatChatRunState {
   sourceMessageId: string
   nextSequence: number
   responseMessageContent: string
+  responseTextStreamId?: string
+  pendingFinalTextContent?: string
+  pendingFinalTextStreamId?: string
+  currentTextSegmentContent?: string
+  currentTextSegmentStreamId?: string
+  sentIntermediateTextContent?: string
+  nextIntermediateSegmentIndex?: number
+  hasIntermediateTextSent?: boolean
   finalMessageContent?: string
   terminalError?: string
   runCreatedAt: number

--- a/community/integrations/wechat/src/lib/handoff/wechat-chat.types.ts
+++ b/community/integrations/wechat/src/lib/handoff/wechat-chat.types.ts
@@ -30,7 +30,7 @@ export interface WechatChatCallbackContext extends Record<string, unknown> {
   chatType?: 'private' | 'group'
   senderId?: string
   senderName?: string
-  responseStrategy?: 'final_text'
+  responseStrategy?: 'final_text' | 'intermediate_text'
   preferLanguage?: string
   conversationUserKey?: string
   conversationId?: string

--- a/community/integrations/wechat/src/lib/types.spec.ts
+++ b/community/integrations/wechat/src/lib/types.spec.ts
@@ -188,6 +188,44 @@ describe('wechat inbound normalization', () => {
         rawText: expect.stringContaining('暗梅幽闻花')
       })
     )
+
+    const inviteTextEvent = normalizeWechatInboundPayload({
+      uuid: 'uuid-1',
+      ownerwxid: 'wxid_owner',
+      contactid: 'room@chatroom',
+      fromusername: 'room@chatroom',
+      chattype: 'room',
+      content: '"牛作用"邀请"老姜 文旅"加入了群聊',
+      newmsgid: 'join-4',
+      msgtype: 10000,
+      isself: false
+    })
+
+    expect(resolveWechatGroupJoinWelcomeInfo(inviteTextEvent)).toEqual({
+      names: ['老姜 文旅'],
+      rawText: '"牛作用"邀请"老姜 文旅"加入了群聊'
+    })
+
+    const inviteXmlEvent = normalizeWechatInboundPayload({
+      uuid: 'uuid-1',
+      ownerwxid: 'wxid_owner',
+      contactid: 'room@chatroom',
+      fromusername: 'room@chatroom',
+      chattype: 'room',
+      content:
+        '<sysmsg type="sysmsgtemplate"><sysmsgtemplate><content_template><template><![CDATA["$inviter$"邀请"$invitee$"加入了群聊]]></template><link_list><link name="inviter" type="link_profile"><memberlist><member><username><![CDATA[wxid_inviter]]></username><nickname><![CDATA[牛作用]]></nickname></member></memberlist></link><link name="invitee" type="link_profile"><memberlist><member><username><![CDATA[wxid_invitee]]></username><nickname><![CDATA[老姜 文旅]]></nickname></member></memberlist></link></link_list></content_template></sysmsgtemplate></sysmsg>',
+      pushcontent: '"牛作用"邀请"老姜 文旅"加入了群聊',
+      newmsgid: 'join-5',
+      msgtype: 10000,
+      isself: false
+    })
+
+    expect(resolveWechatGroupJoinWelcomeInfo(inviteXmlEvent)).toEqual(
+      expect.objectContaining({
+        names: ['老姜 文旅'],
+        rawText: expect.stringContaining('邀请')
+      })
+    )
   })
 
   it('does not treat unrelated system messages as group-join welcomes', () => {

--- a/community/integrations/wechat/src/lib/types.ts
+++ b/community/integrations/wechat/src/lib/types.ts
@@ -64,6 +64,7 @@ export interface TIntegrationWechatOptions {
   timeoutMs?: number
   apiToken?: string
   preferLanguage?: 'en' | 'zh-Hans'
+  agentCallbackIntermediateTextEnabled?: boolean
   webhookCredential?: WechatWebhookCredentialRecord | null
   fallbackToLegacySendText?: boolean
   fallbackToLegacySendImage?: boolean

--- a/community/integrations/wechat/src/lib/types.ts
+++ b/community/integrations/wechat/src/lib/types.ts
@@ -814,23 +814,84 @@ function extractWechatSysmsgTemplateJoinNames(rawText: string): string[] {
   }
 
   const names: string[] = []
-  const adderLinkPattern = /<link\b(?=[^>]*\bname=["']adder["'])[^>]*>([\s\S]*?)<\/link>/gi
-  for (const match of source.matchAll(adderLinkPattern)) {
-    names.push(...extractWechatXmlElementTexts(match[1], 'nickname'))
+  const joinLinkNames = extractWechatSysmsgTemplateJoinLinkNames(source, normalizedText)
+  for (const linkName of joinLinkNames) {
+    names.push(...extractWechatSysmsgTemplateLinkNicknames(source, linkName))
   }
 
   if (!names.length) {
-    const memberPattern = /<member\b[^>]*>([\s\S]*?)<\/member>/gi
-    for (const match of source.matchAll(memberPattern)) {
-      names.push(...extractWechatXmlElementTexts(match[1], 'nickname'))
+    const adderNames = extractWechatSysmsgTemplateLinkNicknames(source, 'adder')
+    names.push(...adderNames)
+  }
+
+  if (!names.length) {
+    const memberNames = extractWechatSysmsgTemplateMemberNicknames(source)
+    if (memberNames.length === 1) {
+      names.push(...memberNames)
     }
   }
 
   return normalizeWechatMemberNames(names.join('、'))
 }
 
+function extractWechatSysmsgTemplateJoinLinkNames(source: string, normalizedText: string): string[] {
+  const templateTexts = [
+    ...extractWechatXmlElementTexts(source, 'template'),
+    ...extractWechatXmlElementTexts(source, 'plain')
+  ]
+  const texts = templateTexts.length ? templateTexts : [normalizedText]
+  const linkNames: string[] = []
+
+  for (const text of texts) {
+    const inviteMatches = text.matchAll(/(?:邀请|邀請)([\s\S]{1,160}?)(?:加入了?群聊|加入群聊)/g)
+    for (const match of inviteMatches) {
+      linkNames.push(...extractWechatTemplatePlaceholderNames(match[1]))
+    }
+  }
+
+  if (linkNames.length) {
+    return Array.from(new Set(linkNames))
+  }
+
+  for (const text of texts) {
+    const joinedMatch = text.match(/^\s*(["“'‘]?\$[^$]+\$["”'’]?)(?:通过[\s\S]{0,80})?(?:加入了?群聊|加入群聊)/)
+    if (joinedMatch) {
+      linkNames.push(...extractWechatTemplatePlaceholderNames(joinedMatch[1]))
+    }
+  }
+
+  return Array.from(new Set(linkNames))
+}
+
+function extractWechatTemplatePlaceholderNames(value: string): string[] {
+  const names: string[] = []
+  for (const match of value.matchAll(/\$([^$\s]{1,80})\$/g)) {
+    names.push(match[1])
+  }
+  return names
+}
+
+function extractWechatSysmsgTemplateLinkNicknames(source: string, linkName: string): string[] {
+  const escapedName = escapeRegExp(linkName)
+  const linkPattern = new RegExp(`<link\\b(?=[^>]*\\bname=["']${escapedName}["'])[^>]*>([\\s\\S]*?)<\\/link>`, 'gi')
+  const names: string[] = []
+  for (const match of source.matchAll(linkPattern)) {
+    names.push(...extractWechatXmlElementTexts(match[1], 'nickname'))
+  }
+  return names
+}
+
+function extractWechatSysmsgTemplateMemberNicknames(source: string): string[] {
+  const memberPattern = /<member\b[^>]*>([\s\S]*?)<\/member>/gi
+  const names: string[] = []
+  for (const match of source.matchAll(memberPattern)) {
+    names.push(...extractWechatXmlElementTexts(match[1], 'nickname'))
+  }
+  return normalizeWechatMemberNames(names.join('、'))
+}
+
 function extractWechatXmlElementTexts(xml: string, elementName: string): string[] {
-  const escapedName = elementName.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+  const escapedName = escapeRegExp(elementName)
   const pattern = new RegExp(`<${escapedName}\\b[^>]*>([\\s\\S]*?)<\\/${escapedName}>`, 'gi')
   const values: string[] = []
   for (const match of xml.matchAll(pattern)) {
@@ -840,6 +901,10 @@ function extractWechatXmlElementTexts(xml: string, elementName: string): string[
     }
   }
   return values
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
 }
 
 function normalizeWechatMemberNames(value: string): string[] {

--- a/community/integrations/wechat/src/lib/wechat-channel.strategy.ts
+++ b/community/integrations/wechat/src/lib/wechat-channel.strategy.ts
@@ -100,6 +100,10 @@ export class WechatChannelStrategy
         outboundQueue: {
           type: 'object',
           description: 'Redis-backed outbound queue and rate-limit settings'
+        },
+        agentCallbackIntermediateTextEnabled: {
+          type: 'boolean',
+          description: 'Send visible assistant text between agent tool calls as intermediate WeChat text messages'
         }
       },
       required: []

--- a/community/integrations/wechat/src/lib/wechat-integration.strategy.ts
+++ b/community/integrations/wechat/src/lib/wechat-integration.strategy.ts
@@ -216,6 +216,18 @@ export class WechatIntegrationStrategy implements IntegrationStrategy<TIntegrati
           enum: ['en', 'zh-Hans'],
           default: 'zh-Hans'
         },
+        agentCallbackIntermediateTextEnabled: {
+          type: 'boolean',
+          title: {
+            en_US: 'Send Intermediate Agent Messages',
+            zh_Hans: '发送 Agent 中间消息'
+          },
+          description: {
+            en_US: 'When enabled, visible assistant messages produced before tool calls are sent to WeChat before the final reply.',
+            zh_Hans: '开启后，Agent 工具调用前已经生成的可见消息会先作为微信消息发送。'
+          },
+          default: false
+        },
         fallbackToLegacySendText: {
           type: 'boolean',
           title: {
@@ -402,6 +414,7 @@ export class WechatIntegrationStrategy implements IntegrationStrategy<TIntegrati
 
     config.apiVersion = normalizeApiVersion(config.apiVersion)
     config.timeoutMs = normalizeTimeoutMs(config.timeoutMs)
+    config.agentCallbackIntermediateTextEnabled = config.agentCallbackIntermediateTextEnabled === true
     config.fallbackToLegacySendText = config.fallbackToLegacySendText !== false
     config.fallbackToLegacySendImage = config.fallbackToLegacySendImage !== false
     config.outboundQueue = {

--- a/community/integrations/wechat/src/lib/workflow/wechat-trigger-aggregation.types.ts
+++ b/community/integrations/wechat/src/lib/workflow/wechat-trigger-aggregation.types.ts
@@ -40,6 +40,7 @@ export interface WechatTriggerAggregationState {
   currentInboundLogIds?: string[]
   duplicateInboundLogIds?: string[]
   historyContext?: string
+  agentCallbackIntermediateTextEnabled?: boolean
   fileMaterializeRetryCount?: number
   fileMaterializeLastError?: string
   lastMessageAt: number
@@ -60,6 +61,7 @@ export interface WechatTriggerAggregatePayload extends Record<string, unknown> {
   files?: WechatInboundFile[]
   pendingFiles?: WechatPendingInboundFile[]
   historyContext?: string
+  agentCallbackIntermediateTextEnabled?: boolean
   currentInboundLogIds?: string[]
   summaryWindowSeconds: number
   sessionTimeoutSeconds: number

--- a/community/integrations/wechat/src/lib/workflow/wechat-trigger.strategy.ts
+++ b/community/integrations/wechat/src/lib/workflow/wechat-trigger.strategy.ts
@@ -851,6 +851,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
     wechatMessage: WechatMessage
     conversationUserKey?: string
     historyContext?: string
+    integrationOptions?: Pick<TIntegrationWechatOptions, 'agentCallbackIntermediateTextEnabled'>
     currentInboundLogIds?: string[]
     triggerOptions?: WechatInboundTriggerOptions
     tenantId: string
@@ -905,7 +906,8 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
           tenantId: params.tenantId,
           organizationId: params.organizationId,
           endUserId: params.endUserId,
-          currentInboundLogIds: params.currentInboundLogIds
+          currentInboundLogIds: params.currentInboundLogIds,
+          integrationOptions: params.integrationOptions
         }
       })
       return this.createHandleResult(true, { dispatched: true })
@@ -922,6 +924,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       files: params.files,
       pendingFiles: params.pendingFiles,
       historyContext: params.historyContext,
+      agentCallbackIntermediateTextEnabled: params.integrationOptions?.agentCallbackIntermediateTextEnabled === true,
       currentInboundLogIds: params.currentInboundLogIds,
       summaryWindowSeconds,
       sessionTimeoutSeconds: this.normalizePositiveSeconds(
@@ -998,6 +1001,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
           ...pendingFileMerge.duplicateLogIds
         ]),
         historyContext: sameRoutingTarget ? currentState?.historyContext ?? payload.historyContext : payload.historyContext,
+        agentCallbackIntermediateTextEnabled: payload.agentCallbackIntermediateTextEnabled === true,
         lastMessageAt: Date.now(),
         tenantId: payload.tenantId,
         organizationId: payload.organizationId,
@@ -1104,7 +1108,10 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
         tenantId: state.tenantId,
         organizationId: state.organizationId,
         endUserId: state.endUserId,
-        currentInboundLogIds: dispatchLogIds
+        currentInboundLogIds: dispatchLogIds,
+        integrationOptions: {
+          agentCallbackIntermediateTextEnabled: state.agentCallbackIntermediateTextEnabled === true
+        }
       }
     })
 


### PR DESCRIPTION
## Summary
- Add a WeChat integration option for sending visible assistant text before tool calls as intermediate WeChat messages.
- Propagate the option through inbound handling, trigger aggregation, dispatch context, and callback processing.
- Track intermediate text segments with idempotency, outbound logging, and final-reply trimming so duplicated callback events do not resend content.
- Improve invite-style WeChat group join parsing and add focused tests for the new callback and join-message behavior.

## Validation
- Not run locally; no local `xpert-plugins` checkout was available in this workspace.
- Inspected the GitHub compare for `main...develop` before creating the PR.