### PR TITLE
Upgrade xpertai release workflow to pnpm 11

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -64,8 +64,10 @@ jobs:
       matrix:
         include:
           - workspace: xpertai
+            pnpm_version: 11.7.0
             install_command: pnpm -C xpertai install --frozen-lockfile
           - workspace: community
+            pnpm_version: 8.15.8
             install_command: pnpm -C community install --no-frozen-lockfile
 
     steps:
@@ -98,17 +100,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        if: steps.decide.outputs.run == 'true'
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
       - name: Setup Node.js
         if: steps.decide.outputs.run == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 22.14.0
+
+      - name: Setup pnpm
+        if: steps.decide.outputs.run == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ matrix.pnpm_version }}
 
       - name: Upgrade npm for trusted publishing
         if: steps.decide.outputs.run == 'true'

--- a/xpertai/package.json
+++ b/xpertai/package.json
@@ -2,6 +2,7 @@
   "name": "@xpert-plugins-starter/source",
   "version": "0.0.0",
   "license": "MIT",
+  "packageManager": "pnpm@11.7.0",
   "scripts": {
     "release:publish": "node ./scripts/release-publish.mjs"
   },
@@ -90,10 +91,6 @@
     "turndown": "^7.2.2",
     "typeorm": "^0.3.24",
     "zod": "3.25.67"
-  },
-  "overrides": {
-    "i18next": "25.6.0",
-    "i18next-fs-backend": "2.6.0"
   },
   "nx": {
     "includedScripts": [],

--- a/xpertai/pnpm-lock.yaml
+++ b/xpertai/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   '@xpert-ai/plugin-sdk@3.12.1>@xpert-ai/contracts': 3.12.1
+  i18next: 25.6.0
+  i18next-fs-backend: 2.6.0
 
 importers:
 
@@ -3950,67 +3952,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -4733,7 +4747,7 @@ packages:
     resolution: {integrity: sha512-J3Vh5RNO/nIWh2TI9LBZPanIsemsM/xLck54W1NNMdYgpDiaRw0HKMfUZeX/D1S/Jsvf3c4Fei3lO8E8nrijMQ==}
     peerDependencies:
       date-fns: ^3.0.4
-      i18next: ^23.14.0
+      i18next: 25.6.0
       idb-keyval: ^6.2.0
       money-clip: ^3.0.5
       rxjs: '>=7.4.0'
@@ -5044,41 +5058,49 @@ packages:
     resolution: {integrity: sha512-4ZSjvCjnBT0WpGdF12hvgLWmok4WftaE09fOWWrMm4b2m8F/5yKgU6usPFTehQa5oqTp08KW60kZMLaOQHOJQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-gnu@21.6.3':
     resolution: {integrity: sha512-l6/YZp5MJ5TYWbHoaR31lsqd4Ia2AnaGSACeNCUAsUsUNaa099nwmvFaKQEJxUX1aMpe4kHLyVbomK7ydEX+pg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@21.6.10':
     resolution: {integrity: sha512-lNzlTsgr7nY56ddIpLTzYZTuNA3FoeWb9Ald07pCWc0EHSZ0W4iatJ+NNnj/QLINW8HWUehE9mAV5qZlhVFBmg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-arm64-musl@21.6.3':
     resolution: {integrity: sha512-klidxt4eiSxgLa1LW7YUHstm3qsptz+XD1+3w0ofX1rkdVkK1afrfcolzoeZ5nc4Av7MzZB0g0PoFTGHUIBkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@21.6.10':
     resolution: {integrity: sha512-nJxUtzcHwk8TgDdcqUmbJnEMV3baQxmdWn77d1NTP4cG677A7jdV93hbnCcw+AQonaFLUzDwJOIX8eIPZ32GLw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-gnu@21.6.3':
     resolution: {integrity: sha512-B5ZvolVUIKKmacbZw1XD2nBIbebE2T6vBbMYq6kZP7PfSsfO5Y0HaWIsK8ulwCj35TPaEn9x/XbHJp5RakU7Ng==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@21.6.10':
     resolution: {integrity: sha512-+VwITTQW9wswP7EvFzNOucyaU86l2UcO6oYxFiwNvRioTlDOE5U7lxYmCgj3OHeGCmy9jhXlujdD+t3OhOT3gQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-musl@21.6.3':
     resolution: {integrity: sha512-11L6SigPvjnIFbr4ivXlcH0fOPs55SvT8gkg2TOsSohKFY/Ze4O43NuoZe/7dilLjNgq8aWTbnbSuRK/kFGdBQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@21.6.10':
     resolution: {integrity: sha512-kkK/0GNVs7pdcgksLfoMBT8k92XGfcePPuhhS1Tsyq+zc3gpsPo+vNIGfeIf2FumKBsUdWUHuChfpxBmjcVFVw==}
@@ -6490,24 +6512,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.5.29':
     resolution: {integrity: sha512-TERh2OICAJz+SdDIK9+0GyTUwF6r4xDlFmpoiHKHrrD/Hh3u+6Zue0d7jQ/he/i80GDn4tJQkHlZys+RZL5UZg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.5.29':
     resolution: {integrity: sha512-WMDPqU7Ji9dJpA+Llek2p9t7pcy7Bob8ggPUvgsIlv3R/eesF9DIzSbrgl6j3EAEPB9LFdSafsgf6kT/qnvqFg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.5.29':
     resolution: {integrity: sha512-DO14glwpdKY4POSN0201OnGg1+ziaSVr6/RFzuSLggshwXeeyVORiHv3baj7NENhJhWhUy3NZlDsXLnRFkmhHQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.5.29':
     resolution: {integrity: sha512-V3Y1+a1zG1zpYXUMqPIHEMEOd+rHoVnIpO/KTyFwAmKVu8v+/xPEVx/AGoYE67x4vDAAvPQrKI3Aokilqa5yVg==}
@@ -7239,41 +7265,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -7449,7 +7483,7 @@ packages:
     peerDependencies:
       '@xpert-ai/store': workspace:*
       date-fns: ^3.0.4
-      i18next: ^23.14.0
+      i18next: 25.6.0
       idb-keyval: ^6.2.0
       money-clip: ^3.0.5
       rxjs: '>=7.4.0'
@@ -7465,8 +7499,8 @@ packages:
       '@xpert-ai/contracts': workspace:*
       '@xpert-ai/ocap-core': workspace:*
       ajv: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7485,8 +7519,8 @@ packages:
       '@xpert-ai/contracts': workspace:*
       '@xpert-ai/ocap-core': workspace:*
       ajv: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7504,8 +7538,8 @@ packages:
       '@nestjs/cqrs': '*'
       '@xpert-ai/ocap-core': workspace:*
       ajv: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7523,8 +7557,8 @@ packages:
       '@nestjs/cqrs': '*'
       '@xpert-ai/ocap-core': 3.9.1
       ajv: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7544,8 +7578,8 @@ packages:
       '@nestjs/cqrs': '*'
       ajv: '*'
       fs: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7567,8 +7601,8 @@ packages:
       '@nestjs/cqrs': '*'
       ajv: '*'
       fs: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7589,8 +7623,8 @@ packages:
       '@xpert-ai/contracts': workspace:*
       '@xpert-ai/ocap-core': workspace:*
       ajv: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -7609,8 +7643,8 @@ packages:
       '@xpert-ai/contracts': workspace:*
       '@xpert-ai/ocap-core': workspace:*
       ajv: '*'
-      i18next: '*'
-      i18next-fs-backend: '*'
+      i18next: 25.6.0
+      i18next-fs-backend: 2.6.0
       json-schema: '*'
       jsonwebtoken: '*'
       lodash-es: '*'
@@ -8143,12 +8177,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   chromadb-js-bindings-linux-x64-gnu@1.3.4:
     resolution: {integrity: sha512-HmTUe7PEIaBngCQ70Yyle81z2wYyg9OMgJYyRUNBYCBp4ED6zTmdaOro41Vs/c/h2UyQeBXFIKNmHDeD2Nr2fw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   chromadb-js-bindings-win32-x64-msvc@1.3.4:
     resolution: {integrity: sha512-punrofQRzKspNMxHmv24qoPeRycV2T3KfedekGV4lOuPPG14i6qggS4x/OWLSAK7ozPfBbrzCejvCa5wfvujhQ==}
@@ -13560,7 +13596,7 @@ snapshots:
       openai: 5.12.2(ws@8.21.0)(zod@3.25.67)
       ws: 8.21.0
       zod: 3.25.67
-      zod-to-json-schema: 3.25.1(zod@3.25.67)
+      zod-to-json-schema: 3.25.2(zod@3.25.67)
     transitivePeerDependencies:
       - bufferutil
       - encoding

--- a/xpertai/pnpm-workspace.yaml
+++ b/xpertai/pnpm-workspace.yaml
@@ -12,18 +12,11 @@ packages:
 
 overrides:
   '@xpert-ai/plugin-sdk@3.12.1>@xpert-ai/contracts': 3.12.1
+  i18next: 25.6.0
+  i18next-fs-backend: 2.6.0
 
-onlyBuiltDependencies:
-  - '@nestjs/core'
-  - '@sap/hana-client'
-  - '@swc/core'
-  - cpu-features
-  - msgpackr-extract
-  - nx
-  - protobufjs
-  - sharp
-  - ssh2
-  - unrs-resolver
+minimumReleaseAgeExclude:
+  - '@xpert-ai/*'
 
 allowBuilds:
   '@nestjs/core': true


### PR DESCRIPTION
## Summary

- Upgrade the xpertai release path to pnpm 11.7.0 and run Node.js setup before pnpm setup so the workflow satisfies pnpm 11's Node 22+ requirement.
- Keep the community release path on its declared pnpm 8.15.8 version to avoid rewriting the community pnpm 8 lockfile in this xpertai-focused fix.
- Move xpertai pnpm overrides into `xpertai/pnpm-workspace.yaml`, remove the old package-level override block, and add `packageManager: pnpm@11.7.0`.
- Regenerate `xpertai/pnpm-lock.yaml` with pnpm 11 and exempt `@xpert-ai/*` from pnpm 11's minimum release age gate so freshly published internal packages do not block release installs.

## Why

The xpertai release workflow was still using pnpm 9 while the repository contained pnpm settings and lockfile state produced across different pnpm generations. This caused `pnpm -C xpertai install --frozen-lockfile` to fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` after merging develop into main.

## Validation

- `pnpm -C xpertai install --lockfile-only --no-frozen-lockfile --ignore-scripts` using pnpm 11.7.0
- `pnpm -C xpertai install --frozen-lockfile --lockfile-only --ignore-scripts` using pnpm 11.7.0
- Clean temporary worktree: `pnpm -C xpertai install --frozen-lockfile --ignore-scripts` using pnpm 11.7.0
- `npx -y pnpm@8.15.8 -C community install --frozen-lockfile --lockfile-only --ignore-scripts`
- `git diff --check`
- Pre-commit hook: Plugin Entity table name check passed