### PR TITLE
[codex] support WeChat reference appmsg mentions

### DIFF
--- a/community/.changeset/lazy-pans-tease.md
+++ b/community/.changeset/lazy-pans-tease.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-community-wechat": minor
+---
+
+add reference msg

--- a/community/integrations/wechat/src/lib/types.spec.ts
+++ b/community/integrations/wechat/src/lib/types.spec.ts
@@ -4,6 +4,7 @@ import {
   matchesWechatMessageFilter,
   normalizeWechatConnectionMode,
   normalizeGroupTriggerOverrides,
+  normalizeWechatAgentInput,
   normalizeWechatInboundPayload,
   resolveWechatGroupJoinWelcomeInfo,
   shouldDispatchWechatBatch,
@@ -398,6 +399,58 @@ describe('wechat inbound normalization', () => {
       })
     )
     expect(shouldDispatchWechatMessage(event)?.triggerReason).toBe('private')
+  })
+
+  it('normalizes mentioned appmsg quote payloads as dispatchable text with quoted source context', () => {
+    const content =
+      'wxid_6mpdxp1z5r8y22:\n<?xml version="1.0"?><msg><appmsg appid="" sdkver="0"><title>@XpertAI 小助手\u2005这是什么</title><type>57</type><refermsg><displayname>XpertAI 小助手</displayname><content>你好！我是 yuanshu assistant1，你的微信小助手</content></refermsg></appmsg></msg>'
+    const event = normalizeWechatInboundPayload({
+      uuid: 'SDwkRBvds0dt',
+      ownerwxid: 'wxid_3xh67h1ukg5a12',
+      contactid: '53061340816@chatroom',
+      sendusername: 'wxid_6mpdxp1z5r8y22',
+      fromusername: '53061340816@chatroom',
+      tousername: 'wxid_3xh67h1ukg5a12',
+      chattype: 'room',
+      content,
+      pushcontent: 'XpertAI (元数信息技术) : @XpertAI 小助手\u2005这是什么',
+      msgsource: '<msgsource><atuserlist>wxid_3xh67h1ukg5a12</atuserlist></msgsource>',
+      newmsgid: '7180799087978278614',
+      msgtype: 49,
+      isself: false
+    })
+
+    expect(event).toEqual(
+      expect.objectContaining({
+        source: 'message_webhook',
+        uuid: 'SDwkRBvds0dt',
+        ownerWxid: 'wxid_3xh67h1ukg5a12',
+        contactId: '53061340816@chatroom',
+        senderId: 'wxid_6mpdxp1z5r8y22',
+        chatType: 'group',
+        messageId: '7180799087978278614',
+        msgType: 49,
+        messageKind: 'text',
+        content: '@XpertAI 小助手\u2005这是什么'
+      })
+    )
+
+    const normalizedInput = normalizeWechatAgentInput(event)
+    expect(normalizedInput).toBe(
+      '@XpertAI 小助手\u2005这是什么\n\n[引用消息]\nXpertAI 小助手: 你好！我是 yuanshu assistant1，你的微信小助手'
+    )
+    expect(normalizedInput).not.toContain('<?xml')
+    expect(normalizedInput).not.toContain('<msgsource>')
+
+    const mention = shouldDispatchWechatMessage(event, {
+      groupTriggerMode: 'mentions',
+      mentionFallbackNames: ['XpertAI 小助手']
+    })
+    expect(mention?.triggerReason).toBe('mention')
+    expect(mention?.input).toBe(
+      '这是什么\n\n[引用消息]\nXpertAI 小助手: 你好！我是 yuanshu assistant1，你的微信小助手'
+    )
+    expect(mention?.input).not.toContain('小助手\u2005这是什么')
   })
 
   it('filters self, empty, unsupported media, and non-triggered group messages without inferring image display text', () => {

--- a/community/integrations/wechat/src/lib/types.ts
+++ b/community/integrations/wechat/src/lib/types.ts
@@ -18,6 +18,8 @@ export type WechatOutboundOverflowAction = 'reject' | 'pause_until_manual_resume
 
 export const DEFAULT_GROUP_JOIN_WELCOME_PROMPT =
   '微信群有新成员加入：{names}。请生成一句简短、友好的中文欢迎语回复群聊，不要提及系统消息。'
+const WECHAT_REFERENCE_APPMSG_TYPE = 57
+const WECHAT_MENTION_SEPARATOR_CLASS = '\\s\\u2005\\u2002\\u2003\\u2004\\u2006\\u2007\\u2008\\u2009\\u200a\\u202f\\u205f\\u3000'
 
 export interface WechatGroupTriggerOverride {
   groupId: string
@@ -498,13 +500,14 @@ export function shouldDispatchWechatMessage(
     return matchesWechatAllowedKeywords(dispatchable.input, options) ? dispatchable : null
   }
 
-  const mentioned = isMentioned(event, normalizeMentionFallbackNames(options?.mentionFallbackNames))
+  const mentionFallbackNames = normalizeMentionFallbackNames(options?.mentionFallbackNames)
+  const mentioned = isMentioned(event, mentionFallbackNames)
   const keyword = matchKeyword(input, normalizeKeywords(options?.groupKeywords))
 
   if ((mode === 'mentions' || mode === 'mention_or_keywords') && mentioned) {
     const dispatchable: WechatDispatchableMessage = {
       ...event,
-      input: stripLeadingMention(input),
+      input: stripLeadingMention(input, mentionFallbackNames),
       triggerReason: 'mention'
     }
     return matchesWechatAllowedKeywords(dispatchable.input, options) ? dispatchable : null
@@ -581,8 +584,9 @@ export function shouldDispatchWechatBatch(
   }
 
   if ((mode === 'mentions' || mode === 'mention_or_keywords') && candidates.some((item) => item.mentioned)) {
+    const mentionFallbackNames = normalizeMentionFallbackNames(options?.mentionFallbackNames)
     const strippedInputParts = candidates.map((item) =>
-      item.mentioned ? stripLeadingMention(normalizeString(item.input)) : normalizeString(item.input)
+      item.mentioned ? stripLeadingMention(normalizeString(item.input), mentionFallbackNames) : normalizeString(item.input)
     )
     return matchesWechatAllowedKeywords(strippedInputParts.join('\n'), options)
       ? {
@@ -952,6 +956,7 @@ function normalizeMessageWebhook(payload: Dict, rawPayload: unknown): WechatInbo
     messageKind === 'image' || messageKind === 'voice' || messageKind === 'file' ? rawContent : rawContent || pushContent,
     isGroup
   ).body
+  const displayContent = isReferencedAppMessage(msgType, content) ? resolveReferencedAppMessageTitle(content) || content : content
   const messageId =
     normalizeString(payload.newmsgid || payload.newMsgId || payload.Newmsgid) ||
     normalizeString(numericMsgId)
@@ -1042,13 +1047,13 @@ function normalizeMessageWebhook(payload: Dict, rawPayload: unknown): WechatInbo
     messageId,
     msgType,
     messageKind,
-    content,
+    content: displayContent,
     displayText:
       messageKind === 'image' || messageKind === 'voice'
         ? pushContent
         : messageKind === 'file'
           ? pushContent || fileRef?.originalName
-          : pushContent || content,
+          : pushContent || displayContent,
     imageRef,
     voiceRef,
     fileRef,
@@ -1063,6 +1068,10 @@ function normalizeMessageWebhook(payload: Dict, rawPayload: unknown): WechatInbo
 export function normalizeWechatAgentInput(event: WechatInboundEvent): string {
   if (event.messageKind === 'image' || event.messageKind === 'file') {
     return ''
+  }
+  const appMsgContent = resolveWechatEventAppMsgContent(event)
+  if (isReferencedAppMessage(event.msgType, appMsgContent)) {
+    return resolveReferencedAppMessageInput(appMsgContent)
   }
   const text = normalizeString(event.content || event.displayText)
   if (!text) {
@@ -1100,6 +1109,10 @@ function isFileMessage(msgType: number | undefined, content?: string): boolean {
   return false
 }
 
+function isReferencedAppMessage(msgType: number | undefined, content?: string): boolean {
+  return msgType === 49 && resolveAppMsgType(content) === WECHAT_REFERENCE_APPMSG_TYPE
+}
+
 function resolveInboundMessageKind(msgType: number | undefined, content?: string): WechatInboundMessageKind {
   if (isImageMessage(msgType)) {
     return 'image'
@@ -1109,6 +1122,9 @@ function resolveInboundMessageKind(msgType: number | undefined, content?: string
   }
   if (isFileMessage(msgType, content)) {
     return 'file'
+  }
+  if (isReferencedAppMessage(msgType, content)) {
+    return 'text'
   }
   if (isTextLikeMessage(msgType)) {
     return 'text'
@@ -1263,6 +1279,41 @@ function resolveAppMsgType(content?: string): number | undefined {
   return normalizeNumber(extractXmlElementText(content, 'type'))
 }
 
+function resolveReferencedAppMessageTitle(content?: string): string | undefined {
+  return normalizeString(extractXmlElementText(content, 'title')) || undefined
+}
+
+function resolveReferencedAppMessageInput(content?: string): string {
+  const title = resolveReferencedAppMessageTitle(content) || ''
+  const quoted = resolveReferencedAppMessageQuote(content)
+  if (!quoted) {
+    return title
+  }
+  return [title, `[引用消息]\n${quoted}`].filter(Boolean).join('\n\n')
+}
+
+function resolveReferencedAppMessageQuote(content?: string): string {
+  const referMsg = extractXmlElementText(content, 'refermsg', { decode: false })
+  if (!referMsg) {
+    return ''
+  }
+  const displayName = normalizeString(extractXmlElementText(referMsg, 'displayname'))
+  const quotedContent = normalizeString(extractXmlElementText(referMsg, 'content'))
+  if (!quotedContent) {
+    return ''
+  }
+  return displayName ? `${displayName}: ${quotedContent}` : quotedContent
+}
+
+function resolveWechatEventAppMsgContent(event: WechatInboundEvent): string {
+  const raw = asRecord(event.raw)
+  const rawContent = normalizeString(raw?.content || raw?.Content)
+  if (rawContent) {
+    return stripGroupSenderPrefix(rawContent, event.chatType === 'group').body
+  }
+  return normalizeString(event.content)
+}
+
 function resolveFileTitle(content?: string): string | undefined {
   return normalizeString(extractXmlElementText(content, 'title')) || undefined
 }
@@ -1383,27 +1434,43 @@ function extractXmlAttribute(content: string, name: string): string {
   return normalizeString(content.match(pattern)?.[1])
 }
 
-function stripLeadingMention(input: string): string {
-  return input.replace(/^@[^\s]+\s*/, '').trim() || input
+function stripLeadingMention(input: string, fallbackNames: string[] = []): string {
+  const text = normalizeString(input)
+  for (const name of [...fallbackNames].sort((left, right) => right.length - left.length)) {
+    const pattern = createMentionNamePattern(name, true)
+    if (!pattern) {
+      continue
+    }
+    const stripped = text.replace(pattern, '').trim()
+    if (stripped !== text) {
+      return stripped || input
+    }
+  }
+  return text.replace(new RegExp(`^@[^${WECHAT_MENTION_SEPARATOR_CLASS}]+[${WECHAT_MENTION_SEPARATOR_CLASS}]*`), '').trim() || input
 }
 
 function hasConfiguredMentionName(content: string, names: string[]): boolean {
   if (!names.length) {
     return false
   }
-  const lowered = content.toLowerCase()
   return names.some((name) => {
-    const token = `@${name}`.toLowerCase()
-    let index = lowered.indexOf(token)
-    while (index >= 0) {
-      const next = content[index + token.length]
-      if (!next || /[\s,，.。:：;；!！?？)）]/.test(next)) {
-        return true
-      }
-      index = lowered.indexOf(token, index + 1)
-    }
-    return false
+    const pattern = createMentionNamePattern(name, false)
+    return pattern ? pattern.test(content) : false
   })
+}
+
+function createMentionNamePattern(name: string, leadingOnly: boolean): RegExp | null {
+  const parts = normalizeString(name)
+    .split(new RegExp(`[${WECHAT_MENTION_SEPARATOR_CLASS}]+`))
+    .filter(Boolean)
+  if (!parts.length) {
+    return null
+  }
+  const body = parts.map(escapeRegExp).join(`[${WECHAT_MENTION_SEPARATOR_CLASS}]+`)
+  const prefix = leadingOnly ? '^' : ''
+  const boundary = `(?=$|[${WECHAT_MENTION_SEPARATOR_CLASS},，.。:：;；!！?？)）])`
+  const suffix = leadingOnly ? `[${WECHAT_MENTION_SEPARATOR_CLASS}]*` : ''
+  return new RegExp(`${prefix}@${body}${boundary}${suffix}`, 'i')
 }
 
 function extractAtUserList(raw: Record<string, unknown>): string[] {


### PR DESCRIPTION
## Summary

- Treat WeChat `msgtype=49` / appmsg `type=57` quote messages as dispatchable text.
- Build agent input from the current quoted-message title plus a `[引用消息]` block containing the referenced source message.
- Improve leading mention stripping for multi-word fallback names and WeChat thin-space separators.

## Root Cause

Quoted WeChat replies arrive as appmsg `type=57`. They can include a valid `atuserlist` that mentions the bot account, but the plugin previously classified this appmsg type as `unsupported`, so mention routing never reached the existing `atuserlist` check.

## Validation

- Full WeChat Jest suite passed: 23 suites / 245 tests.
- Targeted `types.spec.ts` coverage added for `msgtype=49`, appmsg `type=57`, `atuserlist` mention detection, quoted source text concatenation, XML exclusion, and multi-word mention cleanup.

Note: Local `pnpm --filter @xpert-ai/plugin-community-wechat ...` was blocked by the current workspace's broken community pnpm symlinks, so validation used the existing resolvable Jest runtime with the same test files.