### PR TITLE
feat: add Lark message history runtime

### DIFF
--- a/xpertai/.changeset/calm-larks-store-history.md
+++ b/xpertai/.changeset/calm-larks-store-history.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-lark": minor
+---
+
+Persist scoped Lark message history and attachments locally, inject recent context automatically, provide one trigger-bound Lark runtime for local history, current-chat-only remote history, message and workspace-file sending, show administrator guidance cards for missing application permissions, use retry-safe queue identifiers and cleanup scheduling, and add an accurate cursor-paginated administration view with plugin-owned refresh and scrolling.

--- a/xpertai/integrations/lark/src/index.spec.ts
+++ b/xpertai/integrations/lark/src/index.spec.ts
@@ -13,10 +13,9 @@ jest.mock('./lib/integration-lark.module.js', () => ({
 import plugin from './index.js'
 import {
   LARK_ADMIN_TEMPLATE_KEY,
-  LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME,
   LARK_CONVERSATION_TEMPLATE_KEY,
   LARK_FEATURE,
-  LARK_NOTIFY_MIDDLEWARE_NAME,
+  LARK_RUNTIME_MIDDLEWARE_NAME,
   LARK_PLUGIN_NAME,
   LARK_PROVIDER_KEY,
   LARK_VIEW_PROVIDER_KEY
@@ -45,9 +44,7 @@ describe('Lark Plugin', () => {
     expect(xpertMeta?.capabilities).toEqual(expect.arrayContaining([LARK_FEATURE]))
     expect(xpertMeta?.runtime?.integrationProviders).toEqual([LARK_PROVIDER_KEY])
     expect(xpertMeta?.runtime?.channelProviders).toEqual([LARK_PROVIDER_KEY])
-    expect(xpertMeta?.runtime?.middlewareProviders).toEqual(
-      expect.arrayContaining([LARK_NOTIFY_MIDDLEWARE_NAME, LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME])
-    )
+    expect(xpertMeta?.runtime?.middlewareProviders).toEqual([LARK_RUNTIME_MIDDLEWARE_NAME])
     expect(xpertMeta?.runtime?.viewProviders).toEqual([LARK_VIEW_PROVIDER_KEY])
 
     const contents = xpertMeta?.marketplace?.contents ?? []
@@ -55,8 +52,7 @@ describe('Lark Plugin', () => {
       expect.arrayContaining([
         `app:${LARK_PROVIDER_KEY}`,
         `view:${LARK_VIEW_PROVIDER_KEY}`,
-        `tool:${LARK_NOTIFY_MIDDLEWARE_NAME}`,
-        `tool:${LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME}`,
+        `tool:${LARK_RUNTIME_MIDDLEWARE_NAME}`,
         `assistant-template:${LARK_ADMIN_TEMPLATE_KEY}`,
         `assistant-template:${LARK_CONVERSATION_TEMPLATE_KEY}`
       ])
@@ -64,6 +60,14 @@ describe('Lark Plugin', () => {
     expect(contents.find((item) => item.type === 'app')?.operations?.map((operation) => operation.access)).toEqual(
       expect.arrayContaining(['read', 'write', 'admin'])
     )
+    expect(
+      contents
+        .find((item) => item.type === 'app')
+        ?.operations?.find((operation) => operation.name === 'send-lark-messages')?.description
+    ).toContain('workspace file')
+    expect(
+      contents.find((item) => item.type === 'tool' && item.name === LARK_RUNTIME_MIDDLEWARE_NAME)?.description
+    ).toContain('workspace file')
   })
 
   it('registers assistant templates with xpert target metadata', () => {

--- a/xpertai/integrations/lark/src/index.ts
+++ b/xpertai/integrations/lark/src/index.ts
@@ -1,37 +1,37 @@
-import { z } from 'zod';
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
-import { initI18n } from './lib/i18n.js';
-import { iconImage } from './lib/types.js';
-import { IntegrationLarkPluginConfigSchema } from './lib/plugin-config.js';
-import { IntegrationLarkPlugin } from './lib/integration-lark.module.js';
-import { LARK_PLUGIN_CONTEXT } from './lib/tokens.js';
+import { z } from 'zod'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import { dirname, join } from 'path'
+import { initI18n } from './lib/i18n.js'
+import { iconImage } from './lib/types.js'
+import { IntegrationLarkPluginConfigSchema } from './lib/plugin-config.js'
+import { IntegrationLarkPlugin } from './lib/integration-lark.module.js'
+import { LARK_PLUGIN_CONTEXT } from './lib/tokens.js'
 import {
   LARK_ADMIN_TEMPLATE_KEY,
   LARK_ADMIN_VIEW_FEATURE,
   LARK_ASSISTANT_TEMPLATE_FEATURE,
-  LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME,
   LARK_CONVERSATION_TEMPLATE_KEY,
   LARK_DOCUMENT_SOURCE_FEATURE,
   LARK_FEATURE,
+  LARK_LOCAL_HISTORY_FEATURE,
   LARK_LONG_CONNECTION_FEATURE,
   LARK_MESSAGING_FEATURE,
-  LARK_NOTIFY_MIDDLEWARE_NAME,
+  LARK_RUNTIME_MIDDLEWARE_NAME,
   LARK_PLUGIN_NAME,
   LARK_PROVIDER_KEY,
   LARK_TEMPLATE_PROVIDER_KEY,
   LARK_VIEW_PROVIDER_KEY
-} from './lib/constants.js';
-import { larkTemplates } from './lib/lark.templates.js';
-import type { LarkXpertPlugin } from './lib/plugin-metadata-compat.js';
+} from './lib/constants.js'
+import { larkTemplates } from './lib/lark.templates.js'
+import type { LarkXpertPlugin } from './lib/plugin-metadata-compat.js'
 
-const moduleDir = dirname(fileURLToPath(import.meta.url));
+const moduleDir = dirname(fileURLToPath(import.meta.url))
 
 const packageJson = JSON.parse(readFileSync(join(moduleDir, '../package.json'), 'utf8')) as {
-  name: string;
-  version: string;
-};
+  name: string
+  version: string
+}
 
 const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>> = {
   meta: {
@@ -48,7 +48,8 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
           LARK_LONG_CONNECTION_FEATURE,
           LARK_DOCUMENT_SOURCE_FEATURE,
           LARK_ADMIN_VIEW_FEATURE,
-          LARK_ASSISTANT_TEMPLATE_FEATURE
+          LARK_ASSISTANT_TEMPLATE_FEATURE,
+          LARK_LOCAL_HISTORY_FEATURE
         ],
         marketplace: {
           category: 'communication',
@@ -66,19 +67,22 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
                 {
                   name: 'receive-lark-messages',
                   displayName: 'Receive Lark messages',
-                  description: 'Receive Lark webhook or long-connection events and dispatch normalized chat messages to an Agent.',
+                  description:
+                    'Receive Lark webhook or long-connection events and dispatch normalized chat messages to an Agent.',
                   access: 'read'
                 },
                 {
                   name: 'send-lark-messages',
                   displayName: 'Send Lark messages',
-                  description: 'Send text, rich post, or interactive card messages through Lark OpenAPI.',
+                  description:
+                    'Send text, rich post, interactive card, or workspace file messages through Lark OpenAPI.',
                   access: 'write'
                 },
                 {
                   name: 'manage-lark-connections',
                   displayName: 'Manage Lark connections',
-                  description: 'Review and operate webhook or long-connection sessions, users, and conversation bindings.',
+                  description:
+                    'Review and operate webhook or long-connection sessions, users, and conversation bindings.',
                   access: 'admin'
                 }
               ]
@@ -87,19 +91,15 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
               type: 'view',
               name: LARK_VIEW_PROVIDER_KEY,
               displayName: 'Lark Integration View',
-              description: 'Extension view for Lark connection status, managed connections, users, and conversations.'
+              description:
+                'Extension view for Lark connection status, managed connections, users, conversations, and local messages.'
             },
             {
               type: 'tool',
-              name: LARK_NOTIFY_MIDDLEWARE_NAME,
-              displayName: 'Lark Notify Tools',
-              description: 'Assistant middleware for sending, updating, recalling, and routing Lark messages.'
-            },
-            {
-              type: 'tool',
-              name: LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME,
-              displayName: 'Lark Conversation Context Tools',
-              description: 'Assistant middleware for reading Lark message history and message resources.'
+              name: LARK_RUNTIME_MIDDLEWARE_NAME,
+              displayName: 'Lark Runtime',
+              description:
+                'Unified assistant middleware for local history, Lark message and workspace file sending, and remote message access.'
             },
             {
               type: 'feature',
@@ -115,7 +115,8 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
               type: 'assistant-template',
               name: LARK_ADMIN_TEMPLATE_KEY,
               displayName: 'Lark Admin Assistant Template',
-              description: 'Organization-level assistant template for managing Lark integrations, long connections, users, and conversations.',
+              description:
+                'Organization-level assistant template for managing Lark integrations, long connections, users, and conversations.',
               metadata: {
                 templateId: LARK_ADMIN_TEMPLATE_KEY
               }
@@ -124,7 +125,8 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
               type: 'assistant-template',
               name: LARK_CONVERSATION_TEMPLATE_KEY,
               displayName: 'Lark Conversation Assistant Template',
-              description: 'End-user assistant template with a Lark trigger, conversation context, and notification tools.',
+              description:
+                'End-user assistant template with a Lark trigger, locally stored history and attachments, and message/file tools.',
               metadata: {
                 templateId: LARK_CONVERSATION_TEMPLATE_KEY
               }
@@ -134,7 +136,7 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
         runtime: {
           integrationProviders: [LARK_PROVIDER_KEY],
           channelProviders: [LARK_PROVIDER_KEY],
-          middlewareProviders: [LARK_NOTIFY_MIDDLEWARE_NAME, LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME],
+          middlewareProviders: [LARK_RUNTIME_MIDDLEWARE_NAME],
           viewProviders: [LARK_VIEW_PROVIDER_KEY],
           templateProviders: [LARK_TEMPLATE_PROVIDER_KEY],
           triggerProviders: [LARK_PROVIDER_KEY],
@@ -150,7 +152,7 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
     displayName: 'Lark/Feishu Plugin',
     description: 'Bidirectional messaging integration with Lark (Feishu) platform',
     keywords: ['lark', 'feishu', 'document source', 'knowledge', 'integration'],
-    author: 'XpertAI team',
+    author: 'XpertAI team'
   },
   config: {
     schema: IntegrationLarkPluginConfigSchema
@@ -178,9 +180,9 @@ const plugin: LarkXpertPlugin<z.infer<typeof IntegrationLarkPluginConfigSchema>>
   async onStop(ctx) {
     ctx.logger.log('Lark integration plugin stopped')
   }
-};
+}
 
-export default plugin;
-export * from './lib/constants.js';
-export * from './lib/plugin-metadata-compat.js';
-export * from './lib/lark.templates.js';
+export default plugin
+export * from './lib/constants.js'
+export * from './lib/plugin-metadata-compat.js'
+export * from './lib/lark.templates.js'

--- a/xpertai/integrations/lark/src/lib/constants.ts
+++ b/xpertai/integrations/lark/src/lib/constants.ts
@@ -9,10 +9,16 @@ export const LARK_LONG_CONNECTION_FEATURE = 'lark-long-connection'
 export const LARK_DOCUMENT_SOURCE_FEATURE = 'lark-document-source'
 export const LARK_ADMIN_VIEW_FEATURE = 'lark-admin-view'
 export const LARK_ASSISTANT_TEMPLATE_FEATURE = 'lark-assistant-template'
+export const LARK_LOCAL_HISTORY_FEATURE = 'lark-local-history'
 
 export const LARK_NOTIFY_MIDDLEWARE_NAME = 'LarkNotifyMiddleware'
 export const LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME = 'LarkConversationContextMiddleware'
+export const LARK_LOCAL_HISTORY_MIDDLEWARE_NAME = 'LarkLocalHistoryMiddleware'
+export const LARK_RUNTIME_MIDDLEWARE_NAME = 'LarkRuntimeMiddleware'
 export const CHATBI_LARK_MIDDLEWARE_NAME = 'ChatBILarkMiddleware'
+
+export const LARK_SEARCH_CHAT_HISTORY_TOOL_NAME = 'lark_search_chat_history'
+export const LARK_SEND_FILE_TOOL_NAME = 'lark_send_file'
 
 export const LARK_ADMIN_TEMPLATE_KEY = 'lark-admin-assistant'
 export const LARK_CONVERSATION_TEMPLATE_KEY = 'lark-conversation-assistant'

--- a/xpertai/integrations/lark/src/lib/conversation.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.service.spec.ts
@@ -4,20 +4,18 @@
 })
 
 import { LarkConversationService } from './conversation.service.js'
-import {
-	CancelConversationCommand,
-	INTEGRATION_PERMISSION_SERVICE_TOKEN,
-	RequestContext
-} from '@xpert-ai/plugin-sdk'
+import { CancelConversationCommand, INTEGRATION_PERMISSION_SERVICE_TOKEN, RequestContext } from '@xpert-ai/plugin-sdk'
 import { DispatchLarkChatCommand } from './handoff/commands/dispatch-lark-chat.command.js'
 import {
 	ChatLarkContext,
 	LARK_CONFIRM,
+	LARK_DISMISS_PERMISSION_GUIDE,
 	LARK_END_CONVERSATION,
 	LARK_REJECT,
 	LARK_TYPING_REACTION_EMOJI_TYPE
 } from './types.js'
 import { LarkTriggerStrategy } from './workflow/lark-trigger.strategy.js'
+import { buildLarkInboundJobId } from './lark-job-id.js'
 
 const DEFAULT_TRIGGER_CONFIG = {
 	enabled: true,
@@ -89,6 +87,36 @@ describe('LarkConversationService', () => {
 		}
 	}
 
+  function createInboundGroupMessage(): Parameters<LarkConversationService['handleMessage']>[0] {
+    return {
+      chatId: 'chat-1',
+      chatType: 'group',
+      messageId: 'message-duplicate-1',
+      senderId: 'ou_sender_1',
+      senderName: 'Alice',
+      content: 'hello',
+      raw: {},
+      semanticMessage: {
+        rawText: 'hello',
+        displayText: 'hello',
+        agentText: 'hello',
+        mentions: []
+      },
+      isBotMentioned: false
+    }
+  }
+
+  function createInboundEventContext(): Parameters<LarkConversationService['handleMessage']>[1] {
+    return {
+      organizationId: 'org-1',
+      integration: {
+        id: 'integration-1',
+        tenant: null,
+        options: { preferLanguage: 'en_US' }
+      }
+    }
+  }
+
 	function createFixture(params?: {
 		boundXpertId?: string | null
 		triggerHandled?: boolean
@@ -97,6 +125,10 @@ describe('LarkConversationService', () => {
 		conversationBindings?: PersistedConversationBinding[]
 		triggerConfig?: Record<string, unknown>
 		triggerOwnerOpenId?: string | null
+    captureScopeMatches?: boolean
+    captureCreated?: boolean
+    claimInbound?: boolean
+    queuedInbound?: boolean
 	}) {
 		const persistedConversationBindings = [...(params?.conversationBindings ?? [])]
 		let bindingSequence = persistedConversationBindings.length
@@ -122,6 +154,7 @@ describe('LarkConversationService', () => {
 				integrationId: 'integration-1',
 				...(config ?? {})
 			})),
+      matchesInboundScope: jest.fn().mockReturnValue(params?.captureScopeMatches ?? true),
 			matchesInboundMessage: jest.fn().mockImplementation((options: any) => {
 				if (params?.triggerMatches !== undefined) {
 					return params.triggerMatches
@@ -167,9 +200,7 @@ describe('LarkConversationService', () => {
 			})
 		}
 		const conversationBindingRepository = {
-			findOne: jest
-				.fn()
-				.mockImplementation(
+      findOne: jest.fn().mockImplementation(
 					async ({
 						where,
 						order
@@ -187,44 +218,53 @@ describe('LarkConversationService', () => {
 							)
 						}
 						if (where.scopeKey) {
-							return sortBindings(
+            return (
+              sortBindings(
 								persistedConversationBindings.filter((item) => item.scopeKey === where.scopeKey),
 								order
 							)[0] ?? null
+            )
 						}
 						if (where.principalKey) {
-							return sortBindings(
+            return (
+              sortBindings(
 								persistedConversationBindings.filter((item) => item.principalKey === where.principalKey),
 								order
 							)[0] ?? null
+            )
 						}
 						if (where.integrationId && where.chatId) {
-							return sortBindings(
+            return (
+              sortBindings(
 								persistedConversationBindings.filter(
 									(item) => item.integrationId === where.integrationId && item.chatId === where.chatId
 								),
 								order
 							)[0] ?? null
+            )
 						}
 						if (where.userId !== undefined && where.integrationId !== undefined) {
-							return sortBindings(
+            return (
+              sortBindings(
 								persistedConversationBindings.filter(
 									(item) => item.userId === where.userId && item.integrationId === where.integrationId
 								),
 								order
 							)[0] ?? null
+            )
 						}
 						if (where.userId !== undefined) {
-							return sortBindings(
+            return (
+              sortBindings(
 								persistedConversationBindings.filter((item) => item.userId === where.userId),
 								order
 							)[0] ?? null
+            )
 						}
 						if (where.conversationUserKey && where.xpertId) {
 							return (
 								persistedConversationBindings.find(
-									(item) =>
-										item.conversationUserKey === where.conversationUserKey && item.xpertId === where.xpertId
+                (item) => item.conversationUserKey === where.conversationUserKey && item.xpertId === where.xpertId
 								) ?? null
 							)
 						}
@@ -241,9 +281,7 @@ describe('LarkConversationService', () => {
 						return null
 					}
 				),
-				find: jest
-					.fn()
-					.mockImplementation(
+      find: jest.fn().mockImplementation(
 						async ({
 							where,
 							order
@@ -286,9 +324,7 @@ describe('LarkConversationService', () => {
 								})
 							}
 						} else if (conflictPaths.includes('userId') && payload.userId) {
-							const index = persistedConversationBindings.findIndex(
-								(item) => item.userId === payload.userId
-							)
+              const index = persistedConversationBindings.findIndex((item) => item.userId === payload.userId)
 							if (index >= 0) {
 								persistedConversationBindings[index] = {
 									...persistedConversationBindings[index],
@@ -303,8 +339,7 @@ describe('LarkConversationService', () => {
 							}
 						} else {
 							const index = persistedConversationBindings.findIndex(
-								(item) =>
-									item.conversationUserKey === payload.conversationUserKey && item.xpertId === payload.xpertId
+                (item) => item.conversationUserKey === payload.conversationUserKey && item.xpertId === payload.xpertId
 							)
 							if (index >= 0) {
 								persistedConversationBindings[index] = {
@@ -322,17 +357,14 @@ describe('LarkConversationService', () => {
 						return { generatedMaps: [], raw: [], identifiers: [] }
 					}
 				),
-			delete: jest
-				.fn()
-				.mockImplementation(async (criteria: Partial<PersistedConversationBinding>) => {
+      delete: jest.fn().mockImplementation(async (criteria: Partial<PersistedConversationBinding>) => {
 					let removed = 0
 					for (let index = persistedConversationBindings.length - 1; index >= 0; index--) {
 						const item = persistedConversationBindings[index]
 						const matchUserId = criteria.userId === undefined || item.userId === criteria.userId
 						const matchScopeKey = criteria.scopeKey === undefined || item.scopeKey === criteria.scopeKey
 						const matchUserKey =
-							criteria.conversationUserKey === undefined ||
-							item.conversationUserKey === criteria.conversationUserKey
+            criteria.conversationUserKey === undefined || item.conversationUserKey === criteria.conversationUserKey
 						const matchXpertId = criteria.xpertId === undefined || item.xpertId === criteria.xpertId
 						if (matchUserId && matchScopeKey && matchUserKey && matchXpertId) {
 							persistedConversationBindings.splice(index, 1)
@@ -343,16 +375,11 @@ describe('LarkConversationService', () => {
 				})
 		}
 		const triggerBindingRepository = {
-			findOne: jest
-				.fn()
-				.mockImplementation(async ({ where }: { where: { integrationId?: string } }) => {
+      findOne: jest.fn().mockImplementation(async ({ where }: { where: { integrationId?: string } }) => {
 					if (!where.integrationId) {
 						return null
 					}
-					if (
-						persistedTriggerBinding &&
-						persistedTriggerBinding.integrationId === where.integrationId
-					) {
+        if (persistedTriggerBinding && persistedTriggerBinding.integrationId === where.integrationId) {
 						return persistedTriggerBinding
 					}
 					return null
@@ -371,7 +398,9 @@ describe('LarkConversationService', () => {
 		}
 		const cache = new MemoryCache()
 		const larkChannel = {
-			createMessageReaction: jest.fn().mockImplementation(async (_integrationId: string, messageId: string, emojiType: string) => ({
+      createMessageReaction: jest
+        .fn()
+        .mockImplementation(async (_integrationId: string, messageId: string, emojiType: string) => ({
 				messageId,
 				reactionId: `reaction-for-${messageId}`,
 				emojiType
@@ -413,6 +442,25 @@ describe('LarkConversationService', () => {
 		const groupMentionWindowService = {
 			ingest: jest.fn().mockResolvedValue(false)
 		}
+    const messageHistoryService = {
+      captureInbound: jest.fn().mockResolvedValue({
+        log: {
+          id: 'inbound-log-1',
+          createdAt: new Date('2026-07-15T08:00:00.000Z')
+        },
+        created: params?.captureCreated ?? true
+      }),
+      claimInboundStatus: jest.fn().mockResolvedValue(params?.claimInbound ?? true),
+      areInboundLogsInStatus: jest.fn().mockResolvedValue(params?.queuedInbound ?? false),
+      updateInboundStatus: jest.fn().mockResolvedValue([]),
+      materializeFiles: jest.fn().mockResolvedValue({ files: [], failed: [] }),
+      buildHistoryBundle: jest.fn().mockResolvedValue({ messageLogIds: [] }),
+      markContextReset: jest.fn().mockResolvedValue(undefined)
+    }
+    const messageHistoryQueue = {
+      enqueueMaterialize: jest.fn().mockResolvedValue(undefined),
+      scheduleCleanup: jest.fn().mockResolvedValue(undefined)
+    }
 		const service = new LarkConversationService(
 			commandBus as any,
 			cache as any,
@@ -420,6 +468,8 @@ describe('LarkConversationService', () => {
 			contextToolService as any,
 			recipientDirectoryService as any,
 			groupMentionWindowService as any,
+      messageHistoryService as any,
+      messageHistoryQueue as any,
 			conversationBindingRepository as any,
 			triggerBindingRepository as any,
 			pluginContext as any
@@ -434,6 +484,8 @@ describe('LarkConversationService', () => {
 			larkTriggerStrategy,
 			recipientDirectoryService,
 			groupMentionWindowService,
+      messageHistoryService,
+      messageHistoryQueue,
 			conversationBindingRepository,
 			triggerBindingRepository,
 			persistedConversationBindings
@@ -511,7 +563,8 @@ describe('LarkConversationService', () => {
 					reactionId: 'reaction-for-message-1',
 					emojiType: LARK_TYPING_REACTION_EMOJI_TYPE
 				}
-			})
+      }),
+      expect.objectContaining({ removeOnComplete: true })
 		)
 		expect(larkChannel.createMessageReaction).toHaveBeenCalledWith(
 			'integration-1',
@@ -522,7 +575,7 @@ describe('LarkConversationService', () => {
 	})
 
 	it('handleMessage keeps group fallback mention-only when all_messages is not enabled', async () => {
-		const { service, groupMentionWindowService } = createFixture({
+    const { service, groupMentionWindowService, messageHistoryService } = createFixture({
 			boundXpertId: 'trigger-xpert',
 			triggerConfig: {
 				integrationId: 'integration-1',
@@ -569,6 +622,335 @@ describe('LarkConversationService', () => {
 
 		expect(add).not.toHaveBeenCalled()
 		expect(groupMentionWindowService.ingest).not.toHaveBeenCalled()
+    expect(messageHistoryService.captureInbound).not.toHaveBeenCalled()
+  })
+
+  it('persists an allowed unmentioned group message as history_only without triggering the agent', async () => {
+    const { service, messageHistoryService, messageHistoryQueue, groupMentionWindowService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        captureUnmentionedGroupMessages: true,
+        historyContextLimit: 20,
+        historyContextWindowSeconds: 3600,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10,
+        groupReplyStrategy: 'mention_only'
+      }
+    })
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+    messageHistoryQueue.scheduleCleanup.mockRejectedValueOnce(new Error('cleanup queue unavailable'))
+
+    await expect(service.handleMessage(
+      {
+        chatId: 'chat-1',
+        chatType: 'group',
+        messageId: 'message-history-1',
+        senderId: 'ou_sender_1',
+        senderName: 'Alice',
+        content: 'background message',
+        raw: {},
+        semanticMessage: {
+          rawText: 'background message',
+          displayText: 'background message',
+          agentText: 'background message',
+          mentions: []
+        },
+        isBotMentioned: false
+      } as any,
+      {
+        organizationId: 'org-1',
+        integration: { id: 'integration-1', tenant: null, options: { preferLanguage: 'en_US' } }
+      } as any
+    )).resolves.toBeUndefined()
+
+    expect(messageHistoryService.captureInbound).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationId: 'integration-1',
+        xpertId: 'trigger-xpert',
+        messageId: 'message-history-1',
+        chatType: 'group',
+        botMentioned: false
+      })
+    )
+    expect(messageHistoryService.claimInboundStatus).toHaveBeenCalledWith(
+      ['inbound-log-1'],
+      ['received', 'failed'],
+      'history_only'
+    )
+    expect(messageHistoryQueue.scheduleCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ integrationId: 'integration-1', retentionDays: 30 })
+    )
+    expect(messageHistoryService.claimInboundStatus.mock.invocationCallOrder[0]).toBeLessThan(
+      messageHistoryQueue.scheduleCleanup.mock.invocationCallOrder[0]
+    )
+    expect(groupMentionWindowService.ingest).not.toHaveBeenCalled()
+  })
+
+  it('keeps a triggering message queued when cleanup scheduling fails', async () => {
+    const { service, messageHistoryService, messageHistoryQueue } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        groupReplyStrategy: 'all_messages',
+        historyContextLimit: 20,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10
+      }
+    })
+    const add = jest.fn().mockResolvedValue(undefined)
+    jest.spyOn(service, 'getScopeQueue').mockResolvedValue({ add } as any)
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+    messageHistoryQueue.scheduleCleanup.mockRejectedValueOnce(new Error('cleanup queue unavailable'))
+
+    await expect(
+      service.handleMessage(
+        { ...createInboundGroupMessage(), isBotMentioned: true },
+        createInboundEventContext()
+      )
+    ).resolves.toBeUndefined()
+
+    expect(messageHistoryService.claimInboundStatus).toHaveBeenCalledWith(
+      ['inbound-log-1'],
+      ['received', 'failed'],
+      'queued'
+    )
+    expect(add).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        jobId: buildLarkInboundJobId('inbound-log-1'),
+        removeOnComplete: true
+      })
+    )
+    expect(add.mock.calls[0][1].jobId).not.toContain(':')
+    expect(add.mock.invocationCallOrder[0]).toBeLessThan(
+      messageHistoryQueue.scheduleCleanup.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('keeps a direct message queued when cleanup scheduling fails', async () => {
+    const { service, messageHistoryService, messageHistoryQueue } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        historyContextLimit: 20,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10
+      }
+    })
+    const add = jest.fn().mockResolvedValue(undefined)
+    jest.spyOn(service, 'getScopeQueue').mockResolvedValue({ add } as any)
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+    messageHistoryQueue.scheduleCleanup.mockRejectedValueOnce(new Error('cleanup queue unavailable'))
+
+    await expect(
+      service.handleMessage(
+        {
+          chatId: 'chat-p2p-1',
+          chatType: 'p2p',
+          messageId: 'message-p2p-1',
+          senderId: 'ou_sender_1',
+          senderName: 'Alice',
+          content: 'hello',
+          raw: {},
+          semanticMessage: {
+            rawText: 'hello',
+            displayText: 'hello',
+            agentText: 'hello',
+            mentions: []
+          },
+          isBotMentioned: false
+        } as any,
+        createInboundEventContext()
+      )
+    ).resolves.toBeUndefined()
+
+    expect(messageHistoryService.claimInboundStatus).toHaveBeenCalledWith(
+      ['inbound-log-1'],
+      ['received', 'failed'],
+      'queued'
+    )
+    expect(add).toHaveBeenCalledWith(
+      expect.objectContaining({ chatType: 'p2p' }),
+      expect.objectContaining({ jobId: buildLarkInboundJobId('inbound-log-1') })
+    )
+    expect(add.mock.invocationCallOrder[0]).toBeLessThan(
+      messageHistoryQueue.scheduleCleanup.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('keeps a mentioned group message in the mention window when cleanup scheduling fails', async () => {
+    const { service, messageHistoryService, messageHistoryQueue, groupMentionWindowService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        groupReplyStrategy: 'mention_only',
+        historyContextLimit: 20,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10
+      }
+    })
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+    messageHistoryQueue.scheduleCleanup.mockRejectedValueOnce(new Error('cleanup queue unavailable'))
+
+    await expect(
+      service.handleMessage(
+        { ...createInboundGroupMessage(), isBotMentioned: true },
+        createInboundEventContext()
+      )
+    ).resolves.toBeUndefined()
+
+    expect(messageHistoryService.claimInboundStatus).toHaveBeenCalledWith(
+      ['inbound-log-1'],
+      ['received', 'failed'],
+      'queued'
+    )
+    expect(groupMentionWindowService.ingest).toHaveBeenCalledWith(
+      expect.objectContaining({ currentInboundLogIds: ['inbound-log-1'], botMentioned: true })
+    )
+    expect(groupMentionWindowService.ingest.mock.invocationCallOrder[0]).toBeLessThan(
+      messageHistoryQueue.scheduleCleanup.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('resumes a duplicate captured message when its database status is still claimable', async () => {
+    const { service, messageHistoryService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      captureCreated: false,
+      claimInbound: true,
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        groupReplyStrategy: 'all_messages',
+        historyContextLimit: 20,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10
+      }
+    })
+    const add = jest.fn().mockResolvedValue(undefined)
+    jest.spyOn(service, 'getScopeQueue').mockResolvedValue({ add } as any)
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+
+    await service.handleMessage(createInboundGroupMessage(), createInboundEventContext())
+
+    expect(messageHistoryService.claimInboundStatus).toHaveBeenCalledWith(
+      ['inbound-log-1'],
+      ['received', 'failed'],
+      'queued'
+    )
+    expect(add).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a duplicate captured message after another callback already claimed it', async () => {
+    const { service } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      captureCreated: false,
+      claimInbound: false,
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        groupReplyStrategy: 'all_messages',
+        historyContextLimit: 20,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10
+      }
+    })
+    const add = jest.fn().mockResolvedValue(undefined)
+    jest.spyOn(service, 'getScopeQueue').mockResolvedValue({ add } as any)
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+
+    await service.handleMessage(createInboundGroupMessage(), createInboundEventContext())
+
+    expect(add).not.toHaveBeenCalled()
+  })
+
+  it('recovers a duplicate whose process stopped after the queued database claim', async () => {
+    const { service, messageHistoryService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      captureCreated: false,
+      claimInbound: false,
+      queuedInbound: true,
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        groupReplyStrategy: 'all_messages',
+        historyContextLimit: 20,
+        historyRetentionDays: 30,
+        historyAttachmentMaxSizeMb: 10
+      }
+    })
+    const add = jest.fn().mockResolvedValue(undefined)
+    jest.spyOn(service, 'getScopeQueue').mockResolvedValue({ add } as any)
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+
+    await service.handleMessage(createInboundGroupMessage(), createInboundEventContext())
+
+    expect(messageHistoryService.areInboundLogsInStatus).toHaveBeenCalledWith(['inbound-log-1'], 'queued')
+    expect(add).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ jobId: buildLarkInboundJobId('inbound-log-1'), removeOnComplete: true })
+    )
+  })
+
+  it('does not persist messages outside the configured capture scope', async () => {
+    const { service, messageHistoryService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      captureScopeMatches: false,
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        captureUnmentionedGroupMessages: true,
+        historyContextLimit: 20
+      }
+    })
+    jest.spyOn(RequestContext, 'currentUser').mockReturnValue({
+      id: 'creator-user-1',
+      tenantId: 'tenant-1'
+    } as any)
+
+    await service.handleMessage(
+      {
+        chatId: 'chat-outside',
+        chatType: 'group',
+        messageId: 'message-outside',
+        senderId: 'ou_sender_1',
+        content: 'outside',
+        raw: {},
+        semanticMessage: { rawText: 'outside', displayText: 'outside', agentText: 'outside', mentions: [] },
+        isBotMentioned: false
+      } as any,
+      {
+        organizationId: 'org-1',
+        integration: { id: 'integration-1', tenant: null, options: {} }
+      } as any
+    )
+
+    expect(messageHistoryService.captureInbound).not.toHaveBeenCalled()
 	})
 
 	it('processMessage uses mapped sender as fromEndUserId instead of creator fallback', async () => {
@@ -636,6 +1018,130 @@ describe('LarkConversationService', () => {
 			}
 		])
 	})
+
+  it('processMessage sends a materialized current image as inline vision content', async () => {
+    const { service, commandBus, contextToolService, messageHistoryService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      triggerMatches: true,
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        historyAttachmentMaxSizeMb: 10,
+        historyContextLimit: 20,
+        historyContextWindowSeconds: 3600
+      },
+      conversationBindings: [
+        {
+          userId: 'ou_sender_1',
+          integrationId: 'integration-1',
+          scopeKey: 'lark:v2:scope:integration-1:p2p:ou_sender_1',
+          principalKey: 'lark:v2:principal:integration-1:open_id:ou_sender_1',
+          chatType: 'p2p',
+          senderOpenId: 'ou_sender_1',
+          conversationUserKey: 'open_id:ou_sender_1',
+          xpertId: 'trigger-xpert',
+          conversationId: 'conversation-from-db'
+        }
+      ]
+    })
+    messageHistoryService.materializeFiles.mockResolvedValue({
+      files: [
+        {
+          fileAssetId: 'asset-1',
+          fileUrl: 'data:image/png;base64,YWJj',
+          url: 'data:image/png;base64,YWJj',
+          mimeType: 'image/png',
+          originalName: 'photo.png',
+          fileKey: 'img_1'
+        }
+      ],
+      failed: []
+    })
+
+    await service.processMessage({
+      userId: 'creator-user-1',
+      senderOpenId: 'ou_sender_1',
+      integrationId: 'integration-1',
+      chatType: 'p2p',
+      currentInboundLogIds: ['inbound-log-1'],
+      historyBefore: '2026-07-16T09:29:12.000Z',
+      message: {
+        message: {
+          message_id: 'om_image_1',
+          message_type: 'image',
+          content: JSON.stringify({ image_key: 'img_1' })
+        }
+      }
+    } as any)
+
+    expect(messageHistoryService.materializeFiles).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageLogIds: ['inbound-log-1'],
+        inlineImageContent: true
+      })
+    )
+    expect(contextToolService.getMessageResource).not.toHaveBeenCalled()
+    expect(getExecutedDispatchCommands(commandBus as any)[0].input.files).toEqual([
+      expect.objectContaining({
+        fileAssetId: 'asset-1',
+        fileUrl: 'data:image/png;base64,YWJj',
+        mimeType: 'image/png'
+      })
+    ])
+  })
+
+  it('processMessage falls back to the original inline image path when workspace preparation fails', async () => {
+    const { service, commandBus, contextToolService, messageHistoryService } = createFixture({
+      boundXpertId: 'trigger-xpert',
+      triggerMatches: true,
+      triggerConfig: {
+        integrationId: 'integration-1',
+        ...DEFAULT_TRIGGER_CONFIG,
+        historyAttachmentMaxSizeMb: 10,
+        historyContextLimit: 20
+      },
+      conversationBindings: [
+        {
+          userId: 'ou_sender_1',
+          integrationId: 'integration-1',
+          scopeKey: 'lark:v2:scope:integration-1:p2p:ou_sender_1',
+          principalKey: 'lark:v2:principal:integration-1:open_id:ou_sender_1',
+          chatType: 'p2p',
+          senderOpenId: 'ou_sender_1',
+          conversationUserKey: 'open_id:ou_sender_1',
+          xpertId: 'trigger-xpert',
+          conversationId: 'conversation-from-db'
+        }
+      ]
+    })
+    messageHistoryService.materializeFiles.mockRejectedValue(new Error('workspace temporarily unavailable'))
+
+    await service.processMessage({
+      userId: 'creator-user-1',
+      senderOpenId: 'ou_sender_1',
+      integrationId: 'integration-1',
+      chatType: 'p2p',
+      currentInboundLogIds: ['inbound-log-1'],
+      message: {
+        message: {
+          message_id: 'om_image_1',
+          message_type: 'image',
+          content: JSON.stringify({ image_key: 'img_1' })
+        }
+      }
+    } as any)
+
+    expect(contextToolService.getMessageResource).toHaveBeenCalledWith({
+      integrationId: 'integration-1',
+      messageId: 'om_image_1',
+      fileKey: 'img_1',
+      type: 'image',
+      contentMode: 'base64'
+    })
+    expect(getExecutedDispatchCommands(commandBus as any)[0].input.files).toEqual([
+      expect.objectContaining({ fileUrl: 'data:image/png;base64,YWJj', fileKey: 'img_1' })
+    ])
+  })
 
 	it('processMessage forwards inbound post text and images as vision files', async () => {
 		const { service, commandBus, contextToolService } = createFixture({
@@ -798,9 +1304,7 @@ describe('LarkConversationService', () => {
 			]
 		})
 
-		await expect(
-			service.getLatestConversationBindingByUserId('ou_sender_1', 'integration-1')
-		).resolves.toEqual({
+    await expect(service.getLatestConversationBindingByUserId('ou_sender_1', 'integration-1')).resolves.toEqual({
 			userId: 'ou_sender_1',
 			integrationId: 'integration-1',
 			xpertId: 'xpert-current-integration',
@@ -830,9 +1334,7 @@ describe('LarkConversationService', () => {
 			]
 		})
 
-		await expect(
-			service.getLatestConversationBindingByUserId('ou_sender_1', 'integration-1')
-		).resolves.toEqual({
+    await expect(service.getLatestConversationBindingByUserId('ou_sender_1', 'integration-1')).resolves.toEqual({
 			userId: 'ou_sender_1',
 			xpertId: 'xpert-legacy',
 			conversationId: 'conversation-legacy',
@@ -892,9 +1394,7 @@ describe('LarkConversationService', () => {
 			]
 		})
 
-		await expect(
-			service.resolveDispatchExecutionContext('xpert-1', 'open_id:ou_sender_1')
-		).resolves.toEqual({
+    await expect(service.resolveDispatchExecutionContext('xpert-1', 'open_id:ou_sender_1')).resolves.toEqual({
 			tenantId: 'tenant-exact',
 			organizationId: 'org-exact',
 			createdById: 'creator-exact',
@@ -929,9 +1429,7 @@ describe('LarkConversationService', () => {
 			]
 		})
 
-		await expect(
-			service.resolveDispatchExecutionContext('xpert-1', 'open_id:ou_sender_1')
-		).resolves.toEqual({
+    await expect(service.resolveDispatchExecutionContext('xpert-1', 'open_id:ou_sender_1')).resolves.toEqual({
 			tenantId: 'tenant-exact',
 			organizationId: 'org-latest',
 			createdById: 'creator-latest',
@@ -965,9 +1463,7 @@ describe('LarkConversationService', () => {
 			]
 		})
 
-		await expect(
-			service.resolveDispatchExecutionContext('xpert-1', 'open_id:ou_sender_3')
-		).resolves.toEqual({
+    await expect(service.resolveDispatchExecutionContext('xpert-1', 'open_id:ou_sender_3')).resolves.toEqual({
 			tenantId: 'tenant-newest',
 			organizationId: 'org-newest',
 			createdById: 'creator-newest',
@@ -1053,6 +1549,32 @@ describe('LarkConversationService', () => {
 			expect(await service.getActiveMessage(userId, xpertId)).toBeNull()
 		}
 	)
+
+	it('dismisses an application permission guide without dispatching the agent', async () => {
+		const { service, larkChannel, commandBus } = createFixture()
+
+		await service.handleCardAction(
+			{
+				type: 'button',
+				value: { action: LARK_DISMISS_PERMISSION_GUIDE },
+				messageId: 'permission-card-1',
+				chatId: 'chat-1'
+			} as any,
+			{
+				organizationId: 'org-1',
+				integration: {
+					id: 'integration-1',
+					tenant: null,
+					options: { preferLanguage: 'zh_Hans' }
+				}
+			} as any
+		)
+
+		expect(larkChannel.patchInteractiveMessage).toHaveBeenCalledWith('integration-1', 'permission-card-1', {
+			elements: [{ tag: 'markdown', content: '已取消权限开启引导。' }]
+		})
+		expect(commandBus.execute).not.toHaveBeenCalled()
+	})
 
 	it('uses action.messageId fallback when cached thirdPartyMessage.id is missing', async () => {
 		const { service, larkChannel, commandBus } = createFixture()
@@ -1578,11 +2100,7 @@ describe('LarkConversationService', () => {
 			}
 		} as any)
 
-		expect(larkChannel.deleteMessageReaction).toHaveBeenCalledWith(
-			'integration-1',
-			'message-1',
-			'reaction-1'
-		)
+    expect(larkChannel.deleteMessageReaction).toHaveBeenCalledWith('integration-1', 'message-1', 'reaction-1')
 		expect(larkChannel.errorMessage).not.toHaveBeenCalled()
 	})
 
@@ -1618,9 +2136,7 @@ describe('LarkConversationService', () => {
 		const dispatchCommands = getExecutedDispatchCommands(commandBus as any)
 		expect(dispatchCommands).toHaveLength(1)
 		expect(dispatchCommands[0].input.xpertId).toBe('legacy-xpert')
-		expect(
-			await service.getConversation('lark:v2:scope:integration-1:group:chat-new', 'xpert-from-db')
-		).toBeUndefined()
+    expect(await service.getConversation('lark:v2:scope:integration-1:group:chat-new', 'xpert-from-db')).toBeUndefined()
 		expect(larkTriggerStrategy.handleInboundMessage).toHaveBeenCalledTimes(1)
 	})
 
@@ -1908,11 +2424,7 @@ describe('LarkConversationService', () => {
 			}
 		} as any)
 
-		expect(larkChannel.deleteMessageReaction).toHaveBeenCalledWith(
-			'integration-1',
-			'message-2',
-			'reaction-2'
-		)
+    expect(larkChannel.deleteMessageReaction).toHaveBeenCalledWith('integration-1', 'message-2', 'reaction-2')
 		expect(larkChannel.errorMessage).toHaveBeenCalledTimes(1)
 	})
 
@@ -1997,7 +2509,9 @@ describe('LarkConversationService', () => {
 		)
 		const dispatchCommands = getExecutedDispatchCommands(commandBus as any)
 		expect(dispatchCommands).toHaveLength(1)
-		expect(dispatchCommands[0].input.input).toBe('Alice Zhang: \u8bf7\u5e2e\u6211\u603b\u7ed3\u4e00\u4e0b\u4eca\u5929\u7684\u8ba8\u8bba')
+    expect(dispatchCommands[0].input.input).toBe(
+      'Alice Zhang: \u8bf7\u5e2e\u6211\u603b\u7ed3\u4e00\u4e0b\u4eca\u5929\u7684\u8ba8\u8bba'
+    )
 		expect(larkChannel.resolveUserNameByOpenId).not.toHaveBeenCalled()
 	})
 

--- a/xpertai/integrations/lark/src/lib/conversation.service.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.service.ts
@@ -31,12 +31,16 @@ import { translate } from './i18n.js'
 import { LarkChannelStrategy } from './lark-channel.strategy.js'
 import { DispatchLarkChatCommand, DispatchLarkChatPayload } from './handoff/commands/dispatch-lark-chat.command.js'
 import {
+  extractLarkMessageResourceRefs,
 	extractLarkSemanticMessage,
 	getLarkMessageContent,
 	getLarkMessageType,
 	unwrapLarkEventPayload
 } from './lark-message-semantics.js'
 import { LarkRecipientDirectoryService } from './lark-recipient-directory.service.js'
+import { buildLarkCardActionJobId, buildLarkInboundJobId } from './lark-job-id.js'
+import { LarkMessageHistoryQueueService } from './lark-message-history-queue.service.js'
+import { LarkMessageHistoryService } from './lark-message-history.service.js'
 import { LARK_PLUGIN_CONTEXT } from './tokens.js'
 import {
 	ChatLarkContext,
@@ -44,6 +48,7 @@ import {
 	isEndAction,
 	isLarkCardActionValue,
 	isRejectAction,
+	LARK_DISMISS_PERMISSION_GUIDE,
 	LarkGroupWindow,
 	LarkInboundFile,
 	LARK_TYPING_REACTION_EMOJI_TYPE,
@@ -56,6 +61,7 @@ import {
 import { LarkConversationBindingEntity } from './entities/lark-conversation-binding.entity.js'
 import { LarkTriggerBindingEntity } from './entities/lark-trigger-binding.entity.js'
 import { LarkGroupMentionWindowService } from './lark-group-mention-window.service.js'
+import type { TLarkTriggerConfig } from './workflow/lark-trigger.types.js'
 
 type LarkConversationQueueJob = ChatLarkContext<TLarkEvent> & {
 	tenantId?: string
@@ -67,10 +73,17 @@ type LarkInboundImageRef = {
 }
 
 type LarkTriggerService = {
-	normalizeConfig: (
-		config?: Record<string, unknown> | null,
+  normalizeConfig: (config?: Record<string, unknown> | null, integrationId?: string | null) => TLarkTriggerConfig
+  matchesInboundScope: (params: {
+    binding?: LarkTriggerBindingEntity | null
+    config?: Partial<TLarkTriggerConfig> | null
+    ownerOpenId?: string | null
 		integrationId?: string | null
-	) => Record<string, unknown>
+    chatType?: string | null
+    chatId?: string | null
+    senderOpenId?: string | null
+    botMentioned?: boolean
+  }) => boolean
 	matchesInboundMessage: (params: {
 		binding?: LarkTriggerBindingEntity | null
 		config?: Record<string, unknown> | null
@@ -85,6 +98,10 @@ type LarkTriggerService = {
 		integrationId: string
 		input?: string
 		files?: LarkInboundFile[]
+    historyContext?: string
+    historyFiles?: LarkInboundFile[]
+    currentInboundLogIds?: string[]
+    historyBefore?: string
 		larkMessage: ChatLarkMessage
 		options?: {
 			confirm?: boolean
@@ -203,6 +220,8 @@ export class LarkConversationService implements OnModuleDestroy {
 		private readonly contextToolService: LarkContextToolService,
 		private readonly recipientDirectoryService: LarkRecipientDirectoryService,
 		private readonly groupMentionWindowService: LarkGroupMentionWindowService,
+    private readonly messageHistoryService: LarkMessageHistoryService,
+    private readonly messageHistoryQueue: LarkMessageHistoryQueueService,
 		@InjectRepository(LarkConversationBindingEntity)
 		private readonly conversationBindingRepository: Repository<LarkConversationBindingEntity>,
 		@InjectRepository(LarkTriggerBindingEntity)
@@ -318,9 +337,38 @@ export class LarkConversationService implements OnModuleDestroy {
 		return senderName
 	}
 
-	private withSpeakerContext(input: string | undefined, senderName: string | null, chatType?: string | null): string | undefined {
+  private withSpeakerContext(
+    input: string | undefined,
+    senderName: string | null,
+    chatType?: string | null
+  ): string | undefined {
 		return buildLarkSpeakerContextInput(input, senderName, chatType)
 	}
+
+  private mergeInboundFiles(current?: LarkInboundFile[], incoming?: LarkInboundFile[]): LarkInboundFile[] | undefined {
+    const files = [...(current ?? []), ...(incoming ?? [])]
+    if (!files.length) {
+      return undefined
+    }
+    const seen = new Set<string>()
+    return files.filter((file, index) => {
+      const key =
+        file.fileAssetId ??
+        file.fileId ??
+        file.storageFileId ??
+        file.workspacePath ??
+        file.filePath ??
+        file.fileUrl ??
+        file.url ??
+        file.fileKey ??
+        `index:${index}`
+      if (seen.has(key)) {
+        return false
+      }
+      seen.add(key)
+      return true
+    })
+  }
 
 	private async resolveInboundImageFiles(params: {
 		integrationId: string
@@ -345,7 +393,9 @@ export class LarkConversationService implements OnModuleDestroy {
 				throw new Error(`Lark image resource "${ref.fileKey}" did not return inline content`)
 			}
 			if (!item.mimeType?.startsWith('image/')) {
-				throw new Error(`Lark image resource "${ref.fileKey}" returned non-image mime type "${item.mimeType ?? 'unknown'}"`)
+        throw new Error(
+          `Lark image resource "${ref.fileKey}" returned non-image mime type "${item.mimeType ?? 'unknown'}"`
+        )
 			}
 			if (typeof item.size === 'number' && item.size > LarkConversationService.maxInlineImageBytes) {
 				throw new Error(
@@ -507,7 +557,13 @@ export class LarkConversationService implements OnModuleDestroy {
 		const matchedSelectedUser = senderOpenId ? singleChatUserOpenIds.includes(senderOpenId) : false
 
 		this.logger.log(
-			`[lark-dispatch] single-chat-scope integration=${params.integrationId} sender=${senderOpenId ?? 'n/a'} allowed=${params.allowed} scope=${singleChatScope} matchedSelectedUser=${matchedSelectedUser} selectedUserOpenIds=${JSON.stringify(singleChatUserOpenIds)} boundXpert=${params.binding.xpertId} targetBinding=${params.targetBinding ? 'hit' : 'miss'} targetXpert=${params.targetXpertId ?? 'n/a'}`
+      `[lark-dispatch] single-chat-scope integration=${params.integrationId} sender=${senderOpenId ?? 'n/a'} allowed=${
+        params.allowed
+      } scope=${singleChatScope} matchedSelectedUser=${matchedSelectedUser} selectedUserOpenIds=${JSON.stringify(
+        singleChatUserOpenIds
+      )} boundXpert=${params.binding.xpertId} targetBinding=${params.targetBinding ? 'hit' : 'miss'} targetXpert=${
+        params.targetXpertId ?? 'n/a'
+      }`
 		)
 	}
 
@@ -539,8 +595,7 @@ export class LarkConversationService implements OnModuleDestroy {
 	buildBindingMeta(meta: LarkConversationBindingMeta): LarkConversationBindingMeta {
 		const normalizedScopeKey = normalizeConversationUserKey(meta.scopeKey)
 		const allowLegacyFallback = this.shouldAllowLegacyFallbackForScope(normalizedScopeKey)
-		const normalizedLegacyConversationUserKey =
-			allowLegacyFallback
+    const normalizedLegacyConversationUserKey = allowLegacyFallback
 				? normalizeConversationUserKey(meta.legacyConversationUserKey) ??
 				  (this.shouldMirrorLegacyConversationUserKey(normalizedScopeKey)
 						? normalizedScopeKey
@@ -641,12 +696,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		return conversationId
 	}
 
-	async setConversation(
-		scopeKey: string,
-		xpertId: string,
-		conversationId: string,
-		meta?: LarkConversationBindingMeta
-	) {
+  async setConversation(scopeKey: string, xpertId: string, conversationId: string, meta?: LarkConversationBindingMeta) {
 		const normalizedScopeKey = normalizeConversationUserKey(scopeKey)
 		const normalizedXpertId = normalizeConversationUserKey(xpertId)
 		const normalizedConversationId = normalizeConversationUserKey(conversationId)
@@ -712,7 +762,9 @@ export class LarkConversationService implements OnModuleDestroy {
 		return this.normalizeBinding(binding)
 	}
 
-	async getLatestConversationBindingByPrincipalKey(principalKey: string): Promise<LarkConversationBindingLookup | null> {
+  async getLatestConversationBindingByPrincipalKey(
+    principalKey: string
+  ): Promise<LarkConversationBindingLookup | null> {
 		const normalizedPrincipalKey = normalizeConversationUserKey(principalKey)
 		if (!normalizedPrincipalKey) {
 			return null
@@ -813,12 +865,9 @@ export class LarkConversationService implements OnModuleDestroy {
 					return true
 				}
 
-				return [
-					binding.chatId,
-					binding.senderOpenId,
-					binding.xpertId,
-					binding.conversationId
-				].some((value) => normalizeListSearch(value)?.includes(normalizedSearch))
+        return [binding.chatId, binding.senderOpenId, binding.xpertId, binding.conversationId].some((value) =>
+          normalizeListSearch(value)?.includes(normalizedSearch)
+        )
 			})
 
 		const sorted = this.sortBindingListItems(filtered, query.sortBy, query.sortDirection)
@@ -1100,9 +1149,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		groupWindow?: LarkGroupWindow
 		mappedUserId?: string | null
 	}): DispatchLarkChatPayload['options'] | undefined {
-		const fromEndUserId = normalizeConversationUserKey(
-			params?.groupWindow?.items[0]?.userId ?? params?.mappedUserId
-		)
+    const fromEndUserId = normalizeConversationUserKey(params?.groupWindow?.items[0]?.userId ?? params?.mappedUserId)
 		if (!params?.groupWindow && !fromEndUserId) {
 			return undefined
 		}
@@ -1194,9 +1241,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		return Date.now() - lastActiveAt.getTime() > timeoutMs
 	}
 
-	private async getConversationBindingUpdatedAt(
-		binding: LarkConversationBindingLookup
-	): Promise<Date | null> {
+  private async getConversationBindingUpdatedAt(binding: LarkConversationBindingLookup): Promise<Date | null> {
 		const row = binding.scopeKey
 			? await this.conversationBindingRepository.findOne({
 					where: {
@@ -1303,8 +1348,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		fallbackXpertId?: string | null
 		}): Promise<LarkTargetXpertResolution> {
 		let scopeBinding = params.scopeKey ? await this.getLatestConversationBindingByScopeKey(params.scopeKey) : null
-		let fallbackBinding =
-			scopeBinding
+    let fallbackBinding = scopeBinding
 				? null
 				: (params.principalKey ? await this.getLatestConversationBindingByPrincipalKey(params.principalKey) : null) ??
 				  (params.senderOpenId
@@ -1393,13 +1437,15 @@ export class LarkConversationService implements OnModuleDestroy {
 			}))
 		const dispatchInput =
 			options.groupWindow && text ? text : this.withSpeakerContext(text, senderName, options.chatType)
-		let resolvedFiles: LarkInboundFile[] | undefined
+    let resolvedFiles: LarkInboundFile[] | undefined = options.files
+    let historyContext = options.historyContext
+    let historyFiles = options.historyFiles
 		const getDispatchFiles = async () => {
 			if (resolvedFiles) {
 				return resolvedFiles
 			}
-			resolvedFiles = options.files?.length
-				? options.files
+      resolvedFiles = options.currentInboundLogIds?.length
+        ? []
 				: await this.resolveInboundImageFiles({
 						integrationId,
 						message
@@ -1408,13 +1454,8 @@ export class LarkConversationService implements OnModuleDestroy {
 		}
 		const fallbackXpertId = integration.options?.xpertId
 		const boundTriggerBinding = await this.getBoundTriggerBinding(integrationId)
-		const {
-			scopeBinding,
-			fallbackBinding,
-			targetBinding,
-			targetXpertId,
-			useDispatchInputForTrigger
-		} = await this.resolveTargetXpertId({
+    const { scopeBinding, fallbackBinding, targetBinding, targetXpertId, useDispatchInputForTrigger } =
+      await this.resolveTargetXpertId({
 			integrationId,
 			scopeKey: keys.scopeKey,
 			legacyConversationUserKey: keys.legacyConversationUserKey,
@@ -1424,6 +1465,11 @@ export class LarkConversationService implements OnModuleDestroy {
 		})
 
 		if (!targetXpertId) {
+      await this.messageHistoryService.updateInboundStatus(
+        options.currentInboundLogIds ?? [],
+        'failed',
+        'xpert_not_configured'
+      )
 			await this.clearTypingReaction(options)
 			await this.larkChannel.errorMessage(
 				{
@@ -1447,12 +1493,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		let activeTargetBinding = targetBinding
 		if (boundTriggerBinding && activeTargetBinding?.xpertId === boundTriggerBinding.xpertId) {
 			const triggerConfig = larkTriggerStrategy.normalizeConfig(boundTriggerBinding.config, integrationId)
-			if (
-				await this.isTriggerConversationExpired(
-					activeTargetBinding,
-					triggerConfig.sessionTimeoutSeconds
-				)
-			) {
+      if (await this.isTriggerConversationExpired(activeTargetBinding, triggerConfig.sessionTimeoutSeconds)) {
 				await this.purgeBindingSession(
 					activeTargetBinding,
 					activeTargetBinding.scopeKey ?? effectiveScopeKey,
@@ -1464,6 +1505,62 @@ export class LarkConversationService implements OnModuleDestroy {
 			}
 		}
 		const activeTargetXpertId = activeTargetBinding?.xpertId ?? targetXpertId
+    const normalizedTriggerConfig = boundTriggerBinding
+      ? larkTriggerStrategy.normalizeConfig(boundTriggerBinding.config, integrationId)
+      : null
+    if (options.currentInboundLogIds?.length && normalizedTriggerConfig) {
+      try {
+        const materialized = await this.messageHistoryService.materializeFiles({
+          integrationId,
+          xpertId: activeTargetXpertId,
+          tenantId: options.tenantId ?? integration.tenantId,
+          organizationId: options.organizationId ?? integration.organizationId,
+          messageLogIds: options.currentInboundLogIds,
+          maxSizeMb: normalizedTriggerConfig.historyAttachmentMaxSizeMb,
+          maxFiles: 20,
+          inlineImageContent: true
+        })
+        resolvedFiles = this.mergeInboundFiles(options.files, materialized.files)
+        const history = await this.messageHistoryService.buildHistoryBundle({
+          integrationId,
+          scopeKey: effectiveScopeKey,
+          xpertId: activeTargetXpertId,
+          tenantId: options.tenantId ?? integration.tenantId,
+          organizationId: options.organizationId ?? integration.organizationId,
+          limit: normalizedTriggerConfig.historyContextLimit,
+          windowSeconds: normalizedTriggerConfig.historyContextWindowSeconds,
+          before: options.historyBefore,
+          excludedLogIds: options.currentInboundLogIds,
+          maxFiles: 20,
+          maxFileSizeMb: normalizedTriggerConfig.historyAttachmentMaxSizeMb
+        })
+        historyContext ??= history.context
+        historyFiles ??= history.files
+      } catch (error) {
+        this.logger.warn(
+          `[lark-history] attachment/context preparation failed; continue with text: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+        const hasInlineImage = resolvedFiles?.some((file) =>
+          (file.fileUrl ?? file.url)?.startsWith('data:image/')
+        )
+        if (!hasInlineImage) {
+          try {
+            resolvedFiles = this.mergeInboundFiles(
+              resolvedFiles,
+              await this.resolveInboundImageFiles({ integrationId, message })
+            )
+          } catch (fallbackError) {
+            this.logger.warn(
+              `[lark-history] inline image fallback failed: ${
+                fallbackError instanceof Error ? fallbackError.message : String(fallbackError)
+              }`
+            )
+          }
+        }
+      }
+    }
 		if (activeTargetBinding?.conversationId) {
 			await this.cacheConversation(
 				effectiveScopeKey,
@@ -1528,30 +1625,44 @@ export class LarkConversationService implements OnModuleDestroy {
 					legacyConversationUserKey
 				})
 				this.logger.debug(
-					`[lark-dispatch] inbound blocked by trigger scope integration=${integrationId} chat=${options.chatId ?? 'n/a'} sender=${senderOpenId ?? 'n/a'}`
+          `[lark-dispatch] inbound blocked by trigger scope integration=${integrationId} chat=${
+            options.chatId ?? 'n/a'
+          } sender=${senderOpenId ?? 'n/a'}`
 				)
 				await this.clearTypingReaction(options)
 				return null
 			}
 		}
+    const triggerSummaryWindowEnabled = Boolean(
+      boundTriggerBinding && this.resolveTriggerSummaryWindowSeconds(boundTriggerBinding, larkTriggerStrategy) > 0
+    )
 		const shouldBufferTriggerMessage =
-			boundTriggerBinding &&
+      triggerSummaryWindowEnabled &&
 			activeTargetBinding?.xpertId === boundTriggerBinding.xpertId &&
-			this.resolveTriggerSummaryWindowSeconds(boundTriggerBinding, larkTriggerStrategy) > 0
+      Boolean(activeTargetBinding)
 		if (activeTargetBinding && !shouldBufferTriggerMessage) {
-			return await this.dispatchToLarkChat({
+      const dispatched = await this.dispatchToLarkChat({
 				xpertId: activeTargetXpertId,
 				input: dispatchInput,
 				files: await getDispatchFiles(),
+        historyContext,
+        historyFiles,
+        currentInboundLogIds: options.currentInboundLogIds,
 				larkMessage,
 				options: dispatchOptions
 			})
+      await this.messageHistoryService.updateInboundStatus(options.currentInboundLogIds ?? [], 'dispatched')
+      return dispatched
 		}
 
 		const handledByTrigger = await larkTriggerStrategy.handleInboundMessage({
 			integrationId,
 			input: activeTargetBinding || useDispatchInputForTrigger ? dispatchInput : text,
 			files: await getDispatchFiles(),
+      historyContext,
+      historyFiles,
+      currentInboundLogIds: options.currentInboundLogIds,
+      historyBefore: options.historyBefore,
 			larkMessage,
 			options: {
 				...dispatchOptions,
@@ -1559,20 +1670,33 @@ export class LarkConversationService implements OnModuleDestroy {
 			}
 		})
 		if (handledByTrigger) {
+      if (!triggerSummaryWindowEnabled) {
+        await this.messageHistoryService.updateInboundStatus(options.currentInboundLogIds ?? [], 'dispatched')
+      }
 			return larkMessage
 		}
 
 		if (!boundTriggerBinding && fallbackXpertId) {
-			return await this.dispatchToLarkChat({
+      const dispatched = await this.dispatchToLarkChat({
 				xpertId: fallbackXpertId,
 				input: dispatchInput,
 				files: await getDispatchFiles(),
+        historyContext,
+        historyFiles,
+        currentInboundLogIds: options.currentInboundLogIds,
 				larkMessage,
 				options: dispatchOptions
 			})
+      await this.messageHistoryService.updateInboundStatus(options.currentInboundLogIds ?? [], 'dispatched')
+      return dispatched
 		}
 
 		await this.clearTypingReaction(options)
+    await this.messageHistoryService.updateInboundStatus(
+      options.currentInboundLogIds ?? [],
+      'failed',
+      'handoff_dispatch_not_handled'
+    )
 		await this.larkChannel.errorMessage(
 			{
 				integrationId,
@@ -1600,11 +1724,17 @@ export class LarkConversationService implements OnModuleDestroy {
 
 		if (!isEndAction(action) && !isConfirmAction(action) && !isRejectAction(action)) {
 			const scopeQueue = await this.getScopeQueue(chatContext.scopeKey ?? scopeKey)
-			await scopeQueue.add({
-				...chatContext,
-				tenantId: RequestContext.currentUser()?.tenantId,
-				input: action
-			})
+			await scopeQueue.add(
+				{
+					...chatContext,
+					tenantId: RequestContext.currentUser()?.tenantId,
+					input: action
+				},
+				{
+					jobId: buildLarkCardActionJobId(scopeKey, xpertId, action, actionMessageId),
+					removeOnComplete: true
+				}
+			)
 			return
 		}
 
@@ -1655,6 +1785,24 @@ export class LarkConversationService implements OnModuleDestroy {
 		if (isEndAction(action)) {
 			await prevMessage.end()
 			await this.cancelConversation(conversationId)
+      const triggerBinding = await this.getBoundTriggerBinding(chatContext.integrationId)
+      if (triggerBinding) {
+        const triggerConfig = (await this.getLarkTriggerStrategy()).normalizeConfig(
+          triggerBinding.config,
+          chatContext.integrationId
+        )
+        if (triggerConfig.captureUnmentionedGroupMessages || triggerConfig.historyContextLimit > 0) {
+          await this.messageHistoryService.markContextReset({
+            integrationId: chatContext.integrationId,
+            scopeKey,
+            xpertId,
+            conversationId,
+            tenantId: chatContext.tenantId ?? chatContext.tenant?.id,
+            organizationId: chatContext.organizationId,
+            createdById: RequestContext.currentUserId() ?? undefined
+          })
+        }
+      }
 			await this.clearConversationSession(scopeKey, xpertId, {
 				legacyConversationUserKey
 			})
@@ -1762,10 +1910,7 @@ export class LarkConversationService implements OnModuleDestroy {
 		})
 
 		const normalizedLegacyConversationUserKey = normalizeConversationUserKey(legacyConversationUserKey)
-		if (
-			this.shouldAllowLegacyFallbackForScope(scopeKey) &&
-			normalizedLegacyConversationUserKey
-		) {
+    if (this.shouldAllowLegacyFallbackForScope(scopeKey) && normalizedLegacyConversationUserKey) {
 			await this.conversationBindingRepository.delete({
 				conversationUserKey: normalizedLegacyConversationUserKey,
 				xpertId
@@ -1798,9 +1943,7 @@ export class LarkConversationService implements OnModuleDestroy {
 			await this.commandBus.execute(new CancelConversationCommand({ conversationId }))
 		} catch (error) {
 			this.logger.warn(
-				`Failed to cancel conversation "${conversationId}" from Lark end action: ${
-					(error as Error)?.message ?? error
-				}`
+        `Failed to cancel conversation "${conversationId}" from Lark end action: ${(error as Error)?.message ?? error}`
 			)
 		}
 	}
@@ -1848,6 +1991,11 @@ export class LarkConversationService implements OnModuleDestroy {
 							await this.processMessage(job.data as ChatLarkContext<TLarkEvent>)
 							return `Processed message: ${job.id}`
 						} catch (err) {
+              await this.messageHistoryService.updateInboundStatus(
+                job.data.currentInboundLogIds ?? [],
+                'failed',
+                err instanceof Error ? err.message : String(err)
+              )
 							this.logger.error(err)
 							return `Failed to process message: ${job.id} with error ${(err as Error)?.message ?? err}`
 						}
@@ -1910,22 +2058,98 @@ export class LarkConversationService implements OnModuleDestroy {
 		if (semanticMessage?.agentText) {
 			return semanticMessage.agentText
 		}
-		return typeof message.content === 'string' && message.content.trim().length > 0
-			? message.content.trim()
-			: undefined
+    return typeof message.content === 'string' && message.content.trim().length > 0 ? message.content.trim() : undefined
+  }
+
+  private normalizeInboundMessageDate(value: unknown): Date | undefined {
+    const timestamp = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN
+    if (!Number.isFinite(timestamp) || timestamp <= 0) {
+      return undefined
+    }
+    const date = new Date(timestamp < 1_000_000_000_000 ? timestamp * 1000 : timestamp)
+    return Number.isNaN(date.getTime()) ? undefined : date
+  }
+
+  private async enqueueConversationJob(scopeKey: string, queueJob: LarkConversationQueueJob): Promise<boolean> {
+    const currentInboundLogIds = queueJob.currentInboundLogIds ?? []
+    const claimed = await this.messageHistoryService.claimInboundStatus(
+      currentInboundLogIds,
+      ['received', 'failed'],
+      'queued'
+    )
+    const canRecoverQueuedJob =
+      !claimed &&
+      currentInboundLogIds.length > 0 &&
+      (await this.messageHistoryService.areInboundLogsInStatus(currentInboundLogIds, 'queued'))
+    if (!claimed && !canRecoverQueuedJob) {
+      return false
+    }
+    try {
+      await this.bestEffortAttachTypingReaction(queueJob)
+      const scopeQueue = await this.getScopeQueue(scopeKey)
+      await scopeQueue.add(queueJob, {
+        ...(currentInboundLogIds[0] ? { jobId: buildLarkInboundJobId(currentInboundLogIds[0]) } : {}),
+        removeOnComplete: true
+      })
+      return true
+    } catch (error) {
+      await this.messageHistoryService.updateInboundStatus(
+        queueJob.currentInboundLogIds ?? [],
+        'failed',
+        error instanceof Error ? error.message : String(error)
+      )
+      throw error
+    }
+  }
+
+  private scheduleHistoryCleanupBestEffort(payload: {
+    integrationId: string
+    tenantId?: string
+    organizationId?: string
+    retentionDays: number
+  }): void {
+    void (async () => {
+      try {
+        await this.messageHistoryQueue.scheduleCleanup(payload)
+      } catch (error) {
+        this.logger.warn(
+          `[lark-history] Failed to schedule cleanup for integration ${payload.integrationId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+    })()
 	}
+
+  private scheduleHistoryMaterializationBestEffort(payload: {
+    integrationId: string
+    xpertId: string
+    tenantId?: string
+    organizationId?: string
+    messageLogIds: string[]
+    maxSizeMb: number
+  }): void {
+    void (async () => {
+      try {
+        await this.messageHistoryQueue.enqueueMaterialize(payload)
+      } catch (error) {
+        this.logger.warn(
+          `[lark-history] Failed to enqueue attachment materialization for integration ${payload.integrationId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`
+        )
+      }
+    })()
+  }
 
 	private getMappedUserIdFromCurrentRequest(): string | undefined {
 		return (
-			normalizeConversationUserKey(
-				getLarkInboundIdentityMetadata(RequestContext.currentUser())?.mappedUserId
-			) ?? undefined
+      normalizeConversationUserKey(getLarkInboundIdentityMetadata(RequestContext.currentUser())?.mappedUserId) ??
+      undefined
 		)
 	}
 
-	private async shouldBypassGroupMentionWindow(
-		queueJob: LarkConversationQueueJob
-	): Promise<boolean> {
+  private async shouldBypassGroupMentionWindow(queueJob: LarkConversationQueueJob): Promise<boolean> {
 		if (queueJob.chatType !== 'group') {
 			return false
 		}
@@ -1981,6 +2205,107 @@ export class LarkConversationService implements OnModuleDestroy {
 			senderOpenId: message.senderId,
 			fallbackUserId: user.id
 		})
+    const boundTriggerBinding = await this.getBoundTriggerBinding(ctx.integration.id)
+    const larkTriggerStrategy = boundTriggerBinding ? await this.getLarkTriggerStrategy() : null
+    const triggerConfig = boundTriggerBinding
+      ? larkTriggerStrategy!.normalizeConfig(boundTriggerBinding.config, ctx.integration.id)
+      : null
+    const chatType = message.chatType === 'private' ? 'p2p' : message.chatType
+    const botMentioned = Boolean((message as TChatInboundMessage & { isBotMentioned?: boolean }).isBotMentioned)
+    const matchesCaptureScope = Boolean(
+      boundTriggerBinding &&
+        larkTriggerStrategy?.matchesInboundScope({
+          binding: boundTriggerBinding,
+          integrationId: ctx.integration.id,
+          chatType,
+          chatId: message.chatId,
+          senderOpenId: message.senderId,
+          botMentioned
+        })
+    )
+    const historyEnabled = Boolean(
+      triggerConfig && (triggerConfig.captureUnmentionedGroupMessages || triggerConfig.historyContextLimit > 0)
+    )
+    const shouldCaptureInbound = Boolean(
+      historyEnabled &&
+        matchesCaptureScope &&
+        (chatType !== 'group' ||
+          botMentioned ||
+          triggerConfig?.groupReplyStrategy === 'all_messages' ||
+          triggerConfig?.captureUnmentionedGroupMessages)
+    )
+    let currentInboundLogIds: string[] | undefined
+    let historyBefore: string | undefined
+    let cleanupRequest:
+      | {
+          integrationId: string
+          tenantId?: string
+          organizationId?: string
+          retentionDays: number
+        }
+      | undefined
+    if (shouldCaptureInbound && keys.scopeKey && boundTriggerBinding?.xpertId) {
+      const capture = await this.messageHistoryService.captureInbound({
+        integrationId: ctx.integration.id,
+        scopeKey: keys.scopeKey,
+        xpertId: boundTriggerBinding.xpertId,
+        tenantId: user.tenantId || ctx.tenantId,
+        organizationId: ctx.organizationId,
+        messageId: message.messageId,
+        chatType: chatType === 'p2p' ? 'p2p' : chatType === 'group' ? 'group' : null,
+        chatId: message.chatId,
+        senderOpenId: message.senderId,
+        senderName: message.senderName,
+        messageType: getLarkMessageType(unwrapLarkEventPayload(message.raw)?.message) ?? message.contentType,
+        content: semanticMessage?.displayText || (typeof message.content === 'string' ? message.content : ''),
+        botMentioned,
+        messageCreatedAt: this.normalizeInboundMessageDate(message.timestamp),
+        resourceRefs: extractLarkMessageResourceRefs(message.raw),
+        createdById: user.id
+      })
+      if (!capture.created) {
+        this.logger.debug(
+          `[lark-history] duplicate inbound will resume only when claimable integration=${ctx.integration.id} message=${
+            message.messageId ?? 'n/a'
+          }`
+        )
+      }
+      currentInboundLogIds = [capture.log.id]
+      historyBefore = capture.log.createdAt.toISOString()
+      cleanupRequest = {
+        integrationId: ctx.integration.id,
+        tenantId: user.tenantId || ctx.tenantId,
+        organizationId: ctx.organizationId,
+        retentionDays: triggerConfig!.historyRetentionDays
+      }
+
+      const captureOnlyGroupMessage =
+        chatType === 'group' && !botMentioned && triggerConfig?.groupReplyStrategy === 'mention_only'
+      if (captureOnlyGroupMessage) {
+        const claimed = await this.messageHistoryService.claimInboundStatus(
+          currentInboundLogIds,
+          ['received', 'failed'],
+          'history_only'
+        )
+        if (!claimed) {
+          return
+        }
+        if (cleanupRequest) {
+          this.scheduleHistoryCleanupBestEffort(cleanupRequest)
+        }
+        if (extractLarkMessageResourceRefs(message.raw).length) {
+          this.scheduleHistoryMaterializationBestEffort({
+            integrationId: ctx.integration.id,
+            xpertId: boundTriggerBinding.xpertId,
+            tenantId: user.tenantId || ctx.tenantId,
+            organizationId: ctx.organizationId,
+            messageLogIds: currentInboundLogIds,
+            maxSizeMb: triggerConfig!.historyAttachmentMaxSizeMb
+          })
+        }
+        return
+      }
+    }
 		const queueJob: LarkConversationQueueJob = {
 			tenant: ctx.integration.tenant,
 			tenantId: user.tenantId || ctx.tenantId,
@@ -1992,7 +2317,7 @@ export class LarkConversationService implements OnModuleDestroy {
 			message: message.raw,
 			input: this.resolveInboundText(message, semanticMessage),
 			chatId: message.chatId,
-			chatType: message.chatType === 'private' ? 'p2p' : message.chatType,
+      chatType,
 			replyToMessageId:
 				typeof message.messageId === 'string' && message.messageId.trim().length > 0
 					? message.messageId.trim()
@@ -2004,32 +2329,79 @@ export class LarkConversationService implements OnModuleDestroy {
 			scopeKey: keys.scopeKey ?? undefined,
 			legacyConversationUserKey: keys.legacyConversationUserKey ?? undefined,
 			recipientDirectoryKey,
-			botMentioned: Boolean((message as any).isBotMentioned)
+      botMentioned,
+      currentInboundLogIds,
+      historyBefore
 		}
 
 		this.logger.debug(
-			`[lark-dispatch] inbound integration=${ctx.integration.id} chat=${message.chatId} sender=${message.senderId} content=${JSON.stringify(message.content)}`
+      `[lark-dispatch] inbound integration=${ctx.integration.id} chat=${message.chatId} sender=${
+        message.senderId
+      } content=${JSON.stringify(message.content)}`
 		)
 
 		if (queueJob.chatType === 'group' && queueJob.scopeKey) {
 			if (await this.shouldBypassGroupMentionWindow(queueJob)) {
-				await this.bestEffortAttachTypingReaction(queueJob)
-				const scopeQueue = await this.getScopeQueue(queueJob.scopeKey)
-				await scopeQueue.add(queueJob)
+        const enqueued = await this.enqueueConversationJob(queueJob.scopeKey, queueJob)
+        if (enqueued && cleanupRequest) {
+          this.scheduleHistoryCleanupBestEffort(cleanupRequest)
+        }
 				return
 			}
 			if (queueJob.botMentioned) {
+        const claimed = await this.messageHistoryService.claimInboundStatus(
+          queueJob.currentInboundLogIds ?? [],
+          ['received', 'failed'],
+          'queued'
+        )
+        const canRecoverQueuedWindow =
+          !claimed &&
+          (queueJob.currentInboundLogIds?.length ?? 0) > 0 &&
+          (await this.messageHistoryService.areInboundLogsInStatus(queueJob.currentInboundLogIds ?? [], 'queued'))
+        if (!claimed && !canRecoverQueuedWindow) {
+          return
+        }
+        try {
 				await this.groupMentionWindowService.ingest(queueJob)
+          if (cleanupRequest) {
+            this.scheduleHistoryCleanupBestEffort(cleanupRequest)
+          }
+        } catch (error) {
+          await this.messageHistoryService.updateInboundStatus(
+            queueJob.currentInboundLogIds ?? [],
+            'failed',
+            error instanceof Error ? error.message : String(error)
+          )
+          throw error
+        }
 			}
 			return
 		}
 
-		await this.bestEffortAttachTypingReaction(queueJob)
-		const scopeQueue = await this.getScopeQueue(queueJob.scopeKey ?? queueJob.legacyConversationUserKey ?? user.id)
-		await scopeQueue.add(queueJob)
+    const enqueued = await this.enqueueConversationJob(
+      queueJob.scopeKey ?? queueJob.legacyConversationUserKey ?? user.id,
+      queueJob
+    )
+    if (enqueued && cleanupRequest) {
+      this.scheduleHistoryCleanupBestEffort(cleanupRequest)
+    }
 	}
 
 	async handleCardAction(action: TChatCardAction, ctx: TChatEventContext<TIntegrationLarkOptions>): Promise<void> {
+		if (
+			isLarkCardActionValue(action.value) &&
+			resolveLarkCardActionValue(action.value) === LARK_DISMISS_PERMISSION_GUIDE
+		) {
+			if (action.messageId) {
+				const cancelledText = ctx.integration.options?.preferLanguage?.startsWith('en')
+					? 'Permission setup was cancelled.'
+					: '已取消权限开启引导。'
+				await this.larkChannel.patchInteractiveMessage(ctx.integration.id, action.messageId, {
+					elements: [{ tag: 'markdown', content: cancelledText }]
+				})
+			}
+			return
+		}
 		const user = RequestContext.currentUser()
 		if (!user) {
 			this.logger.warn('No user in request context, cannot handle card action')
@@ -2058,14 +2430,14 @@ export class LarkConversationService implements OnModuleDestroy {
 		const boundXpertId = await this.getBoundXpertId(ctx.integration.id)
 		const configuredXpertId = boundXpertId ?? normalizeConversationUserKey(ctx.integration.options?.xpertId)
 		if (this.shouldPurgeBindingForConfiguredXpert(historicalBinding, ctx.integration.id, configuredXpertId)) {
-			await this.purgeBindingSession(historicalBinding, historicalBinding?.scopeKey ?? legacyConversationUserKey, legacyConversationUserKey)
-			historicalBinding = null
-		}
-		const latestBinding = this.shouldPreferHistoricalBinding(
+      await this.purgeBindingSession(
 			historicalBinding,
-			ctx.integration.id,
-			configuredXpertId
+        historicalBinding?.scopeKey ?? legacyConversationUserKey,
+        legacyConversationUserKey
 		)
+      historicalBinding = null
+    }
+    const latestBinding = this.shouldPreferHistoricalBinding(historicalBinding, ctx.integration.id, configuredXpertId)
 			? historicalBinding
 			: null
 		const xpertId = latestBinding?.xpertId ?? configuredXpertId
@@ -2103,7 +2475,9 @@ export class LarkConversationService implements OnModuleDestroy {
 					legacyConversationUserKey
 				})
 				this.logger.debug(
-					`[lark-dispatch] card action blocked by trigger scope integration=${ctx.integration.id} chat=${action.chatId ?? 'n/a'} sender=${action.userId ?? 'n/a'}`
+          `[lark-dispatch] card action blocked by trigger scope integration=${ctx.integration.id} chat=${
+            action.chatId ?? 'n/a'
+          } sender=${action.userId ?? 'n/a'}`
 				)
 				return
 			}
@@ -2119,7 +2493,12 @@ export class LarkConversationService implements OnModuleDestroy {
 			}) ??
 			legacyConversationUserKey
 		if (latestBinding?.conversationId) {
-			await this.cacheConversation(scopeKey, latestBinding.xpertId, latestBinding.conversationId, legacyConversationUserKey)
+      await this.cacheConversation(
+        scopeKey,
+        latestBinding.xpertId,
+        latestBinding.conversationId,
+        legacyConversationUserKey
+      )
 		}
 
 		await this.onAction(

--- a/xpertai/integrations/lark/src/lib/conversation.view-list.spec.ts
+++ b/xpertai/integrations/lark/src/lib/conversation.view-list.spec.ts
@@ -89,6 +89,8 @@ describe('LarkConversationService listBindingsByIntegration', () => {
       { getMessageResource: jest.fn() } as any,
       {} as unknown as LarkRecipientDirectoryService,
       {} as unknown as LarkGroupMentionWindowService,
+      {} as any,
+      {} as any,
       conversationBindingRepository as unknown as Repository<LarkConversationBindingEntity>,
       triggerBindingRepository as unknown as Repository<LarkTriggerBindingEntity>,
       { resolve: jest.fn() } as unknown as PluginContext

--- a/xpertai/integrations/lark/src/lib/entities/index.ts
+++ b/xpertai/integrations/lark/src/lib/entities/index.ts
@@ -1,0 +1,4 @@
+export * from './lark-conversation-binding.entity.js'
+export * from './lark-message-file.entity.js'
+export * from './lark-message-log.entity.js'
+export * from './lark-trigger-binding.entity.js'

--- a/xpertai/integrations/lark/src/lib/entities/lark-message-file.entity.ts
+++ b/xpertai/integrations/lark/src/lib/entities/lark-message-file.entity.ts
@@ -1,0 +1,109 @@
+import {
+	Column,
+	CreateDateColumn,
+	Entity,
+	Index,
+	PrimaryGeneratedColumn,
+	UpdateDateColumn
+} from 'typeorm'
+import type { WorkspaceFileCatalog } from '@xpert-ai/plugin-sdk'
+import type { LarkMessageResourceType } from '../types.js'
+
+export type LarkMessageFileStatus = 'pending' | 'processing' | 'ready' | 'failed'
+
+@Entity(LarkMessageFileEntity.tableName)
+@Index('plugin_lark_message_file_resource_uq', ['messageLogId', 'resourceKey'], { unique: true })
+@Index('plugin_lark_message_file_log_idx', ['messageLogId'])
+@Index('plugin_lark_message_file_asset_idx', ['fileAssetId'])
+@Index('plugin_lark_message_file_history_idx', ['scopeKey', 'xpertId', 'createdAt'])
+@Index('plugin_lark_message_file_tenant_org_idx', ['tenantId', 'organizationId'])
+export class LarkMessageFileEntity {
+	static readonly tableName = 'plugin_lark_message_file'
+
+	@PrimaryGeneratedColumn('uuid')
+	id: string
+
+	@Column({ length: 36 })
+	messageLogId: string
+
+	@Column({ length: 36 })
+	integrationId: string
+
+	@Column({ length: 512 })
+	scopeKey: string
+
+	@Column({ nullable: true, length: 36 })
+	xpertId?: string | null
+
+	@Column({ nullable: true, length: 128 })
+	messageId?: string | null
+
+	@Column({ length: 512 })
+	resourceKey: string
+
+	@Column({ length: 16 })
+	resourceType: LarkMessageResourceType
+
+	@Column({ nullable: true, length: 36 })
+	fileAssetId?: string | null
+
+	@Column({ nullable: true, length: 36 })
+	fileId?: string | null
+
+	@Column({ nullable: true, length: 36 })
+	storageFileId?: string | null
+
+	@Column({ nullable: true, length: 1024 })
+	workspacePath?: string | null
+
+	@Column({ nullable: true, length: 1024 })
+	filePath?: string | null
+
+	@Column({ nullable: true, length: 2048 })
+	fileUrl?: string | null
+
+	@Column({ nullable: true, length: 255 })
+	originalName?: string | null
+
+	@Column({ nullable: true, length: 255 })
+	mimeType?: string | null
+
+	@Column({ type: 'integer', nullable: true })
+	size?: number | null
+
+	@Column({ length: 24, default: 'pending' })
+	status: LarkMessageFileStatus
+
+	@Column({ nullable: true, length: 1024 })
+	error?: string | null
+
+	@Column({ nullable: true, length: 24 })
+	workspaceCatalog?: WorkspaceFileCatalog | null
+
+	@Column({ nullable: true, length: 36 })
+	workspaceScopeId?: string | null
+
+	@Column({ nullable: true, length: 36 })
+	workspaceUserId?: string | null
+
+	@Column({ type: 'boolean', nullable: true })
+	workspaceIsolateByUser?: boolean | null
+
+	@Column({ nullable: true, length: 36 })
+	tenantId?: string | null
+
+	@Column({ nullable: true, length: 36 })
+	organizationId?: string | null
+
+	@Column({ nullable: true, length: 36 })
+	createdById?: string | null
+
+	@Column({ nullable: true, length: 36 })
+	updatedById?: string | null
+
+	@CreateDateColumn({ type: 'timestamptz' })
+	createdAt: Date
+
+	@UpdateDateColumn({ type: 'timestamptz' })
+	updatedAt: Date
+}

--- a/xpertai/integrations/lark/src/lib/entities/lark-message-log.entity.ts
+++ b/xpertai/integrations/lark/src/lib/entities/lark-message-log.entity.ts
@@ -1,0 +1,131 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm'
+
+export type LarkMessageDirection = 'inbound' | 'outbound' | 'system'
+
+export type LarkMessageLogStatus =
+  | 'received'
+  | 'history_only'
+  | 'queued'
+  | 'dispatched'
+  | 'sent'
+  | 'failed'
+  | 'context_reset'
+
+export type LarkMessageChatType = 'p2p' | 'group'
+
+@Entity(LarkMessageLogEntity.tableName)
+@Index('plugin_lark_message_log_message_uq', ['integrationId', 'direction', 'messageId'], {
+  unique: true
+})
+@Index('plugin_lark_message_log_run_uq', ['integrationId', 'direction', 'runId'], {
+  unique: true
+})
+@Index('plugin_lark_message_log_history_idx', [
+  'tenantId',
+  'organizationId',
+  'integrationId',
+  'scopeKey',
+  'xpertId',
+  'createdAt',
+  'id'
+])
+@Index('plugin_lark_message_log_integration_created_idx', ['integrationId', 'createdAt', 'id'])
+@Index('plugin_lark_message_log_integration_message_created_idx', ['integrationId', 'messageCreatedAt', 'id'])
+@Index('plugin_lark_message_log_integration_direction_idx', ['integrationId', 'direction', 'id'])
+@Index('plugin_lark_message_log_integration_status_idx', ['integrationId', 'status', 'id'])
+@Index('plugin_lark_message_log_integration_sender_idx', ['integrationId', 'senderName', 'id'])
+@Index('plugin_lark_message_log_integration_mentioned_idx', ['integrationId', 'botMentioned', 'id'])
+@Index('plugin_lark_message_log_scope_status_created_idx', [
+  'integrationId',
+  'scopeKey',
+  'xpertId',
+  'direction',
+  'status',
+  'createdAt',
+  'id'
+])
+@Index('plugin_lark_message_log_admin_status_created_idx', [
+  'integrationId',
+  'direction',
+  'status',
+  'createdAt',
+  'id'
+])
+export class LarkMessageLogEntity {
+  static readonly tableName = 'plugin_lark_message_log'
+
+  @PrimaryGeneratedColumn('uuid')
+  id: string
+
+  @Column({ length: 36 })
+  integrationId: string
+
+  @Column({ nullable: true, length: 128 })
+  messageId?: string | null
+
+  @Column({ nullable: true, length: 128 })
+  runId?: string | null
+
+  @Column({ length: 512 })
+  scopeKey: string
+
+  @Column({ nullable: true, length: 36 })
+  xpertId?: string | null
+
+  @Column({ nullable: true, length: 36 })
+  conversationId?: string | null
+
+  @Column({ nullable: true, length: 16 })
+  chatType?: LarkMessageChatType | null
+
+  @Column({ nullable: true, length: 128 })
+  chatId?: string | null
+
+  @Column({ nullable: true, length: 128 })
+  senderOpenId?: string | null
+
+  @Column({ nullable: true, length: 255 })
+  senderName?: string | null
+
+  @Column({ nullable: true, length: 32 })
+  messageType?: string | null
+
+  @Column({ type: 'boolean', default: false })
+  botMentioned: boolean
+
+  @Column({ length: 16 })
+  direction: LarkMessageDirection
+
+  @Column({ length: 24 })
+  status: LarkMessageLogStatus
+
+  @Column({ type: 'text', nullable: true })
+  content?: string | null
+
+  @Column({ nullable: true, length: 1024 })
+  error?: string | null
+
+  @Column({ type: 'timestamptz', nullable: true })
+  messageCreatedAt?: Date | null
+
+  @Column({ type: 'timestamptz', nullable: true })
+  sentAt?: Date | null
+
+  @Column({ nullable: true, length: 36 })
+  tenantId?: string | null
+
+  @Column({ nullable: true, length: 36 })
+  organizationId?: string | null
+
+  @Column({ nullable: true, length: 36 })
+  createdById?: string | null
+
+  @Column({ nullable: true, length: 36 })
+  updatedById?: string | null
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date
+}

--- a/xpertai/integrations/lark/src/lib/handoff/commands/dispatch-lark-chat.command.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/commands/dispatch-lark-chat.command.ts
@@ -3,8 +3,16 @@ import { ChatLarkMessage } from '../../message.js'
 
 export type DispatchLarkChatPayload = {
 	xpertId: string
+	executionContext?: {
+		tenantId?: string
+		organizationId?: string
+		createdById?: string
+	}
 	input?: string
 	files?: LarkInboundFile[]
+	historyContext?: string
+	historyFiles?: LarkInboundFile[]
+	currentInboundLogIds?: string[]
 	larkMessage: ChatLarkMessage
 	options?: {
 		confirm?: boolean
@@ -13,6 +21,8 @@ export type DispatchLarkChatPayload = {
 		executorUserId?: string
 		streamingEnabled?: boolean
 		groupWindow?: LarkGroupWindow
+		/** Internal stale-steer recovery: reuse the existing card and start a normal run. */
+		forceNewRun?: boolean
 	}
 }
 

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat-callback.processor.spec.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat-callback.processor.spec.ts
@@ -75,12 +75,25 @@ describe('LarkChatStreamCallbackProcessor', () => {
 		}
 		const conversationService = {
 			setConversation: jest.fn().mockResolvedValue(undefined),
-			setActiveMessage: jest.fn().mockResolvedValue(undefined)
+			setActiveMessage: jest.fn().mockResolvedValue(undefined),
+			getActiveMessage: jest.fn().mockResolvedValue(null)
+		}
+		const messageHistoryService = {
+			updateInboundStatus: jest.fn().mockResolvedValue(undefined),
+			claimInboundStatus: jest.fn().mockResolvedValue(true),
+			areInboundLogsInStatus: jest.fn().mockResolvedValue(false),
+			areInboundLogsInStatusWithError: jest.fn().mockResolvedValue(false),
+			recordOutbound: jest.fn().mockResolvedValue({ created: true })
+		}
+		const dispatchService = {
+			enqueueDispatch: jest.fn().mockResolvedValue(undefined)
 		}
 
 		const processor = new LarkChatStreamCallbackProcessor(
 			larkChannel as any,
 			runStateService,
+			messageHistoryService as any,
+			dispatchService as any,
 			pluginContext as any
 		)
 		;(processor as any).conversationService = conversationService as any
@@ -89,7 +102,10 @@ describe('LarkChatStreamCallbackProcessor', () => {
 			runStateService,
 			larkChannel,
 			conversationService,
-			processor
+			messageHistoryService,
+			dispatchService,
+			processor,
+			pluginContext
 		}
 	}
 
@@ -157,6 +173,34 @@ describe('LarkChatStreamCallbackProcessor', () => {
 			runId: 'run-id',
 			traceId: 'trace-id',
 			abortSignal: new AbortController().signal
+		}
+	}
+
+	function createStaleSteerContext() {
+		return {
+			tenantId: 'tenant-id',
+			userId: 'user-id',
+			xpertId: 'xpert-1',
+			conversationId: 'conversation-1',
+			integrationId: 'integration-1',
+			chatId: 'chat-1',
+			chatType: 'group',
+			senderOpenId: 'sender-1',
+			scopeKey: 'group:chat-1',
+			currentInboundLogIds: ['inbound-follow-up-1'],
+			followUpMode: 'steer',
+			message: { id: 'unused-current-message' },
+			steerFallback: {
+				input: 'follow up',
+				message: {
+					id: 'lark-card-1',
+					messageId: 'ai-1',
+					deliveryMode: 'interactive',
+					status: 'thinking',
+					language: 'zh-Hans',
+					elements: []
+				}
+			}
 		}
 	}
 
@@ -1000,9 +1044,40 @@ describe('LarkChatStreamCallbackProcessor', () => {
 		expect(await runStateService.get('run-1')).toBeNull()
 	})
 
+	it('records one final sent row after merging stream patches', async () => {
+		const { processor, runStateService, messageHistoryService } = createFixture()
+		await runStateService.save(
+			createRunState({
+				context: {
+					currentInboundLogIds: ['inbound-log-1'],
+					conversationId: 'conversation-1'
+				} as any
+			})
+		)
+
+		await processor.process(createStreamMessage(1, 'final ') as any, createProcessContext() as any)
+		await processor.process(createStreamMessage(2, 'answer') as any, createProcessContext() as any)
+		await processor.process(createCompleteMessage(3) as any, createProcessContext() as any)
+
+		expect(messageHistoryService.recordOutbound).toHaveBeenCalledTimes(1)
+		expect(messageHistoryService.recordOutbound).toHaveBeenCalledWith(
+			expect.objectContaining({
+				integrationId: 'integration-id',
+				scopeKey: 'lark:v2:scope:integration-id:group:chat-id',
+				xpertId: 'xpert-id',
+				runId: 'run-1',
+				status: 'sent',
+				content: 'final answer',
+				conversationId: 'conversation-1'
+			})
+		)
+	})
+
 	it('handles error callback and clears run state', async () => {
-		const { processor, runStateService, larkChannel } = createFixture()
-		await runStateService.save(createRunState())
+		const { processor, runStateService, larkChannel, messageHistoryService } = createFixture()
+		await runStateService.save(
+			createRunState({ context: { currentInboundLogIds: ['inbound-log-1'] } as any })
+		)
 
 		await processor.process(createErrorMessage(1, 'boom') as any, createProcessContext() as any)
 
@@ -1012,7 +1087,268 @@ describe('LarkChatStreamCallbackProcessor', () => {
 			tag: 'markdown',
 			content: 'boom'
 		})
+		expect(messageHistoryService.recordOutbound).toHaveBeenCalledWith(
+			expect.objectContaining({ status: 'failed', runId: 'run-1', error: 'boom' })
+		)
 		expect(await runStateService.get('run-1')).toBeNull()
+	})
+
+	it('ignores callbacks for steer follow-ups without creating a second Lark card state', async () => {
+		const { processor, runStateService, larkChannel, conversationService, messageHistoryService } =
+			createFixture()
+		const getRunState = jest.spyOn(runStateService, 'get')
+		const message = createCompleteMessage(1, 'follow-up-run-1') as any
+		message.payload.context = {
+			followUpMode: 'steer'
+		}
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({
+			status: 'ok'
+		})
+
+		expect(getRunState).not.toHaveBeenCalled()
+		expect(larkChannel.interactiveMessage).not.toHaveBeenCalled()
+		expect(larkChannel.patchInteractiveMessage).not.toHaveBeenCalled()
+		expect(conversationService.setActiveMessage).not.toHaveBeenCalled()
+		expect(messageHistoryService.recordOutbound).not.toHaveBeenCalled()
+	})
+
+	it('records steer callback errors without creating a second Lark card', async () => {
+		const { processor, runStateService, larkChannel, conversationService, messageHistoryService } =
+			createFixture()
+		const getRunState = jest.spyOn(runStateService, 'get')
+		const message = createErrorMessage(1, 'steer failed') as any
+		message.payload.context = {
+			followUpMode: 'steer',
+			currentInboundLogIds: ['inbound-follow-up-1']
+		}
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({
+			status: 'ok'
+		})
+
+		expect(getRunState).not.toHaveBeenCalled()
+		expect(messageHistoryService.updateInboundStatus).toHaveBeenCalledWith(
+			['inbound-follow-up-1'],
+			'failed',
+			'steer failed'
+		)
+		expect(larkChannel.interactiveMessage).not.toHaveBeenCalled()
+		expect(larkChannel.patchInteractiveMessage).not.toHaveBeenCalled()
+		expect(conversationService.setActiveMessage).not.toHaveBeenCalled()
+		expect(messageHistoryService.recordOutbound).not.toHaveBeenCalled()
+	})
+
+	it('retries stale steer recovery until the existing response card is terminal', async () => {
+		const { processor, conversationService, dispatchService, pluginContext } = createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'thinking' }
+		})
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual(
+			expect.objectContaining({ status: 'retry', delayMs: 1000 })
+		)
+
+		expect(pluginContext.resolve).not.toHaveBeenCalled()
+		expect(dispatchService.enqueueDispatch).not.toHaveBeenCalled()
+	})
+
+	it('claims and reuses the existing card exactly once for stale steer fallback', async () => {
+		const { processor, conversationService, dispatchService, messageHistoryService, pluginContext } =
+			createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		let claimState: string | null = null
+		const redis = {
+			set: jest.fn().mockImplementation(async (_key: string, value: string, ...args: unknown[]) => {
+				if (args.includes('NX')) {
+					if (claimState !== null) return null
+					claimState = value
+					return 'OK'
+				}
+				claimState = value
+				return 'OK'
+			}),
+			get: jest.fn().mockImplementation(async () => claimState),
+			eval: jest.fn().mockImplementation(async (script: string, _keys: number, _key: string, owner: string) => {
+				if (claimState !== owner) return 0
+				if (script.includes("'done'")) {
+					claimState = 'done'
+					return 'OK'
+				}
+				claimState = null
+				return 1
+			}),
+			del: jest.fn().mockImplementation(async () => {
+				claimState = null
+			})
+		}
+		pluginContext.resolve.mockReturnValue({ getRedis: jest.fn().mockResolvedValue(redis) })
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({ status: 'ok' })
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({ status: 'ok' })
+
+		expect(messageHistoryService.claimInboundStatus).toHaveBeenCalledWith(
+			['inbound-follow-up-1'],
+			['dispatched', 'failed'],
+			'queued'
+		)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+		expect(claimState).toBe('done')
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				xpertId: 'xpert-1',
+				input: 'follow up',
+				currentInboundLogIds: ['inbound-follow-up-1'],
+				larkMessage: expect.objectContaining({ id: 'lark-card-1', messageId: 'ai-1' }),
+				options: expect.objectContaining({ forceNewRun: true })
+			})
+		)
+	})
+
+	it('retries a processing stale-steer claim instead of acknowledging lost work', async () => {
+		const { processor, conversationService, dispatchService, pluginContext } = createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		pluginContext.resolve.mockReturnValue({
+			getRedis: jest.fn().mockResolvedValue({
+				set: jest.fn().mockResolvedValue(null),
+				get: jest.fn().mockResolvedValue('processing:other-worker')
+			})
+		})
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual(
+			expect.objectContaining({ status: 'retry', delayMs: 1000 })
+		)
+		expect(dispatchService.enqueueDispatch).not.toHaveBeenCalled()
+	})
+
+	it('releases a stale-steer processing claim when enqueue fails so callback retry can recover', async () => {
+		const { processor, conversationService, dispatchService, pluginContext } = createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		const redis = {
+			set: jest.fn().mockResolvedValue('OK'),
+			get: jest.fn(),
+			eval: jest.fn().mockResolvedValue(1)
+		}
+		pluginContext.resolve.mockReturnValue({ getRedis: jest.fn().mockResolvedValue(redis) })
+		dispatchService.enqueueDispatch.mockRejectedValue(new Error('queue unavailable'))
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).rejects.toThrow('queue unavailable')
+		expect(redis.eval).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('DEL'"),
+			1,
+			'lark:steer-fallback:integration-1:run-1',
+			expect.stringMatching(/^processing:/)
+		)
+	})
+
+	it('does not roll back an enqueued stale-steer recovery when Redis completion fails', async () => {
+		const { processor, conversationService, dispatchService, messageHistoryService, pluginContext } =
+			createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		pluginContext.resolve.mockReturnValue({
+			getRedis: jest.fn().mockResolvedValue({
+				set: jest.fn().mockResolvedValue('OK'),
+				get: jest.fn(),
+				eval: jest.fn().mockRejectedValue(new Error('redis unavailable'))
+			})
+		})
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({ status: 'ok' })
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+		expect(messageHistoryService.updateInboundStatus).toHaveBeenLastCalledWith(
+			['inbound-follow-up-1'],
+			'queued',
+			'stale_steer_fallback_enqueued'
+		)
+		expect(messageHistoryService.updateInboundStatus).not.toHaveBeenCalledWith(
+			['inbound-follow-up-1'],
+			'failed',
+			expect.anything()
+		)
+	})
+
+	it('recovers stale steer when the inbound row is still queued during callback delivery', async () => {
+		const { processor, conversationService, dispatchService, messageHistoryService, pluginContext } =
+			createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		pluginContext.resolve.mockReturnValue({
+			getRedis: jest.fn().mockResolvedValue({
+				set: jest.fn().mockResolvedValue('OK'),
+				eval: jest.fn().mockResolvedValue('OK')
+			})
+		})
+		messageHistoryService.claimInboundStatus.mockResolvedValue(false)
+		messageHistoryService.areInboundLogsInStatus.mockResolvedValue(true)
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({ status: 'ok' })
+
+		expect(messageHistoryService.areInboundLogsInStatus).toHaveBeenCalledWith(
+			['inbound-follow-up-1'],
+			'queued'
+		)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+	})
+
+	it('acknowledges a durable stale-steer enqueue marker without enqueueing again', async () => {
+		const { processor, conversationService, dispatchService, messageHistoryService, pluginContext } =
+			createFixture()
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		pluginContext.resolve.mockReturnValue({
+			getRedis: jest.fn().mockResolvedValue({
+				set: jest.fn().mockResolvedValue('OK'),
+				eval: jest.fn().mockResolvedValue('OK')
+			})
+		})
+		messageHistoryService.areInboundLogsInStatusWithError.mockResolvedValue(true)
+		const message = createErrorMessage(1, 'target ended') as any
+		message.payload.errorCode = 'steer_target_not_running'
+		message.payload.context = createStaleSteerContext()
+
+		await expect(processor.process(message, createProcessContext() as any)).resolves.toEqual({ status: 'ok' })
+
+		expect(messageHistoryService.areInboundLogsInStatusWithError).toHaveBeenCalledWith(
+			['inbound-follow-up-1'],
+			'queued',
+			'stale_steer_fallback_enqueued'
+		)
+		expect(dispatchService.enqueueDispatch).not.toHaveBeenCalled()
 	})
 
 	it('serializes same-source callbacks to avoid stale state overwrite', async () => {

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat-callback.processor.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat-callback.processor.ts
@@ -3,10 +3,13 @@ import {
 	HandoffMessage,
 	HandoffProcessorStrategy,
 	IHandoffProcessor,
+	MANAGED_QUEUE_SERVICE_TOKEN,
+	type ManagedQueueService,
 	type PluginContext,
 	ProcessContext,
 	ProcessResult,
 } from '@xpert-ai/plugin-sdk'
+import { randomUUID } from 'node:crypto'
 import { ChatEventEnvelope, ChatMessageEventTypeEnum, ChatMessageTypeEnum } from '@xpert-ai/chatkit-types'
 import { ChatLarkMessage, cloneStructuredElement } from '../message.js'
 import { LarkConversationService } from '../conversation.service.js'
@@ -30,6 +33,8 @@ import {
 import { LarkChatRunState, LarkChatRunStateService } from './lark-chat-run-state.service.js'
 import { LarkCardElement, LarkStructuredElement } from '../types.js'
 import { messageContentText, XpertAgentExecutionStatusEnum } from '../contracts-compat.js'
+import { LarkMessageHistoryService } from '../lark-message-history.service.js'
+import { LarkChatDispatchService } from './lark-chat-dispatch.service.js'
 
 const HIDDEN_LARK_CHAT_EVENT_TYPES = [
 	'thread_context_usage',
@@ -38,6 +43,11 @@ const HIDDEN_LARK_CHAT_EVENT_TYPES = [
 
 type HiddenLarkChatEventType = (typeof HIDDEN_LARK_CHAT_EVENT_TYPES)[number]
 const HIDDEN_LARK_CHAT_EVENT_TYPE_SET = new Set<HiddenLarkChatEventType>(HIDDEN_LARK_CHAT_EVENT_TYPES)
+const STALE_STEER_ERROR_CODE = 'steer_target_not_running'
+const STALE_STEER_RETRY_DELAY_MS = 1000
+const STALE_STEER_PROCESSING_TTL_MS = 10 * 60 * 1000
+const STALE_STEER_DONE_TTL_MS = 10 * 60 * 1000
+const STALE_STEER_ENQUEUED_MARKER = 'stale_steer_fallback_enqueued'
 
 /**
  * Callback processor for Lark stream events.
@@ -68,6 +78,8 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 	constructor(
 		private readonly larkChannel: LarkChannelStrategy,
 		private readonly runStateService: LarkChatRunStateService,
+		private readonly messageHistoryService: LarkMessageHistoryService,
+		private readonly dispatchService: LarkChatDispatchService,
 		@Inject(LARK_PLUGIN_CONTEXT)
 		private readonly pluginContext: PluginContext<IntegrationLarkPluginConfig>
 	) {}
@@ -88,6 +100,25 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 				status: 'dead',
 				reason: 'Missing sequence in Lark callback payload'
 			}
+		}
+		if (payload.context?.followUpMode === 'steer') {
+			// A steer follow-up is consumed by the already running Xpert execution.
+			// It must not create or update a second Lark card/run state.
+			if (payload.kind === 'error') {
+				if (payload.errorCode === STALE_STEER_ERROR_CODE && payload.context.steerFallback) {
+					return this.recoverStaleSteer(payload)
+				}
+				const error = payload.error || 'Lark steer follow-up failed'
+				await this.messageHistoryService.updateInboundStatus(
+					payload.context.currentInboundLogIds ?? [],
+					'failed',
+					error
+				)
+				this.logger.warn(
+					`Lark steer follow-up "${payload.sourceMessageId}" failed without creating a second response card: ${error}`
+				)
+			}
+			return { status: 'ok' }
 		}
 
 		return this.runWithSourceLock(payload.sourceMessageId, async () => {
@@ -120,6 +151,202 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 
 			return { status: 'ok' }
 		})
+	}
+
+	private async recoverStaleSteer(payload: LarkChatStreamCallbackPayload): Promise<ProcessResult> {
+		const context = payload.context!
+		const fallback = context.steerFallback!
+		if (!context.scopeKey || !context.xpertId) {
+			return { status: 'dead', reason: 'Missing trusted Lark scope for stale steer fallback' }
+		}
+
+		const active = await this.conversationService.getActiveMessage(context.scopeKey, context.xpertId, {
+			legacyConversationUserKey: context.legacyConversationUserKey
+		})
+		if (active?.thirdPartyMessage?.id !== fallback.message.id) {
+			await this.messageHistoryService.updateInboundStatus(
+				context.currentInboundLogIds ?? [],
+				'failed',
+				'stale_steer_active_card_changed'
+			)
+			return { status: 'dead', reason: 'Active Lark response card changed before stale steer fallback' }
+		}
+		if (this.isInProgressStatus(active.thirdPartyMessage?.status)) {
+			return {
+				status: 'retry',
+				delayMs: STALE_STEER_RETRY_DELAY_MS,
+				reason: 'Waiting for the previous Lark response card to finish before stale steer fallback'
+			}
+		}
+		if (
+			await this.messageHistoryService.areInboundLogsInStatusWithError(
+				context.currentInboundLogIds ?? [],
+				'queued',
+				STALE_STEER_ENQUEUED_MARKER
+			)
+		) {
+			return { status: 'ok' }
+		}
+
+		const claim = await this.claimStaleSteerFallback(payload.sourceMessageId, context.integrationId)
+		if (claim.state === 'done') {
+			return { status: 'ok' }
+		}
+		if (claim.state !== 'claimed') {
+			return {
+				status: 'retry',
+				delayMs: STALE_STEER_RETRY_DELAY_MS,
+				reason: 'Another worker is recovering the stale Lark steer fallback'
+			}
+		}
+		const claimOwnerToken = claim.ownerToken
+		const claimedLogs = await this.messageHistoryService.claimInboundStatus(
+			context.currentInboundLogIds ?? [],
+			['dispatched', 'failed'],
+			'queued'
+		)
+		const alreadyQueued =
+			!claimedLogs &&
+			(context.currentInboundLogIds?.length ?? 0) > 0 &&
+			(await this.messageHistoryService.areInboundLogsInStatus(
+				context.currentInboundLogIds ?? [],
+				'queued'
+			))
+		if (!claimedLogs && !alreadyQueued) {
+			await this.completeStaleSteerFallbackClaim(
+				payload.sourceMessageId,
+				context.integrationId,
+				claimOwnerToken
+			)
+			return { status: 'ok' }
+		}
+
+		const fallbackContext: LarkChatCallbackContext = {
+			...context,
+			message: fallback.message,
+			followUpMode: undefined,
+			steerFallback: undefined
+		}
+		const larkMessage = this.createLarkMessage(fallbackContext)
+		try {
+			await this.dispatchService.enqueueDispatch({
+				xpertId: context.xpertId,
+				input: fallback.input,
+				files: fallback.files,
+				currentInboundLogIds: context.currentInboundLogIds,
+				larkMessage,
+				options: {
+					forceNewRun: true,
+					fromEndUserId: fallback.fromEndUserId,
+					executorUserId: fallback.executorUserId,
+					streamingEnabled: fallback.streamingEnabled
+				}
+			})
+		} catch (error) {
+			await this.messageHistoryService.updateInboundStatus(
+				context.currentInboundLogIds ?? [],
+				'failed',
+				String(error)
+			)
+			await this.releaseStaleSteerFallbackClaim(
+				payload.sourceMessageId,
+				context.integrationId,
+				claimOwnerToken
+			)
+			throw error
+		}
+		try {
+			await this.messageHistoryService.updateInboundStatus(
+				context.currentInboundLogIds ?? [],
+				'queued',
+				STALE_STEER_ENQUEUED_MARKER
+			)
+		} catch (error) {
+			this.logger.warn(`Unable to persist stale Lark steer enqueue marker: ${String(error)}`)
+		}
+		await this.completeStaleSteerFallbackClaim(
+			payload.sourceMessageId,
+			context.integrationId,
+			claimOwnerToken
+		)
+		return { status: 'ok' }
+	}
+
+	private isInProgressStatus(status: unknown): boolean {
+		return status === 'thinking' || status === 'continuing'
+	}
+
+	private async claimStaleSteerFallback(
+		sourceMessageId: string,
+		integrationId?: string
+	): Promise<{ state: 'claimed'; ownerToken: string } | { state: 'processing' | 'done' }> {
+		try {
+			const queue = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN) as ManagedQueueService
+			const redis = await queue.getRedis()
+			const key = this.staleSteerFallbackKey(sourceMessageId, integrationId)
+			const ownerToken = randomUUID()
+			const processingValue = `processing:${ownerToken}`
+			const result = await redis.set(
+				key,
+				processingValue,
+				'PX',
+				STALE_STEER_PROCESSING_TTL_MS,
+				'NX'
+			)
+			if (result === 'OK') {
+				return { state: 'claimed', ownerToken }
+			}
+			const state = await redis.get(key)
+			return { state: state === 'done' ? 'done' : 'processing' }
+		} catch (error) {
+			this.logger.error(`Unable to claim stale Lark steer fallback: ${String(error)}`)
+			throw error
+		}
+	}
+
+	private async completeStaleSteerFallbackClaim(
+		sourceMessageId: string,
+		integrationId: string | undefined,
+		ownerToken: string
+	): Promise<void> {
+		try {
+			const queue = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN) as ManagedQueueService
+			const redis = await queue.getRedis()
+			await redis.eval(
+				`if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('SET', KEYS[1], 'done', 'PX', ARGV[2]) else return 0 end`,
+				1,
+				this.staleSteerFallbackKey(sourceMessageId, integrationId),
+				`processing:${ownerToken}`,
+				String(STALE_STEER_DONE_TTL_MS)
+			)
+		} catch (error) {
+			// The durable inbound marker prevents re-dispatch even if this best-effort
+			// completion marker cannot be written after enqueue succeeds.
+			this.logger.warn(`Unable to complete stale Lark steer fallback claim: ${String(error)}`)
+		}
+	}
+
+	private async releaseStaleSteerFallbackClaim(
+		sourceMessageId: string,
+		integrationId: string | undefined,
+		ownerToken: string
+	): Promise<void> {
+		try {
+			const queue = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN) as ManagedQueueService
+			const redis = await queue.getRedis()
+			await redis.eval(
+				`if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end`,
+				1,
+				this.staleSteerFallbackKey(sourceMessageId, integrationId),
+				`processing:${ownerToken}`
+			)
+		} catch (error) {
+			this.logger.warn(`Unable to release stale Lark steer fallback claim: ${String(error)}`)
+		}
+	}
+
+	private staleSteerFallbackKey(sourceMessageId: string, integrationId?: string): string {
+		return `lark:steer-fallback:${integrationId ?? 'unknown'}:${sourceMessageId}`
 	}
 
 	private async runWithSourceLock(
@@ -300,6 +527,7 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 				const conversationUserKey = this.resolveConversationUserKey(context)
 				const conversationId = this.toNonEmptyString(eventData?.id)
 				if (conversationUserKey && conversationId) {
+					context.conversationId = conversationId
 					await this.conversationService.setConversation(
 						conversationUserKey,
 						context.xpertId,
@@ -313,6 +541,12 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 							senderOpenId: context.senderOpenId,
 							legacyConversationUserKey: context.legacyConversationUserKey
 						}
+					)
+					await this.messageHistoryService.updateInboundStatus(
+						context.currentInboundLogIds ?? [],
+						'dispatched',
+						undefined,
+						conversationId
 					)
 				}
 				break
@@ -401,6 +635,12 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 
 		context.message = this.toMessageSnapshot(larkMessage, context.message?.text)
 		await this.syncActiveMessageCache(context)
+		await this.recordRunHistory(
+			state,
+			keepTerminalState ? 'failed' : 'sent',
+			larkMessage,
+			keepTerminalState ? String(currentStatus ?? 'agent_execution_failed') : undefined
+		)
 	}
 
 	private async failRun(state: LarkChatRunState, error?: string) {
@@ -408,6 +648,39 @@ export class LarkChatStreamCallbackProcessor implements IHandoffProcessor<LarkCh
 		await larkMessage.error(error || 'Internal Error')
 		state.context.message = this.toMessageSnapshot(larkMessage, state.context.message?.text)
 		await this.syncActiveMessageCache(state.context)
+		await this.recordRunHistory(state, 'failed', larkMessage, error || 'Internal Error')
+	}
+
+	private async recordRunHistory(
+		state: LarkChatRunState,
+		status: 'sent' | 'failed',
+		larkMessage: ChatLarkMessage,
+		error?: string
+	): Promise<void> {
+		const context = state.context
+		if (
+			!context.currentInboundLogIds?.length ||
+			!context.integrationId ||
+			!context.scopeKey ||
+			!context.xpertId
+		) {
+			return
+		}
+		await this.messageHistoryService.recordOutbound({
+			integrationId: context.integrationId,
+			scopeKey: context.scopeKey,
+			xpertId: context.xpertId,
+			tenantId: context.tenantId,
+			organizationId: context.organizationId,
+			runId: state.sourceMessageId,
+			status,
+			content: state.responseMessageContent,
+			messageId: larkMessage.messageId ?? larkMessage.id,
+			conversationId: context.conversationId,
+			error,
+			sentAt: status === 'sent' ? new Date() : undefined,
+			createdById: context.userId
+		})
 	}
 
 	private createLarkMessage(context: LarkChatCallbackContext): ChatLarkMessage {

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.spec.ts
@@ -2,12 +2,14 @@ jest.mock('@xpert-ai/plugin-sdk', () => {
 	const { createLarkPluginSdkMock } = require('../../../../../test-utils/larkPluginSdkMock.cjs')
 	return createLarkPluginSdkMock(jest, {
 		AGENT_CHAT_DISPATCH_MESSAGE_TYPE: 'agent.chat.dispatch',
-		HANDOFF_PERMISSION_SERVICE_TOKEN: 'HANDOFF_PERMISSION_SERVICE_TOKEN'
+		HANDOFF_PERMISSION_SERVICE_TOKEN: 'HANDOFF_PERMISSION_SERVICE_TOKEN',
+		MANAGED_QUEUE_SERVICE_TOKEN: 'MANAGED_QUEUE_SERVICE_TOKEN'
 	})
 })
 
 import {
 	HANDOFF_PERMISSION_SERVICE_TOKEN,
+	MANAGED_QUEUE_SERVICE_TOKEN,
 	RequestContext
 } from '@xpert-ai/plugin-sdk'
 import { LarkChatDispatchService } from './lark-chat-dispatch.service.js'
@@ -94,6 +96,7 @@ function mockRequestContext(params?: {
 
 describe('LarkChatDispatchService', () => {
 	afterEach(() => {
+		jest.useRealTimers()
 		jest.restoreAllMocks()
 	})
 
@@ -125,10 +128,33 @@ describe('LarkChatDispatchService', () => {
 		const handoffPermissionService = {
 			enqueue: jest.fn().mockResolvedValue(undefined)
 		}
+		const dispatchLocks = new Map<string, string>()
+		const redis = {
+			set: jest.fn(async (key: string, owner: string) => {
+				if (dispatchLocks.has(key)) {
+					return null
+				}
+				dispatchLocks.set(key, owner)
+				return 'OK'
+			}),
+			eval: jest.fn(async (_script: string, _keyCount: number, key: string, owner: string) => {
+				if (dispatchLocks.get(key) !== owner) {
+					return 0
+				}
+				dispatchLocks.delete(key)
+				return 1
+			})
+		}
+		const managedQueueService = {
+			getRedis: jest.fn().mockResolvedValue(redis)
+		}
 		const pluginContext = {
 			resolve: jest.fn((token: unknown) => {
 				if (token === HANDOFF_PERMISSION_SERVICE_TOKEN) {
 					return handoffPermissionService
+				}
+				if (token === MANAGED_QUEUE_SERVICE_TOKEN) {
+					return managedQueueService
 				}
 				throw new Error(`Unexpected token: ${String(token)}`)
 			})
@@ -143,9 +169,109 @@ describe('LarkChatDispatchService', () => {
 			service,
 			conversationService,
 			runStateService,
-			handoffPermissionService
+			handoffPermissionService,
+			managedQueueService,
+			redis,
+			dispatchLocks
 		}
 	}
+
+	it('serializes concurrent dispatch decisions and reuses the active response card', async () => {
+		jest.useFakeTimers()
+		mockRequestContext()
+		const { service, conversationService, redis, dispatchLocks } = createFixture({
+			conversationId: 'conversation-1'
+		})
+		let activeMessage: unknown = null
+		let releaseFirstLookup!: () => void
+		let notifyFirstLookupStarted!: () => void
+		const firstLookupStarted = new Promise<void>((resolve) => {
+			notifyFirstLookupStarted = resolve
+		})
+		const firstLookupGate = new Promise<void>((resolve) => {
+			releaseFirstLookup = resolve
+		})
+		conversationService.getConversation = jest
+			.fn()
+			.mockImplementationOnce(async () => {
+				notifyFirstLookupStarted()
+				await firstLookupGate
+				return 'conversation-1'
+			})
+			.mockResolvedValue('conversation-1')
+		conversationService.getActiveMessage = jest.fn().mockImplementation(async () => activeMessage)
+		conversationService.setActiveMessage = jest.fn().mockImplementation(async (_scopeKey, _xpertId, value) => {
+			activeMessage = value
+		})
+		const firstLarkMessage = createLarkMessage({ id: 'card-1', messageId: 'message-1' })
+		const secondLarkMessage = createLarkMessage({ id: 'card-2', messageId: 'message-2' })
+
+		const firstDispatch = service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: 'first',
+			currentInboundLogIds: ['log-1'],
+			larkMessage: firstLarkMessage as any
+		})
+		await firstLookupStarted
+
+		const secondDispatch = service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: 'second',
+			currentInboundLogIds: ['log-2'],
+			larkMessage: secondLarkMessage as any
+		})
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(conversationService.getConversation).toHaveBeenCalledTimes(1)
+		releaseFirstLookup()
+		const firstMessage = await firstDispatch
+		await jest.advanceTimersByTimeAsync(50)
+		const secondMessage = await secondDispatch
+
+		expect((firstMessage.payload as any).request.action).toBe('send')
+		expect((secondMessage.payload as any).request).toEqual(
+			expect.objectContaining({
+				action: 'follow_up',
+				mode: 'steer',
+				target: { aiMessageId: 'message-1' }
+			})
+		)
+		expect(firstLarkMessage.update).toHaveBeenCalledWith({ status: 'thinking' })
+		expect(secondLarkMessage.update).not.toHaveBeenCalled()
+		expect(conversationService.setActiveMessage).toHaveBeenCalledTimes(1)
+		expect(redis.eval).toHaveBeenCalledTimes(2)
+		expect(dispatchLocks.size).toBe(0)
+	})
+
+	it('releases the dispatch decision lock when message construction fails', async () => {
+		mockRequestContext()
+		const { service, conversationService, redis, dispatchLocks } = createFixture()
+		conversationService.resolveDispatchExecutionContext
+			.mockRejectedValueOnce(new Error('context lookup failed'))
+			.mockResolvedValueOnce({ source: 'request-fallback' })
+		const larkMessage = createLarkMessage()
+
+		await expect(
+			service.buildDispatchMessage({
+				xpertId: 'xpert-1',
+				input: 'first',
+				larkMessage: larkMessage as any
+			})
+		).rejects.toThrow('context lookup failed')
+
+		expect(redis.eval).toHaveBeenCalledTimes(1)
+		expect(dispatchLocks.size).toBe(0)
+		await expect(
+			service.buildDispatchMessage({
+				xpertId: 'xpert-1',
+				input: 'retry',
+				larkMessage: larkMessage as any
+			})
+		).resolves.toEqual(expect.objectContaining({ payload: expect.any(Object) }))
+		expect(redis.eval).toHaveBeenCalledTimes(2)
+		expect(dispatchLocks.size).toBe(0)
+	})
 
 	it('buildDispatchMessage uses assistant runtime principal with creator callback context', async () => {
 		mockRequestContext({
@@ -310,6 +436,276 @@ describe('LarkChatDispatchService', () => {
 			input: '',
 			files
 		})
+	})
+
+	it('composes local history once while preserving the raw callback snapshot', async () => {
+		mockRequestContext()
+		const { service, runStateService } = createFixture()
+		const larkMessage = createLarkMessage()
+		const currentFile = {
+			fileAssetId: 'asset-current',
+			workspacePath: 'files/lark/current.txt',
+			originalName: 'current.txt'
+		}
+		const historyFile = {
+			fileAssetId: 'asset-history',
+			workspacePath: 'files/lark/history.txt',
+			originalName: 'history.txt'
+		}
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: '请总结',
+			files: [currentFile],
+			historyContext: '[历史上下文]\n用户: 上一条',
+			historyFiles: [historyFile, historyFile],
+			currentInboundLogIds: ['log-1', 'log-2', 'log-1'],
+			larkMessage: larkMessage as any
+		})
+
+		expect((message.payload as any).request.message.input).toEqual({
+			input: '[历史上下文]\n用户: 上一条\n\n[本次用户消息]\n请总结',
+			files: [currentFile, historyFile]
+		})
+		expect((message.payload as any).request.state.human.input).toBe(
+			'[历史上下文]\n用户: 上一条\n\n[本次用户消息]\n请总结'
+		)
+		expect((message.payload as any).options.context).toEqual(
+			expect.objectContaining({
+				integrationId: 'integration-1',
+				scopeKey: 'lark:v2:scope:integration-1:group:chat-1',
+				currentInboundLogIds: ['log-1', 'log-2'],
+				sourceMessageLogIds: ['log-1', 'log-2']
+			})
+		)
+		expect(runStateService.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				context: expect.objectContaining({
+					currentInboundLogIds: ['log-1', 'log-2'],
+					message: expect.objectContaining({ text: '请总结' })
+				})
+			})
+		)
+	})
+
+	it('turns a new inbound message into a steer follow-up while the active response is still running', async () => {
+		mockRequestContext()
+		const { service, conversationService, runStateService } = createFixture({
+			conversationId: 'conversation-1'
+		})
+		conversationService.getActiveMessage = jest.fn().mockResolvedValue({
+			id: 'ai-message-1',
+			thirdPartyMessage: {
+				id: 'lark-card-1',
+				messageId: 'ai-message-1',
+				status: 'thinking'
+			}
+		})
+		const larkMessage = createLarkMessage()
+		const currentFile = {
+			fileAssetId: 'asset-current',
+			workspacePath: 'files/lark/current.txt',
+			originalName: 'current.txt'
+		}
+		const historyFile = {
+			fileAssetId: 'asset-history',
+			workspacePath: 'files/lark/history.txt',
+			originalName: 'history.txt'
+		}
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: '先调整成简版',
+			files: [currentFile],
+			historyContext: '[历史上下文]\n用户: 不应重复注入',
+			historyFiles: [historyFile],
+			currentInboundLogIds: ['log-follow-up-1'],
+			larkMessage: larkMessage as any
+		})
+
+		expect((message.payload as any).request).toEqual({
+			action: 'follow_up',
+			conversationId: 'conversation-1',
+			mode: 'steer',
+			message: {
+				clientMessageId: 'log-follow-up-1',
+				input: {
+					input: '[历史上下文]\n用户: 不应重复注入\n\n[本次用户消息]\n先调整成简版',
+					files: [currentFile, historyFile]
+				}
+			},
+			target: {
+				aiMessageId: 'ai-message-1'
+			},
+			state: expect.objectContaining({
+				human: {
+					input: '[历史上下文]\n用户: 不应重复注入\n\n[本次用户消息]\n先调整成简版',
+					files: [currentFile, historyFile]
+				}
+			})
+		})
+		expect((message.payload as any).callback.context).toEqual(
+			expect.objectContaining({
+				followUpMode: 'steer',
+				conversationId: 'conversation-1',
+				currentInboundLogIds: ['log-follow-up-1']
+			})
+		)
+		expect(larkMessage.update).not.toHaveBeenCalled()
+		expect(conversationService.setActiveMessage).not.toHaveBeenCalled()
+		expect(runStateService.save).not.toHaveBeenCalled()
+	})
+
+	it('forces stale steer recovery into a normal send while reusing the same card and client message id', async () => {
+		mockRequestContext()
+		const { service, conversationService, runStateService } = createFixture({
+			conversationId: 'conversation-1'
+		})
+		conversationService.getActiveMessage.mockResolvedValue({
+			id: 'ai-message-1',
+			thirdPartyMessage: { id: 'lark-card-1', status: 'success' }
+		})
+		const larkMessage = createLarkMessage({
+			id: 'lark-card-1',
+			messageId: 'ai-message-1',
+			status: 'success',
+			elements: [{ tag: 'markdown', content: 'previous response' }]
+		})
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: 'continue safely',
+			currentInboundLogIds: ['log-follow-up-1'],
+			larkMessage: larkMessage as any,
+			options: { forceNewRun: true }
+		})
+
+		expect((message.payload as any).request).toEqual(
+			expect.objectContaining({
+				action: 'send',
+				conversationId: 'conversation-1',
+				message: expect.objectContaining({
+					clientMessageId: 'log-follow-up-1',
+					input: expect.objectContaining({ input: 'continue safely' })
+				})
+			})
+		)
+		expect((message.payload as any).callback.context.followUpMode).toBeUndefined()
+		expect(message.id).toMatch(/^lark_chat_recovery_[a-f0-9]{32}$/)
+		expect(message.id).not.toContain(':')
+		const duplicate = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: 'continue safely',
+			currentInboundLogIds: ['log-follow-up-1'],
+			larkMessage: larkMessage as any,
+			options: { forceNewRun: true }
+		})
+		expect(duplicate.id).toBe(message.id)
+		expect(larkMessage.update).toHaveBeenCalledWith({ status: 'thinking' })
+		expect(conversationService.setActiveMessage).toHaveBeenCalled()
+		expect(runStateService.save).toHaveBeenCalled()
+	})
+
+	it('uses a normal send only after the active response completes while waiting for its conversation', async () => {
+		mockRequestContext()
+		const { service, conversationService, runStateService } = createFixture({
+			conversationId: undefined
+		})
+		conversationService.getActiveMessage = jest
+			.fn()
+			.mockResolvedValueOnce({
+				id: 'ai-message-1',
+				thirdPartyMessage: { status: 'thinking' }
+			})
+			.mockResolvedValueOnce({
+				id: 'ai-message-1',
+				thirdPartyMessage: { status: 'success' }
+			})
+		const larkMessage = createLarkMessage()
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: '开始下一件事',
+			larkMessage: larkMessage as any
+		})
+
+		expect((message.payload as any).request).toEqual(
+			expect.objectContaining({
+				action: 'send'
+			})
+		)
+		expect((message.payload as any).request.conversationId).toBeUndefined()
+		expect(larkMessage.update).toHaveBeenCalledWith({ status: 'thinking' })
+		expect(conversationService.setActiveMessage).toHaveBeenCalledTimes(1)
+		expect(runStateService.save).toHaveBeenCalledTimes(1)
+	})
+
+	it('does not fall back to a second response card while an active response lacks a conversation binding', async () => {
+		jest.useFakeTimers()
+		mockRequestContext()
+		const { service, conversationService, runStateService } = createFixture({
+			conversationId: undefined
+		})
+		conversationService.getActiveMessage = jest.fn().mockResolvedValue({
+			id: 'ai-message-1',
+			thirdPartyMessage: { status: 'thinking' }
+		})
+		const larkMessage = createLarkMessage({
+			typingReaction: {
+				messageId: 'source-message-1',
+				reactionId: 'reaction-1',
+				emojiType: 'Typing'
+			}
+		})
+
+		const dispatch = service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: '继续补充',
+			larkMessage: larkMessage as any
+		})
+		const rejection = expect(dispatch).rejects.toThrow('follow-up was not dispatched')
+		await jest.advanceTimersByTimeAsync(30_000)
+
+		await rejection
+		expect(larkMessage.update).not.toHaveBeenCalled()
+		expect(larkMessage.larkChannel.deleteMessageReaction).toHaveBeenCalledWith(
+			'integration-1',
+			'source-message-1',
+			'reaction-1'
+		)
+		expect(conversationService.setActiveMessage).not.toHaveBeenCalled()
+		expect(runStateService.save).not.toHaveBeenCalled()
+	})
+
+	it('keeps the normal send path after the active response has completed', async () => {
+		mockRequestContext()
+		const { service, conversationService, runStateService } = createFixture({
+			conversationId: 'conversation-1'
+		})
+		conversationService.getActiveMessage = jest.fn().mockResolvedValue({
+			id: 'ai-message-1',
+			thirdPartyMessage: {
+				status: 'success'
+			}
+		})
+		const larkMessage = createLarkMessage()
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			input: '开始下一件事',
+			larkMessage: larkMessage as any
+		})
+
+		expect((message.payload as any).request).toEqual(
+			expect.objectContaining({
+				action: 'send',
+				conversationId: 'conversation-1'
+			})
+		)
+		expect((message.payload as any).callback.context.followUpMode).toBeUndefined()
+		expect(larkMessage.update).toHaveBeenCalledWith({ status: 'thinking' })
+		expect(conversationService.setActiveMessage).toHaveBeenCalledTimes(1)
+		expect(runStateService.save).toHaveBeenCalledTimes(1)
 	})
 
 	it('buildDispatchMessage continues when deleting typing reaction fails', async () => {
@@ -560,6 +956,50 @@ describe('LarkChatDispatchService', () => {
 				larkMessage: larkMessage as any
 			})
 		).rejects.toThrow('Missing tenantId in resolved dispatch context')
+	})
+
+	it('buildDispatchMessage uses trusted trigger execution context for a first async conversation', async () => {
+		mockRequestContext({
+			userId: undefined,
+			tenantId: undefined,
+			organizationId: undefined
+		})
+		const { service } = createFixture({
+			conversationId: undefined,
+			dispatchContext: {
+				source: 'request-fallback'
+			}
+		})
+		const larkMessage = createLarkMessage()
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			executionContext: {
+				tenantId: 'trigger-tenant-id',
+				organizationId: 'trigger-organization-id',
+				createdById: 'trigger-created-by-id'
+			},
+			input: 'hello',
+			larkMessage: larkMessage as any
+		})
+
+		expect(message.tenantId).toBe('trigger-tenant-id')
+		expect(message.headers).toEqual(
+			expect.objectContaining({
+				organizationId: 'trigger-organization-id',
+				userId: 'trigger-created-by-id'
+			})
+		)
+		expect((message.payload as any).options).toEqual(
+			expect.objectContaining({
+				tenantId: 'trigger-tenant-id',
+				organizationId: 'trigger-organization-id',
+				user: {
+					id: 'trigger-created-by-id',
+					tenantId: 'trigger-tenant-id'
+				}
+			})
+		)
 	})
 
 	it('buildDispatchMessage throws when final executor userId cannot be resolved', async () => {

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat-dispatch.service.ts
@@ -5,11 +5,13 @@ import {
 	HandoffMessage,
 	HANDOFF_PERMISSION_SERVICE_TOKEN,
 	HandoffPermissionService,
+	MANAGED_QUEUE_SERVICE_TOKEN,
+	type ManagedQueueService,
 	type PluginContext,
 	RequestContext,
 	AgentChatDispatchPayload
 } from '@xpert-ai/plugin-sdk'
-import { randomUUID } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import { LarkConversationService } from '../conversation.service.js'
 import { LanguagesEnum, STATE_VARIABLE_HUMAN } from '../contracts-compat.js'
 import { ChatLarkMessage } from '../message.js'
@@ -24,6 +26,12 @@ import {
 
 export type TLarkChatDispatchInput = DispatchLarkChatPayload
 
+const LARK_STEER_CONVERSATION_WAIT_MS = 30_000
+const LARK_STEER_CONVERSATION_POLL_MS = 100
+const LARK_DISPATCH_BUILD_LOCK_TTL_MS = 60_000
+const LARK_DISPATCH_BUILD_LOCK_WAIT_MS = 35_000
+const LARK_DISPATCH_BUILD_LOCK_POLL_MS = 50
+
 type LarkAgentChatDispatchOptions = AgentChatDispatchPayload['options'] & {
 	tenantId: string
 	organizationId?: string
@@ -35,6 +43,7 @@ type LarkAgentChatDispatchOptions = AgentChatDispatchPayload['options'] & {
 		id: string
 		tenantId: string
 	}
+	context?: Record<string, unknown>
 }
 
 /**
@@ -74,6 +83,16 @@ export class LarkChatDispatchService {
 	}
 
 	async buildDispatchMessage(input: TLarkChatDispatchInput): Promise<HandoffMessage<AgentChatDispatchPayload>> {
+		const scopeKey = input.larkMessage['scopeKey'] as string | undefined
+		if (!scopeKey) {
+			return this.buildDispatchMessageUnlocked(input)
+		}
+		return this.runWithDispatchBuildLock(scopeKey, input.xpertId, () =>
+			this.buildDispatchMessageUnlocked(input)
+		)
+	}
+
+	private async buildDispatchMessageUnlocked(input: TLarkChatDispatchInput): Promise<HandoffMessage<AgentChatDispatchPayload>> {
 		const { xpertId, larkMessage } = input
 		const requestUserId = RequestContext.currentUserId()
 		const requestTenantId = RequestContext.currentTenantId()
@@ -81,16 +100,41 @@ export class LarkChatDispatchService {
 		const scopeKey = larkMessage['scopeKey'] as string | undefined
 		const legacyConversationUserKey = larkMessage['legacyConversationUserKey'] as string | undefined
 		const principalKey = larkMessage['principalKey'] as string | undefined
-		const conversationId = scopeKey
+		const currentInboundLogIds = this.normalizeInboundLogIds(input.currentInboundLogIds)
+		let conversationId = scopeKey
 			? await this.conversationService.getConversation(scopeKey, xpertId, {
 					legacyConversationUserKey
 			  })
 			: undefined
-		const activeMessage = scopeKey
+		let activeMessage = scopeKey
 			? await this.conversationService.getActiveMessage(scopeKey, xpertId, {
 					legacyConversationUserKey
 			  })
 			: null
+		let steerCandidate =
+			!input.options?.forceNewRun &&
+			!input.options?.confirm &&
+			!input.options?.reject &&
+			this.isActiveMessageInProgress(activeMessage)
+		if (!conversationId && steerCandidate && scopeKey) {
+			let resolved: Awaited<ReturnType<LarkChatDispatchService['waitForConversationOrCompletion']>>
+			try {
+				resolved = await this.waitForConversationOrCompletion(
+					scopeKey,
+					xpertId,
+					legacyConversationUserKey
+				)
+			} catch (error) {
+				await this.clearTypingReaction(larkMessage)
+				throw error
+			}
+			conversationId = resolved.conversationId
+			activeMessage = resolved.activeMessage
+			steerCandidate = this.isActiveMessageInProgress(activeMessage)
+		}
+		const followUpMode = conversationId && steerCandidate ? ('steer' as const) : undefined
+		const dispatchInput = this.composeDispatchInput(input.input, input.historyContext)
+		const dispatchFiles = this.mergeFiles(input.files, input.historyFiles)
 		// Dispatch must run under xpert creator context; request context is only a safety fallback.
 		const dispatchContext = await this.conversationService.resolveDispatchExecutionContext(
 			xpertId,
@@ -99,10 +143,12 @@ export class LarkChatDispatchService {
 				legacyConversationUserKey
 			}
 		)
-		const tenantId = dispatchContext.tenantId ?? requestTenantId
-		const organizationId = dispatchContext.organizationId ?? requestOrganizationId
+		const tenantId = dispatchContext.tenantId ?? input.executionContext?.tenantId ?? requestTenantId
+		const organizationId =
+			dispatchContext.organizationId ?? input.executionContext?.organizationId ?? requestOrganizationId
 		const mappedExecutorUserId = input.options?.executorUserId
-		const executorUserId = mappedExecutorUserId ?? dispatchContext.createdById ?? requestUserId
+		const executorUserId =
+			mappedExecutorUserId ?? dispatchContext.createdById ?? input.executionContext?.createdById ?? requestUserId
 		if (!tenantId) {
 			throw new Error('Missing tenantId in resolved dispatch context')
 		}
@@ -118,19 +164,24 @@ export class LarkChatDispatchService {
 		)
 
 		await this.clearTypingReaction(larkMessage)
-		await larkMessage.update({ status: 'thinking' })
-		if (scopeKey) {
-			await this.conversationService.setActiveMessage(
-				scopeKey,
-				xpertId,
-				this.toActiveMessageCache(larkMessage),
-				{
-					legacyConversationUserKey
-				}
-			)
+		if (!followUpMode) {
+			await larkMessage.update({ status: 'thinking' })
+			if (scopeKey) {
+				await this.conversationService.setActiveMessage(
+					scopeKey,
+					xpertId,
+					this.toActiveMessageCache(larkMessage),
+					{
+						legacyConversationUserKey
+					}
+				)
+			}
 		}
 
-		const runId = `lark-chat-${randomUUID()}`
+		const runId =
+			input.options?.forceNewRun && currentInboundLogIds.length
+				? this.buildRecoveryRunId(larkMessage.integrationId, currentInboundLogIds)
+				: `lark-chat-${randomUUID()}`
 		const sessionKey = conversationId ?? runId
 		const language = larkMessage.language || RequestContext.getLanguageCode()
 		const callbackContext: LarkChatCallbackContext = {
@@ -138,6 +189,7 @@ export class LarkChatDispatchService {
 			organizationId,
 			userId: executorUserId,
 			xpertId,
+			conversationId,
 			connectionMode: larkMessage.connectionMode,
 			integrationId: larkMessage.integrationId,
 			chatId: larkMessage.chatId,
@@ -150,38 +202,60 @@ export class LarkChatDispatchService {
 			recipientDirectoryKey: larkMessage.recipientDirectoryKey,
 			groupWindowId: input.options?.groupWindow?.windowId,
 			groupWindow: input.options?.groupWindow,
+			...(currentInboundLogIds.length ? { currentInboundLogIds } : {}),
+			...(followUpMode
+				? {
+						followUpMode,
+						steerFallback: {
+							input: dispatchInput,
+							files: dispatchFiles,
+							message: this.toMessageSnapshotFromActive(activeMessage),
+							fromEndUserId: input.options?.fromEndUserId,
+							executorUserId: input.options?.executorUserId,
+							streamingEnabled: input.options?.streamingEnabled
+						}
+				  }
+				: {}),
 			reject: Boolean(input.options?.reject),
 			streaming: this.resolveStreamingConfig(input.options),
 			message: this.toMessageSnapshot(larkMessage, input.input)
 		}
 
-		await this.runStateService.save({
-			sourceMessageId: runId,
-			nextSequence: 1,
-			responseMessageContent: '',
-			context: callbackContext,
-			pendingEvents: {},
-			lastFlushAt: 0,
-			lastFlushedLength: 0,
-			renderItems: (callbackContext.message?.elements ?? []).map((element) => ({
-				kind: 'structured' as const,
-				element: { ...element }
-			}))
-		})
+		if (!followUpMode) {
+			await this.runStateService.save({
+				sourceMessageId: runId,
+				nextSequence: 1,
+				responseMessageContent: '',
+				context: callbackContext,
+				pendingEvents: {},
+				lastFlushAt: 0,
+				lastFlushedLength: 0,
+				renderItems: (callbackContext.message?.elements ?? []).map((element) => ({
+					kind: 'structured' as const,
+					element: { ...element }
+				}))
+			})
+		}
 
 		this.logger.debug(
 			`[lark-dispatch] runId=${runId} integration=${larkMessage.integrationId ?? 'n/a'} chat=${larkMessage.chatId ?? 'n/a'} conversationId=${
 				conversationId ?? 'n/a'
 			} recipientDirectoryKey=${larkMessage.recipientDirectoryKey ?? 'n/a'}`
 		)
-		const state = this.buildChatState(input)
+		const state = this.buildChatState({
+			...input,
+			input: dispatchInput,
+			files: dispatchFiles
+		})
 		const request = this.buildChatRequest({
 			conversationId,
 			activeMessageId: activeMessage?.id,
+			followUpMode,
+			clientMessageId: currentInboundLogIds[0],
 			state,
 			options: input.options,
-			input: input.input,
-			files: input.files
+			input: dispatchInput,
+			files: dispatchFiles
 		})
 		const dispatchOptions: LarkAgentChatDispatchOptions = {
 			xpertId,
@@ -210,7 +284,25 @@ export class LarkChatDispatchService {
 			channelType: 'lark',
 			integrationId: larkMessage.integrationId,
 			chatId: larkMessage.chatId,
-			channelUserId: larkMessage.senderOpenId
+			channelUserId: larkMessage.senderOpenId,
+			context: {
+				from: 'lark',
+				channelType: 'lark',
+				sourceIntegrationId: larkMessage.integrationId,
+				integrationId: larkMessage.integrationId,
+				chatId: larkMessage.chatId,
+				chatType: larkMessage['chatType'] as string | undefined,
+				senderOpenId: larkMessage.senderOpenId,
+				senderName: larkMessage['senderName'] as string | undefined,
+				scopeKey,
+				xpertId,
+				...(currentInboundLogIds.length
+					? {
+							currentInboundLogIds,
+							sourceMessageLogIds: currentInboundLogIds
+					  }
+					: {})
+			}
 		}
 		const payload: AgentChatDispatchPayload = {
 			request,
@@ -258,6 +350,50 @@ export class LarkChatDispatchService {
 		}
 	}
 
+	private async runWithDispatchBuildLock<T>(scopeKey: string, xpertId: string, task: () => Promise<T>): Promise<T> {
+		const queue = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN) as ManagedQueueService
+		const redis = await queue.getRedis()
+		const key = this.dispatchBuildLockKey(scopeKey, xpertId)
+		const owner = randomUUID()
+		const deadline = Date.now() + LARK_DISPATCH_BUILD_LOCK_WAIT_MS
+
+		while (Date.now() < deadline) {
+			const claimed = await redis.set(key, owner, 'PX', LARK_DISPATCH_BUILD_LOCK_TTL_MS, 'NX')
+			if (claimed === 'OK') {
+				try {
+					return await task()
+				} finally {
+					try {
+						await redis.eval(
+							`if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end`,
+							1,
+							key,
+							owner
+						)
+					} catch (error) {
+						this.logger.warn(`Unable to release Lark dispatch decision lock: ${String(error)}`)
+					}
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, LARK_DISPATCH_BUILD_LOCK_POLL_MS))
+		}
+
+		throw new Error(`Timed out waiting for the active Lark response decision for scope=${scopeKey}, xpertId=${xpertId}`)
+	}
+
+	private dispatchBuildLockKey(scopeKey: string, xpertId: string): string {
+		const digest = createHash('sha256').update(`${scopeKey}\0${xpertId}`).digest('hex').slice(0, 32)
+		return `lark:dispatch-build:${digest}`
+	}
+
+	private buildRecoveryRunId(integrationId: string, inboundLogIds: string[]): string {
+		const digest = createHash('sha256')
+			.update([integrationId, ...inboundLogIds].join('\u0000'))
+			.digest('hex')
+			.slice(0, 32)
+		return `lark_chat_recovery_${digest}`
+	}
+
 	private async clearTypingReaction(larkMessage: ChatLarkMessage): Promise<void> {
 		const typingReaction = larkMessage.typingReaction
 		const deleteMessageReaction = larkMessage.larkChannel?.deleteMessageReaction
@@ -287,6 +423,7 @@ export class LarkChatDispatchService {
 
 	private buildChatState(input: TLarkChatDispatchInput): Record<string, any> {
 		const { larkMessage } = input
+		const sourceMessageLogIds = this.normalizeInboundLogIds(input.currentInboundLogIds)
 		const files = Array.isArray(input.files) && input.files.length > 0 ? input.files : undefined
 		const humanInput =
 			input.input !== undefined || files
@@ -305,8 +442,14 @@ export class LarkChatDispatchService {
 				chatId: larkMessage.chatId ?? '',
 				chatType: (larkMessage['chatType'] as string | undefined) ?? '',
 				senderOpenId: larkMessage.senderOpenId ?? '',
-				senderName: (larkMessage['senderName'] as string | undefined) ?? ''
+				senderName: (larkMessage['senderName'] as string | undefined) ?? '',
+				...(sourceMessageLogIds.length
+					? { currentInboundLogIds: sourceMessageLogIds, sourceMessageLogIds }
+					: {})
 			},
+			...(sourceMessageLogIds.length
+				? { currentInboundLogIds: sourceMessageLogIds, sourceMessageLogIds }
+				: {}),
 			...(larkMessage.recipientDirectoryKey
 				? {
 						recipientDirectoryKey: larkMessage.recipientDirectoryKey,
@@ -324,6 +467,8 @@ export class LarkChatDispatchService {
 	private buildChatRequest(params: {
 		conversationId?: string
 		activeMessageId?: string
+		followUpMode?: 'steer'
+		clientMessageId?: string
 		state: Record<string, any>
 		options?: TLarkChatDispatchInput['options']
 		input?: string
@@ -346,11 +491,34 @@ export class LarkChatDispatchService {
 				state: params.state
 			} as unknown as TChatRequest
 		}
+		if (params.followUpMode) {
+			if (!params.conversationId) {
+				throw new Error('Missing conversationId for Lark steer follow-up')
+			}
+
+			return {
+				action: 'follow_up',
+				conversationId: params.conversationId,
+				mode: params.followUpMode,
+				message: {
+					...(params.clientMessageId ? { clientMessageId: params.clientMessageId } : {}),
+					input: {
+						input: params.input ?? '',
+						...(params.files?.length ? { files: params.files } : {})
+					}
+				},
+				target: {
+					...(params.activeMessageId ? { aiMessageId: params.activeMessageId } : {})
+				},
+				state: params.state
+			} as unknown as TChatRequest
+		}
 
 		return {
 			action: 'send',
 			...(params.conversationId ? { conversationId: params.conversationId } : {}),
 			message: {
+				...(params.clientMessageId ? { clientMessageId: params.clientMessageId } : {}),
 				input: {
 					input: params.input ?? '',
 					...(params.files?.length ? { files: params.files } : {})
@@ -358,6 +526,98 @@ export class LarkChatDispatchService {
 			},
 			state: params.state
 		} as unknown as TChatRequest
+	}
+
+	private isActiveMessageInProgress(
+		message: Awaited<ReturnType<LarkConversationService['getActiveMessage']>>
+	): boolean {
+		const status = message?.thirdPartyMessage?.status
+		return status === 'thinking' || status === 'continuing'
+	}
+
+	private async waitForConversationOrCompletion(
+		scopeKey: string,
+		xpertId: string,
+		legacyConversationUserKey?: string
+	): Promise<{
+		conversationId?: string
+		activeMessage: Awaited<ReturnType<LarkConversationService['getActiveMessage']>>
+	}> {
+		const deadline = Date.now() + LARK_STEER_CONVERSATION_WAIT_MS
+		while (Date.now() < deadline) {
+			const [conversationId, activeMessage] = await Promise.all([
+				this.conversationService.getConversation(scopeKey, xpertId, {
+					legacyConversationUserKey
+				}),
+				this.conversationService.getActiveMessage(scopeKey, xpertId, {
+					legacyConversationUserKey
+				})
+			])
+			if (!this.isActiveMessageInProgress(activeMessage)) {
+				return {
+					conversationId,
+					activeMessage
+				}
+			}
+			if (conversationId) {
+				return {
+					conversationId,
+					activeMessage
+				}
+			}
+			await new Promise((resolve) => setTimeout(resolve, LARK_STEER_CONVERSATION_POLL_MS))
+		}
+		const message =
+			`Active Lark response has no conversation binding after ${LARK_STEER_CONVERSATION_WAIT_MS}ms; ` +
+			`follow-up was not dispatched to avoid creating a duplicate response card for scope=${scopeKey}, xpertId=${xpertId}`
+		this.logger.warn(message)
+		throw new Error(message)
+	}
+
+	private composeDispatchInput(input?: string, historyContext?: string): string | undefined {
+		const history = typeof historyContext === 'string' ? historyContext.trim() : ''
+		if (!history) {
+			return input
+		}
+		return `${history}\n\n[本次用户消息]\n${input ?? ''}`
+	}
+
+	private normalizeInboundLogIds(ids?: string[]): string[] {
+		return Array.from(
+			new Set(
+				(ids ?? [])
+					.map((id) => (typeof id === 'string' ? id.trim() : ''))
+					.filter((id): id is string => Boolean(id))
+			)
+		)
+	}
+
+	private mergeFiles(
+		current?: TLarkChatDispatchInput['files'],
+		history?: TLarkChatDispatchInput['historyFiles']
+	): TLarkChatDispatchInput['files'] {
+		const files = [...(current ?? []), ...(history ?? [])]
+		if (!files.length) {
+			return undefined
+		}
+		const seen = new Set<string>()
+		return files.filter((file, index) => {
+			const key =
+				file.fileAssetId ??
+				file.fileId ??
+				file.storageFileId ??
+				file.workspacePath ??
+				file.filePath ??
+				file.fileUrl ??
+				file.url ??
+				file.fileKey ??
+				`index:${index}`
+			if (seen.has(key)) {
+				return false
+			}
+			seen.add(key)
+			return true
+		})
 	}
 
 	private toMessageSnapshot(message: ChatLarkMessage, text?: string): LarkChatMessageSnapshot {
@@ -370,6 +630,24 @@ export class LarkChatDispatchService {
 			header: message.header,
 			elements: [...(message.elements ?? [])],
 			text
+		}
+	}
+
+	private toMessageSnapshotFromActive(
+		message: Awaited<ReturnType<LarkConversationService['getActiveMessage']>>
+	): LarkChatMessageSnapshot {
+		const snapshot = message?.thirdPartyMessage
+		if (!snapshot?.id) {
+			throw new Error('Missing active Lark response card for steer fallback')
+		}
+		return {
+			id: snapshot.id,
+			messageId: snapshot.messageId ?? message?.id,
+			deliveryMode: snapshot.deliveryMode,
+			status: snapshot.status,
+			language: snapshot.language,
+			header: snapshot.header,
+			elements: [...(snapshot.elements ?? [])]
 		}
 	}
 

--- a/xpertai/integrations/lark/src/lib/handoff/lark-chat.types.ts
+++ b/xpertai/integrations/lark/src/lib/handoff/lark-chat.types.ts
@@ -3,7 +3,7 @@ import {
 	defineChannelMessageType,
 	AgentChatCallbackEnvelopePayload
 } from '@xpert-ai/plugin-sdk'
-import { LarkCardElement, LarkGroupWindow, LarkStructuredElement } from '../types.js'
+import { LarkCardElement, LarkGroupWindow, LarkInboundFile, LarkStructuredElement } from '../types.js'
 
 export const LARK_CHAT_STREAM_CALLBACK_MESSAGE_TYPE = defineChannelMessageType(
 	'lark',
@@ -74,6 +74,7 @@ export interface LarkChatCallbackContext extends Record<string, unknown> {
 	organizationId?: string
 	userId: string
 	xpertId: string
+	conversationId?: string
 	connectionMode?: 'webhook' | 'long_connection'
 	preferLanguage?: string
 	integrationId?: string
@@ -87,6 +88,16 @@ export interface LarkChatCallbackContext extends Record<string, unknown> {
 	recipientDirectoryKey?: string
 	groupWindowId?: string
 	groupWindow?: LarkGroupWindow
+	currentInboundLogIds?: string[]
+	followUpMode?: 'steer'
+	steerFallback?: {
+		input?: string
+		files?: LarkInboundFile[]
+		message: LarkChatMessageSnapshot
+		fromEndUserId?: string
+		executorUserId?: string
+		streamingEnabled?: boolean
+	}
 	reject?: boolean
 	streaming?: {
 		enabled?: boolean
@@ -96,6 +107,7 @@ export interface LarkChatCallbackContext extends Record<string, unknown> {
 }
 
 export interface LarkChatStreamCallbackPayload extends AgentChatCallbackEnvelopePayload {
+	errorCode?: 'steer_target_not_running'
 	context?: LarkChatCallbackContext
 }
 

--- a/xpertai/integrations/lark/src/lib/integration-lark.module.ts
+++ b/xpertai/integrations/lark/src/lib/integration-lark.module.ts
@@ -3,6 +3,7 @@ import { XpertServerPlugin, IOnPluginBootstrap, IOnPluginDestroy } from '@xpert-
 import { CqrsModule } from '@nestjs/cqrs'
 import { DiscoveryModule } from '@nestjs/core'
 import { TypeOrmModule } from '@nestjs/typeorm'
+import { Logger } from '@nestjs/common'
 
 import { LarkChannelStrategy } from './lark-channel.strategy.js'
 import { LarkIntegrationStrategy } from './lark-integration.strategy.js'
@@ -21,10 +22,13 @@ import { LarkGroupMentionWindowService } from './lark-group-mention-window.servi
 import { LarkRecipientDirectoryService } from './lark-recipient-directory.service.js'
 import { LarkConversationBindingEntity } from './entities/lark-conversation-binding.entity.js'
 import { LarkTriggerBindingEntity } from './entities/lark-trigger-binding.entity.js'
+import { LarkMessageFileEntity, LarkMessageLogEntity } from './entities/index.js'
 import {
-	ChatBILarkMiddleware,
-	LarkConversationContextMiddleware,
-	LarkNotifyMiddleware
+  ChatBILarkMiddleware,
+  LarkConversationContextMiddleware,
+  LarkLocalHistoryMiddleware,
+  LarkNotifyMiddleware,
+  LarkRuntimeMiddleware
 } from './middlewares/index.js'
 import { LarkTriggerStrategy } from './workflow/lark-trigger.strategy.js'
 import { LarkTriggerAggregationService } from './workflow/lark-trigger-aggregation.service.js'
@@ -34,76 +38,102 @@ import { LarkDocTransformerStrategy } from './transformer.strategy.js'
 import { Handlers } from './handoff/commands/handlers/index.js'
 import { LARK_CONVERSATION_QUEUE_SERVICE, LARK_LONG_CONNECTION_SERVICE } from './tokens.js'
 import { LarkIntegrationViewProvider } from './views/index.js'
+import { LarkMessageHistoryService } from './lark-message-history.service.js'
+import { LarkMessageHistoryQueueService } from './lark-message-history-queue.service.js'
+import { LarkMessageHistoryQueueProcessor } from './lark-message-history-queue.processor.js'
+import { LarkMessageHistorySchemaService } from './lark-message-history-schema.service.js'
 
 @XpertServerPlugin({
-	imports: [
-		DiscoveryModule,
-		CqrsModule,
-		TypeOrmModule.forFeature([LarkConversationBindingEntity, LarkTriggerBindingEntity]),
-	],
-	entities: [LarkConversationBindingEntity, LarkTriggerBindingEntity],
-	controllers: [LarkHooksController],
-	providers: [
-		LarkConversationService,
-		LarkConversationBindingSchemaService,
-		LarkContextToolService,
-		LarkGroupMentionWindowService,
-		LarkChannelStrategy,
-		LarkCapabilityService,
-		LarkInboundIdentityService,
-		LarkIntegrationStrategy,
-		LarkTriggerStrategy,
-		LarkTriggerAggregationService,
-		LarkTriggerFlushProcessor,
-		LarkLongConnectionService,
-		LarkChatDispatchService,
-		LarkChatRunStateService,
-		LarkChatStreamCallbackProcessor,
-		LarkRecipientDirectoryService,
-		LarkIntegrationViewProvider,
-		LarkTokenStrategy,
-		ChatBILarkMiddleware,
-		LarkConversationContextMiddleware,
-		LarkNotifyMiddleware,
-		LarkSourceStrategy,
-		LarkDocTransformerStrategy,
-		{
-			provide: LARK_LONG_CONNECTION_SERVICE,
-			useExisting: LarkLongConnectionService
-		},
-		{
-			provide: LARK_CONVERSATION_QUEUE_SERVICE,
-			useExisting: LarkConversationService
-		},
-		...Handlers
-	],
-	exports: [
-		LarkChannelStrategy,
-		LarkCapabilityService,
-		LarkIntegrationStrategy,
-		LarkTriggerStrategy,
-		LarkLongConnectionService,
-		LarkChatDispatchService,
-		LarkRecipientDirectoryService,
-		LarkGroupMentionWindowService,
-		LarkContextToolService,
-		ChatBILarkMiddleware,
-		LarkConversationContextMiddleware,
-		LarkNotifyMiddleware
-	]
+  imports: [
+    DiscoveryModule,
+    CqrsModule,
+    TypeOrmModule.forFeature([
+      LarkConversationBindingEntity,
+      LarkTriggerBindingEntity,
+      LarkMessageLogEntity,
+      LarkMessageFileEntity
+    ])
+  ],
+  entities: [LarkConversationBindingEntity, LarkTriggerBindingEntity, LarkMessageLogEntity, LarkMessageFileEntity],
+  controllers: [LarkHooksController],
+  providers: [
+    LarkConversationService,
+    LarkConversationBindingSchemaService,
+    LarkContextToolService,
+    LarkGroupMentionWindowService,
+    LarkChannelStrategy,
+    LarkCapabilityService,
+    LarkInboundIdentityService,
+    LarkIntegrationStrategy,
+    LarkTriggerStrategy,
+    LarkTriggerAggregationService,
+    LarkTriggerFlushProcessor,
+    LarkLongConnectionService,
+    LarkChatDispatchService,
+    LarkChatRunStateService,
+    LarkChatStreamCallbackProcessor,
+    LarkRecipientDirectoryService,
+    LarkMessageHistoryService,
+    LarkMessageHistorySchemaService,
+    LarkMessageHistoryQueueService,
+    LarkMessageHistoryQueueProcessor,
+    LarkIntegrationViewProvider,
+    LarkTokenStrategy,
+    ChatBILarkMiddleware,
+    LarkConversationContextMiddleware,
+    LarkLocalHistoryMiddleware,
+    LarkNotifyMiddleware,
+    LarkRuntimeMiddleware,
+    LarkSourceStrategy,
+    LarkDocTransformerStrategy,
+    {
+      provide: LARK_LONG_CONNECTION_SERVICE,
+      useExisting: LarkLongConnectionService
+    },
+    {
+      provide: LARK_CONVERSATION_QUEUE_SERVICE,
+      useExisting: LarkConversationService
+    },
+    ...Handlers
+  ],
+  exports: [
+    LarkChannelStrategy,
+    LarkCapabilityService,
+    LarkIntegrationStrategy,
+    LarkTriggerStrategy,
+    LarkLongConnectionService,
+    LarkChatDispatchService,
+    LarkRecipientDirectoryService,
+    LarkGroupMentionWindowService,
+    LarkContextToolService,
+    LarkMessageHistoryService,
+    LarkLocalHistoryMiddleware,
+    ChatBILarkMiddleware,
+    LarkConversationContextMiddleware,
+    LarkNotifyMiddleware,
+    LarkRuntimeMiddleware
+  ]
 })
 export class IntegrationLarkPlugin implements IOnPluginBootstrap, IOnPluginDestroy {
-	private logEnabled = true
+  private logEnabled = true
+  private readonly logger = new Logger(IntegrationLarkPlugin.name)
 
-	onPluginBootstrap(): void | Promise<void> {
-		if (this.logEnabled) {
-			console.log(chalk.green(`${IntegrationLarkPlugin.name} is being bootstrapped...`))
-		}
-	}
+  constructor(private readonly messageHistorySchemaService: LarkMessageHistorySchemaService) {}
 
-	onPluginDestroy(): void | Promise<void> {
-		if (this.logEnabled) {
-			console.log(chalk.green(`${IntegrationLarkPlugin.name} is being destroyed...`))
-		}
-	}
+  onPluginBootstrap(): void {
+    // Index creation may scan a large history table. Keep plugin startup and
+    // trigger publishing available while the PostgreSQL concurrent build runs.
+    void this.messageHistorySchemaService
+      .ensureSchema()
+      .catch((error) => this.logger.warn(`Unable to initialize Lark history search schema: ${String(error)}`))
+    if (this.logEnabled) {
+      console.log(chalk.green(`${IntegrationLarkPlugin.name} is being bootstrapped...`))
+    }
+  }
+
+  onPluginDestroy(): void | Promise<void> {
+    if (this.logEnabled) {
+      console.log(chalk.green(`${IntegrationLarkPlugin.name} is being destroyed...`))
+    }
+  }
 }

--- a/xpertai/integrations/lark/src/lib/lark-channel.card-action.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-channel.card-action.spec.ts
@@ -1,0 +1,186 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+	const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+	return createLarkPluginSdkMock(jest, {
+		MANAGED_QUEUE_SERVICE_TOKEN: 'MANAGED_QUEUE_SERVICE_TOKEN'
+	})
+})
+
+jest.mock('@larksuiteoapi/node-sdk', () => {
+	class EventDispatcher {
+		readonly handles = new Map<string, (data: unknown) => Promise<unknown>>()
+
+		register(handles: Record<string, (data: unknown) => Promise<unknown>>) {
+			for (const [event, handler] of Object.entries(handles)) {
+				this.handles.set(event, handler)
+			}
+			return this
+		}
+	}
+
+	return {
+		EventDispatcher,
+		LoggerLevel: {
+			debug: 'debug'
+		},
+		adaptExpress: jest.fn()
+	}
+})
+
+import { LarkChannelStrategy } from './lark-channel.strategy.js'
+
+describe('LarkChannelStrategy card action callbacks', () => {
+	const ctx = {
+		integration: {
+			id: 'integration-1',
+			options: {
+				appId: 'app-id',
+				appSecret: 'app-secret',
+				verificationToken: 'verification-token',
+				encryptKey: 'encrypt-key'
+			}
+		}
+	} as any
+
+	afterEach(() => {
+		jest.restoreAllMocks()
+	})
+
+	function createStrategy(resolve = jest.fn()) {
+		const strategy = new LarkChannelStrategy(
+			{
+				resolve
+			} as any,
+			{} as any
+		)
+		const action = {
+			action: 'end',
+			messageId: 'message-1'
+		}
+		jest.spyOn(strategy, 'parseCardAction').mockReturnValue(action as any)
+		return { strategy, action }
+	}
+
+	function getCardActionCallback(strategy: LarkChannelStrategy, onCardAction: jest.Mock) {
+		const dispatcher = strategy.createEventDispatcher(ctx, { onCardAction } as any)
+		return (dispatcher as any).handles.get('card.action.trigger') as (
+			data: unknown
+		) => Promise<unknown>
+	}
+
+	async function flushBackgroundHandlers() {
+		await new Promise((resolve) => setImmediate(resolve))
+		await new Promise((resolve) => setImmediate(resolve))
+	}
+
+	it('returns a valid empty card response while processing the action in background', async () => {
+		const { strategy, action } = createStrategy()
+		const onCardAction = jest.fn().mockResolvedValue(undefined)
+		const callback = getCardActionCallback(strategy, onCardAction)
+
+		await expect(callback({ event: 'card-action' })).resolves.toEqual({})
+		await flushBackgroundHandlers()
+
+		expect(onCardAction).toHaveBeenCalledTimes(1)
+		expect(onCardAction).toHaveBeenCalledWith(action, ctx)
+	})
+
+	it('claims the event id through Redis so duplicate deliveries across instances execute once', async () => {
+		const claimedKeys = new Set<string>()
+		const redis = {
+			set: jest.fn(async (key: string) => {
+				if (claimedKeys.has(key)) {
+					return null
+				}
+				claimedKeys.add(key)
+				return 'OK'
+			})
+		}
+		const managedQueue = {
+			getRedis: jest.fn().mockResolvedValue(redis)
+		}
+		const resolve = jest.fn().mockReturnValue(managedQueue)
+		const first = createStrategy(resolve)
+		const second = createStrategy(resolve)
+		const onCardAction = jest.fn().mockResolvedValue(undefined)
+		const firstCallback = getCardActionCallback(first.strategy, onCardAction)
+		const secondCallback = getCardActionCallback(second.strategy, onCardAction)
+
+		await expect(
+			Promise.all([
+				firstCallback({ event_id: 'event-duplicate' }),
+				secondCallback({ event_id: 'event-duplicate' })
+			])
+		).resolves.toEqual([{}, {}])
+		await flushBackgroundHandlers()
+
+		expect(onCardAction).toHaveBeenCalledTimes(1)
+		expect(redis.set).toHaveBeenCalledTimes(2)
+		expect(redis.set).toHaveBeenCalledWith(
+			'plugin_lark:card_action:event:integration-1:event-duplicate',
+			'1',
+			'PX',
+			10 * 60 * 1000,
+			'NX'
+		)
+	})
+
+	it('processes different event ids independently', async () => {
+		const redis = {
+			set: jest.fn().mockResolvedValue('OK')
+		}
+		const { strategy } = createStrategy(
+			jest.fn().mockReturnValue({ getRedis: jest.fn().mockResolvedValue(redis) })
+		)
+		const onCardAction = jest.fn().mockResolvedValue(undefined)
+		const callback = getCardActionCallback(strategy, onCardAction)
+
+		await Promise.all([
+			callback({ event_id: 'event-distinct-a' }),
+			callback({ event_id: 'event-distinct-b' })
+		])
+		await flushBackgroundHandlers()
+
+		expect(onCardAction).toHaveBeenCalledTimes(2)
+		expect(redis.set).toHaveBeenCalledTimes(2)
+	})
+
+	it('preserves legacy behavior when event_id is missing', async () => {
+		const resolve = jest.fn()
+		const { strategy } = createStrategy(resolve)
+		const onCardAction = jest.fn().mockResolvedValue(undefined)
+		const callback = getCardActionCallback(strategy, onCardAction)
+
+		await Promise.all([callback({ event: 'legacy-action' }), callback({ event: 'legacy-action' })])
+		await flushBackgroundHandlers()
+
+		expect(onCardAction).toHaveBeenCalledTimes(2)
+		expect(resolve).not.toHaveBeenCalled()
+	})
+
+	it('acks immediately and uses process-local deduplication when Redis is unavailable', async () => {
+		let rejectRedis: (error: Error) => void = () => undefined
+		const pendingRedis = new Promise<never>((_resolve, reject) => {
+			rejectRedis = reject
+		})
+		const getRedis = jest
+			.fn()
+			.mockReturnValueOnce(pendingRedis)
+			.mockRejectedValue(new Error('redis unavailable'))
+		const resolve = jest.fn().mockReturnValue({ getRedis })
+		const first = createStrategy(resolve)
+		const second = createStrategy(resolve)
+		const onCardAction = jest.fn().mockResolvedValue(undefined)
+		const firstCallback = getCardActionCallback(first.strategy, onCardAction)
+		const secondCallback = getCardActionCallback(second.strategy, onCardAction)
+
+		await expect(firstCallback({ event_id: 'event-fallback' })).resolves.toEqual({})
+		expect(onCardAction).not.toHaveBeenCalled()
+
+		rejectRedis(new Error('redis unavailable'))
+		await flushBackgroundHandlers()
+		await expect(secondCallback({ event_id: 'event-fallback' })).resolves.toEqual({})
+		await flushBackgroundHandlers()
+
+		expect(onCardAction).toHaveBeenCalledTimes(1)
+	})
+})

--- a/xpertai/integrations/lark/src/lib/lark-channel.strategy.ts
+++ b/xpertai/integrations/lark/src/lib/lark-channel.strategy.ts
@@ -11,6 +11,8 @@ import {
 	IChatChannel,
 	INTEGRATION_PERMISSION_SERVICE_TOKEN,
 	IntegrationPermissionService,
+	MANAGED_QUEUE_SERVICE_TOKEN,
+	type ManagedQueueService,
 	type PluginContext,
 	TChatCardAction,
 	TChatChannelCapabilities,
@@ -63,6 +65,10 @@ type LarkRecipient = {
 	type: 'chat_id' | 'open_id' | 'user_id' | 'union_id' | 'email'
 	id: string
 }
+
+const LARK_CARD_ACTION_DEDUP_TTL_MS = 10 * 60 * 1000
+const LARK_CARD_ACTION_DEDUP_KEY_PREFIX = 'plugin_lark:card_action:event'
+const larkCardActionFallbackClaims = new Map<string, number>()
 
 @Injectable()
 @ChatChannel('lark')
@@ -195,11 +201,22 @@ export class LarkChannelStrategy implements IChatChannel<TIntegrationLarkOptions
 					if (action) {
 						// Lark webhook callbacks should return within 3s, so we ack first and process in background.
 						this.runBackgroundEventHandler('card action', async () => {
+							if (!(await this.claimCardActionEvent(data, integration.id))) {
+								this.logger.debug(
+									`Skip duplicate Lark card action event integration=${integration.id} event=${
+										this.getCardActionEventId(data) ?? 'unknown'
+									}`
+								)
+								return
+							}
 							await eventHandlers.onCardAction?.(action, ctx)
 						})
 					}
 
-					return true
+					// Card callbacks must return a valid card response object. An empty
+					// object acknowledges the action while keeping the current card as-is;
+					// the actual action continues asynchronously above.
+					return {}
 				}
 			})
 		}
@@ -225,6 +242,66 @@ export class LarkChannelStrategy implements IChatChannel<TIntegrationLarkOptions
 					stack
 				)
 			})
+	}
+
+	private async claimCardActionEvent(data: unknown, integrationId: string): Promise<boolean> {
+		const eventId = this.getCardActionEventId(data)
+		if (!eventId) {
+			return true
+		}
+
+		const claimKey = `${integrationId}:${eventId}`
+		try {
+			const managedQueue = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN) as ManagedQueueService
+			const redis = await managedQueue.getRedis()
+			const result = await redis.set(
+				`${LARK_CARD_ACTION_DEDUP_KEY_PREFIX}:${claimKey}`,
+				'1',
+				'PX',
+				LARK_CARD_ACTION_DEDUP_TTL_MS,
+				'NX'
+			)
+			if (result === 'OK') {
+				return true
+			}
+			if (result === null) {
+				return false
+			}
+			throw new Error(`Unexpected Redis SET response: ${String(result)}`)
+		} catch (error) {
+			this.logger.warn(
+				`Unable to claim Lark card action event in Redis; using process-local fallback: ${getErrorMessage(error)}`
+			)
+			return this.claimCardActionEventLocally(claimKey)
+		}
+	}
+
+	private claimCardActionEventLocally(claimKey: string): boolean {
+		const now = Date.now()
+		for (const [key, expiresAt] of larkCardActionFallbackClaims) {
+			if (expiresAt <= now) {
+				larkCardActionFallbackClaims.delete(key)
+			}
+		}
+
+		if ((larkCardActionFallbackClaims.get(claimKey) ?? 0) > now) {
+			return false
+		}
+		larkCardActionFallbackClaims.set(claimKey, now + LARK_CARD_ACTION_DEDUP_TTL_MS)
+		return true
+	}
+
+	private getCardActionEventId(data: unknown): string | null {
+		if (!data || typeof data !== 'object') {
+			return null
+		}
+		const record = data as Record<string, unknown>
+		const header =
+			record.header && typeof record.header === 'object'
+				? (record.header as Record<string, unknown>)
+				: null
+		const eventId = record.event_id ?? header?.event_id
+		return typeof eventId === 'string' && eventId.trim() ? eventId.trim() : null
 	}
 
 	parseInboundMessage(event: any, _ctx: TChatEventContext<TIntegrationLarkOptions>): TChatInboundMessage | null {

--- a/xpertai/integrations/lark/src/lib/lark-context-tool.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-context-tool.service.spec.ts
@@ -1,3 +1,8 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  ...require('../../../../test-utils/larkPluginSdkMock.cjs').createLarkPluginSdkMock(jest),
+  getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error))
+}))
+
 import { Readable } from 'node:stream'
 import { LarkContextToolService } from './lark-context-tool.service.js'
 
@@ -86,7 +91,12 @@ async function createFixture() {
   }
 
   const larkChannel = {
-    getOrCreateLarkClientById: jest.fn().mockResolvedValue(client)
+    getOrCreateLarkClientById: jest.fn().mockResolvedValue(client),
+    readIntegrationById: jest.fn().mockResolvedValue({
+      id: 'integration-1',
+      options: { appId: 'cli_test_app', isLark: false }
+    }),
+    createMessage: jest.fn().mockResolvedValue({ data: { message_id: 'permission-card-1' } })
   }
 
   return {
@@ -113,17 +123,17 @@ describe('LarkContextToolService', () => {
       params: {
         container_id_type: 'chat',
         container_id: 'oc_chat_1',
-        start_time: undefined,
-        end_time: undefined,
+        start_time: null,
+        end_time: null,
         sort_type: undefined,
         page_size: undefined,
-        page_token: undefined
+        page_token: null
       }
     })
     expect(result.pageToken).toBe('next-page')
     expect(result.hasMore).toBe(true)
     expect(result.items).toEqual([
-      {
+      expect.objectContaining({
         messageId: 'om_text_1',
         chatId: 'oc_chat_1',
         senderOpenId: 'ou_sender_1',
@@ -139,12 +149,11 @@ describe('LarkContextToolService', () => {
         createTime: '1710000000000',
         hasResource: false,
         resourceRefs: undefined
-      },
-      {
+      }),
+      expect.objectContaining({
         messageId: 'om_file_1',
         chatId: 'oc_chat_1',
         msgType: 'file',
-        text: 'report.pdf',
         hasResource: true,
         resourceRefs: [
           {
@@ -153,8 +162,187 @@ describe('LarkContextToolService', () => {
             name: 'report.pdf'
           }
         ]
-      }
+      })
     ])
+  })
+
+  it('preserves structured application permission failures for the runtime middleware', async () => {
+    const { service, messageList } = await createFixture()
+    messageList.mockRejectedValue({
+      code: 99991679,
+      msg: 'Access denied',
+      error: {
+        message: 'missing permission',
+        permission_violations: [
+          { type: 'action_privilege_required', subject: 'im:message.group_msg' }
+        ]
+      }
+    })
+
+    await expect(
+      service.listMessages({
+        integrationId: 'integration-1',
+        containerIdType: 'chat',
+        containerId: 'oc_chat_1'
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: 'LarkApplicationPermissionError',
+        code: 99991679,
+        scopes: ['im:message.group_msg']
+      })
+    )
+  })
+
+  it('preserves application permission failures returned as successful SDK responses', async () => {
+    const { service, messageList } = await createFixture()
+    messageList.mockResolvedValue({
+      code: 99991679,
+      msg: 'Access denied',
+      error: {
+        message: 'missing permission',
+        permission_violations: [
+          { type: 'action_privilege_required', subject: 'im:message.group_msg' }
+        ]
+      }
+    })
+
+    await expect(
+      service.listMessages({
+        integrationId: 'integration-1',
+        containerIdType: 'chat',
+        containerId: 'oc_chat_1'
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: 'LarkApplicationPermissionError',
+        code: 99991679,
+        scopes: ['im:message.group_msg']
+      })
+    )
+  })
+
+  it('extracts required scopes from a trusted application permission error message', async () => {
+    const { service, messageList } = await createFixture()
+    messageList.mockResolvedValue({
+      code: 99991679,
+      msg: 'Access denied. Required scope: im:message.group_msg',
+      error: {
+        message: 'The app does not have im:message.group_msg permission'
+      }
+    })
+
+    await expect(
+      service.listMessages({
+        integrationId: 'integration-1',
+        containerIdType: 'chat',
+        containerId: 'oc_chat_1'
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: 'LarkApplicationPermissionError',
+        code: 99991679,
+        scopes: ['im:message.group_msg']
+      })
+    )
+  })
+
+  it('handles the missing-scope code returned by the Lark message list API', async () => {
+    const { service, messageList } = await createFixture()
+    messageList.mockResolvedValue({
+      code: 230027,
+      msg: 'Lack of necessary permissions, ext=need scope: im:message.group_msg',
+      error: {
+        message: 'Lack of necessary permissions'
+      }
+    })
+
+    await expect(
+      service.listMessages({
+        integrationId: 'integration-1',
+        containerIdType: 'chat',
+        containerId: 'oc_chat_1'
+      })
+    ).rejects.toEqual(
+      expect.objectContaining({
+        name: 'LarkApplicationPermissionError',
+        code: 230027,
+        scopes: ['im:message.group_msg']
+      })
+    )
+  })
+
+  it('sends a deterministic administrator permission guide card to the trusted chat', async () => {
+    const { service, larkChannel } = await createFixture()
+
+    await expect(
+      service.sendApplicationPermissionGuideCard({
+        integrationId: 'integration-1',
+        chatId: 'oc_chat_1',
+        scopes: ['im:message.group_msg'],
+        toolCallId: 'tool-call-1'
+      })
+    ).resolves.toEqual({
+      messageId: 'permission-card-1',
+      consoleUrl:
+        'https://open.feishu.cn/app/cli_test_app/auth?q=im%3Amessage.group_msg&op_from=openapi&token_type=tenant'
+    })
+
+    expect(larkChannel.createMessage).toHaveBeenCalledWith(
+      'integration-1',
+      expect.objectContaining({
+        params: { receive_id_type: 'chat_id' },
+        data: expect.objectContaining({
+          receive_id: 'oc_chat_1',
+          msg_type: 'interactive',
+          uuid: expect.stringMatching(/^lark_permission_[a-f0-9]{32}$/)
+        })
+      })
+    )
+    const card = JSON.parse(larkChannel.createMessage.mock.calls[0][1].data.content)
+    expect(card.header.title.content).toBe('🔐 请管理员开启以下权限')
+    expect(card.elements[0].content).toContain('im:message.group_msg')
+    expect(card.elements[1].elements[0].content).toContain('cli_test_app')
+    expect(card.elements[2].actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: { tag: 'plain_text', content: '开启权限' },
+          multi_url: {
+            url: 'https://open.feishu.cn/app/cli_test_app/auth?q=im%3Amessage.group_msg&op_from=openapi&token_type=tenant'
+          }
+        }),
+        expect.objectContaining({
+          text: { tag: 'plain_text', content: '取消' },
+          value: { action: 'lark-dismiss-permission-guide' }
+        })
+      ])
+    )
+  })
+
+  it('rejects list responses containing messages outside the trusted current chat', async () => {
+    const { service, messageList } = await createFixture()
+    messageList.mockResolvedValue({
+      data: {
+        items: [
+          {
+            message_id: 'om_other_chat',
+            chat_id: 'oc_chat_other',
+            msg_type: 'text',
+            body: { content: JSON.stringify({ text: 'private' }) }
+          }
+        ]
+      }
+    })
+
+    await expect(
+      service.listMessages({
+        integrationId: 'integration-1',
+        containerIdType: 'chat',
+        containerId: 'oc_chat_current',
+        expectedChatId: 'oc_chat_current',
+        timeoutMs: 1000
+      })
+    ).rejects.toThrow('Lark returned a message outside the current chat')
   })
 
   it('normalizes getMessageResource into metadata plus optional base64 payload', async () => {
@@ -188,5 +376,58 @@ describe('LarkContextToolService', () => {
       contentEncoding: 'base64',
       contentBase64: 'YWJj'
     })
+  })
+
+  it('rejects messages returned outside the trusted current chat', async () => {
+    const { service, messageGet } = await createFixture()
+    messageGet.mockResolvedValue({
+      data: {
+        items: [
+          {
+            message_id: 'om_other_chat',
+            chat_id: 'oc_chat_other',
+            msg_type: 'text',
+            body: { content: JSON.stringify({ text: 'private' }) }
+          }
+        ]
+      }
+    })
+
+    await expect(
+      service.getMessage({
+        integrationId: 'integration-1',
+        messageId: 'om_other_chat',
+        expectedChatId: 'oc_chat_current',
+        timeoutMs: 1000
+      })
+    ).rejects.toThrow('Lark returned a message outside the current chat')
+  })
+
+  it('does not download resources until current-chat membership is verified', async () => {
+    const { service, messageGet, messageResourceGet } = await createFixture()
+    messageGet.mockResolvedValue({
+      data: {
+        items: [
+          {
+            message_id: 'om_other_chat',
+            chat_id: 'oc_chat_other',
+            msg_type: 'file',
+            body: { content: JSON.stringify({ file_key: 'file_1' }) }
+          }
+        ]
+      }
+    })
+
+    await expect(
+      service.getMessageResource({
+        integrationId: 'integration-1',
+        messageId: 'om_other_chat',
+        fileKey: 'file_1',
+        type: 'file',
+        expectedChatId: 'oc_chat_current',
+        timeoutMs: 1000
+      })
+    ).rejects.toThrow('Lark returned a message outside the current chat')
+    expect(messageResourceGet).not.toHaveBeenCalled()
   })
 })

--- a/xpertai/integrations/lark/src/lib/lark-context-tool.service.ts
+++ b/xpertai/integrations/lark/src/lib/lark-context-tool.service.ts
@@ -1,20 +1,35 @@
 import type * as lark from '@larksuiteoapi/node-sdk'
 import { Injectable, Logger } from '@nestjs/common'
 import { getErrorMessage } from '@xpert-ai/plugin-sdk'
+import { createHash } from 'node:crypto'
 import { Readable } from 'node:stream'
 import { normalizeLarkTextWithMentions, parseLarkMentionIdentity } from './lark-message-semantics.js'
 import { LarkChannelStrategy } from './lark-channel.strategy.js'
-import type {
-  LarkMessageResourceType,
-  NormalizedMessage,
-  NormalizedMessageMention,
-  NormalizedMessageResource,
-  NormalizedMessageResourceRef
+import {
+  LARK_DISMISS_PERMISSION_GUIDE,
+  parseLarkClientError,
+  type LarkMessageResourceType,
+  type NormalizedMessage,
+  type NormalizedMessageMention,
+  type NormalizedMessageResource,
+  type NormalizedMessageResourceRef
 } from './types.js'
 import { toLarkApiErrorMessage, toNonEmptyString } from './utils.js'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const RESOURCE_INLINE_CONTENT_MODE = 'base64'
+const LARK_MISSING_PERMISSION_CODES = new Set([99991679, 230027])
+
+export class LarkApplicationPermissionError extends Error {
+  constructor(
+    readonly code: number,
+    readonly scopes: string[],
+    message: string
+  ) {
+    super(message)
+    this.name = 'LarkApplicationPermissionError'
+  }
+}
 
 type LarkMessageItem = {
   message_id?: string
@@ -55,6 +70,7 @@ type ListMessagesInput = {
   integrationId: string
   containerIdType: string
   containerId: string
+  expectedChatId?: string | null
   startTime?: string | null
   endTime?: string | null
   sortType?: 'ByCreateTimeAsc' | 'ByCreateTimeDesc' | null
@@ -66,6 +82,7 @@ type ListMessagesInput = {
 type GetMessageInput = {
   integrationId: string
   messageId: string
+  expectedChatId?: string | null
   userIdType?: 'open_id' | 'user_id' | 'union_id' | null
   timeoutMs?: number
 }
@@ -73,6 +90,7 @@ type GetMessageInput = {
 type GetMessageResourceInput = {
   integrationId: string
   messageId: string
+  expectedChatId?: string | null
   fileKey: string
   type: LarkMessageResourceType | string
   contentMode?: 'metadata' | 'base64' | null
@@ -119,10 +137,12 @@ export class LarkContextToolService {
         `[lark_list_messages] load messages from ${containerIdType}:${containerId}`
       )
     } catch (error) {
-      throw new Error(`[lark_list_messages] Failed to list messages: ${this.formatError(error)}`)
+      throw this.toContextToolError(error, 'lark_list_messages', 'Failed to list messages')
     }
+    this.assertLarkApiSuccess(response, 'lark_list_messages', 'Failed to list messages')
 
     const items = this.normalizeMessages(response?.data?.items ?? [])
+    this.assertMessagesBelongToExpectedChat(items, input.expectedChatId, 'lark_list_messages')
     return {
       items,
       pageToken: toOptionalString(response?.data?.page_token) ?? null,
@@ -153,16 +173,20 @@ export class LarkContextToolService {
         `[lark_get_message] load message '${messageId}'`
       )
     } catch (error) {
-      throw new Error(`[lark_get_message] Failed to get message '${messageId}': ${this.formatError(error)}`)
+      throw this.toContextToolError(error, 'lark_get_message', `Failed to get message '${messageId}'`)
     }
+    this.assertLarkApiSuccess(response, 'lark_get_message', `Failed to get message '${messageId}'`)
 
     const item = (response?.data?.items ?? [])[0] as LarkMessageItem | undefined
     if (!item?.message_id) {
       throw new Error(`[lark_get_message] Message '${messageId}' was not found`)
     }
 
+    const normalizedItem = this.normalizeMessage(item)
+    this.assertMessagesBelongToExpectedChat([normalizedItem], input.expectedChatId, 'lark_get_message')
+
     return {
-      item: this.normalizeMessage(item)
+      item: normalizedItem
     }
   }
 
@@ -180,6 +204,7 @@ export class LarkContextToolService {
     const message = await this.getMessage({
       integrationId,
       messageId,
+      expectedChatId: input.expectedChatId,
       timeoutMs
     })
 
@@ -199,8 +224,10 @@ export class LarkContextToolService {
         `[lark_get_message_resource] load resource '${fileKey}' from message '${messageId}'`
       )) as LarkMessageResourceDownload
     } catch (error) {
-      throw new Error(
-        `[lark_get_message_resource] Failed to get resource '${fileKey}' from message '${messageId}': ${this.formatError(error)}`
+      throw this.toContextToolError(
+        error,
+        'lark_get_message_resource',
+        `Failed to get resource '${fileKey}' from message '${messageId}'`
       )
     }
 
@@ -251,6 +278,110 @@ export class LarkContextToolService {
       )
     } catch (error) {
       throw new Error(`[lark-context] Integration '${integrationId}' is unavailable: ${this.formatError(error)}`)
+    }
+  }
+
+  async sendApplicationPermissionGuideCard(input: {
+    integrationId: string
+    chatId: string
+    scopes: string[]
+    toolCallId?: string
+  }): Promise<{ messageId?: string; consoleUrl: string }> {
+    const integrationId = this.requireString(input.integrationId, 'integrationId')
+    const chatId = this.requireString(input.chatId, 'chatId')
+    const scopes = Array.from(new Set(input.scopes.map((scope) => scope.trim()).filter(Boolean))).sort()
+    if (!scopes.length) {
+      throw new Error('At least one Lark application permission scope is required')
+    }
+    const integration = await this.larkChannel.readIntegrationById(integrationId)
+    if (!integration) {
+      throw new Error(`Integration ${integrationId} not found`)
+    }
+    const appId = toOptionalString(integration.options?.appId)
+    const consoleBaseUrl = integration.options?.isLark
+      ? 'https://open.larksuite.com/app'
+      : 'https://open.feishu.cn/app'
+    const consoleUrl = appId
+      ? `${consoleBaseUrl}/${encodeURIComponent(appId)}/auth?q=${encodeURIComponent(scopes.join(' '))}&op_from=openapi&token_type=tenant`
+      : consoleBaseUrl
+    const permissionLines = scopes
+      .map((scope) => `- ${describeApplicationScope(scope)}\n  \`${escapeMarkdownCode(scope)}\``)
+      .join('\n')
+    const note = [
+      appId ? `App ID: ${appId}` : null,
+      '请在开发者后台的“权限管理”中开通权限并发布应用，然后重新发起请求。'
+    ]
+      .filter(Boolean)
+      .join(' · ')
+    const uuid = createHash('sha256')
+      .update([integrationId, chatId, input.toolCallId ?? '', ...scopes].join('\u001f'))
+      .digest('hex')
+      .slice(0, 32)
+    const card = {
+      header: {
+        template: 'orange',
+        title: { tag: 'plain_text', content: '🔐 请管理员开启以下权限' }
+      },
+      elements: [
+        { tag: 'markdown', content: permissionLines },
+        {
+          tag: 'note',
+          elements: [{ tag: 'plain_text', content: note }]
+        },
+        {
+          tag: 'action',
+          layout: 'default',
+          actions: [
+            {
+              tag: 'button',
+              text: { tag: 'plain_text', content: '开启权限' },
+              type: 'primary',
+              multi_url: { url: consoleUrl }
+            },
+            {
+              tag: 'button',
+              text: { tag: 'plain_text', content: '取消' },
+              type: 'default',
+              complex_interaction: true,
+              value: { action: LARK_DISMISS_PERMISSION_GUIDE },
+              behaviors: [
+                {
+                  type: 'callback',
+                  value: { action: LARK_DISMISS_PERMISSION_GUIDE }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+    const result = await this.larkChannel.createMessage(integrationId, {
+      params: { receive_id_type: 'chat_id' },
+      data: {
+        receive_id: chatId,
+        msg_type: 'interactive',
+        content: JSON.stringify(card),
+        uuid: `lark_permission_${uuid}`
+      }
+    })
+    return {
+      messageId: toOptionalString(result?.data?.message_id) ?? undefined,
+      consoleUrl
+    }
+  }
+
+  private assertMessagesBelongToExpectedChat(
+    items: NormalizedMessage[],
+    expectedChatId: string | null | undefined,
+    toolName: string
+  ) {
+    const normalizedExpectedChatId = toOptionalString(expectedChatId)
+    if (!normalizedExpectedChatId) {
+      return
+    }
+
+    if (items.some((item) => item.chatId !== normalizedExpectedChatId)) {
+      throw new Error(`[${toolName}] Lark returned a message outside the current chat.`)
     }
   }
 
@@ -433,6 +564,58 @@ export class LarkContextToolService {
   private formatError(error: unknown): string {
     return toLarkApiErrorMessage(error) || getErrorMessage(error) || 'Unknown error'
   }
+
+  private toContextToolError(error: unknown, toolName: string, operation: string): Error {
+    const parsed = parseLarkClientError(error)
+    const scopes = extractApplicationPermissionScopes(parsed)
+    if (LARK_MISSING_PERMISSION_CODES.has(parsed.code) && scopes.length) {
+      return new LarkApplicationPermissionError(
+        parsed.code,
+        scopes,
+        `[${toolName}] ${operation}: ${this.formatError(error)}`
+      )
+    }
+    return new Error(`[${toolName}] ${operation}: ${this.formatError(error)}`)
+  }
+
+  private assertLarkApiSuccess(response: unknown, toolName: string, operation: string): void {
+    const parsed = parseLarkClientError(response)
+    if (parsed.code !== -1 && parsed.code !== 0) {
+      throw this.toContextToolError(response, toolName, operation)
+    }
+  }
+}
+
+function extractApplicationPermissionScopes(parsed: ReturnType<typeof parseLarkClientError>): string[] {
+  const structuredScopes = (parsed.error.permission_violations ?? [])
+    .filter((violation) => violation.type === 'action_privilege_required')
+    .map((violation) => violation.subject.trim())
+    .filter(Boolean)
+
+  if (structuredScopes.length) {
+    return Array.from(new Set(structuredScopes))
+  }
+
+  if (!LARK_MISSING_PERMISSION_CODES.has(parsed.code)) {
+    return []
+  }
+
+  const message = `${parsed.msg}\n${parsed.error.message}`
+  const textScopes = message.match(/\b[a-z][a-z0-9_]*(?::[a-z0-9_.-]+)+\b/gi) ?? []
+  return Array.from(new Set(textScopes.map((scope) => scope.trim()).filter((scope) => scope.length <= 128)))
+}
+
+function describeApplicationScope(scope: string): string {
+  const labels: Record<string, string> = {
+    'im:message.group_msg': '获取群组消息（应用身份）',
+    'im:message.p2p_msg': '获取单聊消息（应用身份）',
+    'im:message': '获取与发送单聊、群组消息（应用身份）'
+  }
+  return labels[scope] ?? '飞书应用权限'
+}
+
+function escapeMarkdownCode(value: string): string {
+  return value.replace(/`/g, '')
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {

--- a/xpertai/integrations/lark/src/lib/lark-group-mention-window.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-group-mention-window.service.spec.ts
@@ -1,6 +1,12 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+	const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+	return createLarkPluginSdkMock(jest)
+})
+
 import { buildLarkGroupWindowPrompt } from './lark-agent-prompt.js'
 import { LarkChannelStrategy } from './lark-channel.strategy.js'
 import { LarkGroupMentionWindowService } from './lark-group-mention-window.service.js'
+import { buildLarkInboundJobId } from './lark-job-id.js'
 import { LARK_TYPING_REACTION_EMOJI_TYPE } from './types.js'
 
 class MemoryCache {
@@ -103,14 +109,32 @@ describe('LarkGroupMentionWindowService', () => {
 		} as any
 	}
 
+	it('uses a deterministic colon-free job id for the inbound group window', async () => {
+		const { service, flushQueue } = createService()
+
+		await service.ingest(createContext())
+
+		const firstJobId = flushQueue.add.mock.calls[0][1].jobId
+		expect(firstJobId).not.toContain(':')
+		expect(firstJobId).toMatch(/^lark_group_window_flush_[a-f0-9]{32}$/)
+		expect((service as any).toFlushJobId('lark:mention-window:integration-1:chat-1')).toBe(firstJobId)
+	})
+
 	it('merges multiple group mentions into one flushed context', async () => {
 		const { service, scopeQueue, larkChannel } = createService({
 			maxMessages: 2
 		})
 
-		await service.ingest(createContext())
 		await service.ingest(
 			createContext({
+				currentInboundLogIds: ['log-1'],
+				historyBefore: '2026-07-15T08:00:00.000Z'
+			})
+		)
+		await service.ingest(
+			createContext({
+				currentInboundLogIds: ['log-2'],
+				historyBefore: '2026-07-15T08:00:02.000Z',
 				userId: 'user-2',
 				senderOpenId: 'ou-2',
 				senderName: 'Bob',
@@ -126,7 +150,19 @@ describe('LarkGroupMentionWindowService', () => {
 
 		expect(scopeQueue.add).toHaveBeenCalledTimes(1)
 		const flushed = (scopeQueue.add as jest.Mock).mock.calls[0][0]
+		const queueOptions = (scopeQueue.add as jest.Mock).mock.calls[0][1]
+		expect(queueOptions).toEqual({
+			jobId: buildLarkInboundJobId('log-1'),
+			removeOnComplete: true
+		})
+		expect(queueOptions.jobId).not.toContain(':')
 		expect(flushed.groupWindow.items).toHaveLength(2)
+		expect(flushed.currentInboundLogIds).toEqual(['log-1', 'log-2'])
+		expect(flushed.historyBefore).toBe('2026-07-15T08:00:00.000Z')
+		expect(flushed.groupWindow.items.map((item: any) => item.messageLogId)).toEqual([
+			'log-1',
+			'log-2'
+		])
 		expect(flushed.replyToMessageId).toBe('m-1')
 		expect(flushed.typingReaction).toEqual({
 			messageId: 'm-1',
@@ -177,7 +213,11 @@ describe('LarkGroupMentionWindowService', () => {
 		} as any)
 		;(first as any).flushQueue = createFlushQueueMock()
 
-		await first.ingest(createContext())
+		await first.ingest(
+			createContext({
+				currentInboundLogIds: ['log-1']
+			})
+		)
 
 		const scopeQueue = {
 			add: jest.fn().mockResolvedValue(undefined)
@@ -213,6 +253,10 @@ describe('LarkGroupMentionWindowService', () => {
 
 		expect(scopeQueue.add).toHaveBeenCalledTimes(1)
 		const flushed = (scopeQueue.add as jest.Mock).mock.calls[0][0]
+		expect((scopeQueue.add as jest.Mock).mock.calls[0][1]).toEqual({
+			jobId: buildLarkInboundJobId('log-1'),
+			removeOnComplete: true
+		})
 		expect(flushed.groupWindow.items).toHaveLength(1)
 		expect(flushed.input).toBe('Alice: hello')
 	})

--- a/xpertai/integrations/lark/src/lib/lark-group-mention-window.service.ts
+++ b/xpertai/integrations/lark/src/lib/lark-group-mention-window.service.ts
@@ -15,6 +15,8 @@ import {
 } from './types.js'
 import { buildLarkGroupWindowPrompt } from './lark-agent-prompt.js'
 import { LarkChannelStrategy } from './lark-channel.strategy.js'
+import { extractLarkMessageResourceRefs } from './lark-message-semantics.js'
+import { buildLarkGroupWindowFlushJobId, buildLarkInboundJobId } from './lark-job-id.js'
 import {
 	DEFAULT_GROUP_MENTION_DEBOUNCE_MS,
 	DEFAULT_GROUP_MENTION_MAX_MESSAGES,
@@ -169,13 +171,19 @@ export class LarkGroupMentionWindowService implements OnModuleDestroy {
 	private toWindowItem(context: ChatLarkContext<TLarkEvent>): LarkGroupWindowItem | null {
 		const messageId = this.resolveMessageId(context)
 		const senderOpenId = typeof context.senderOpenId === 'string' ? context.senderOpenId.trim() : ''
-		const text = typeof context.input === 'string' ? context.input.trim() : ''
+		const inputText = typeof context.input === 'string' ? context.input.trim() : ''
+		const text =
+			inputText || extractLarkMessageResourceRefs(context.message).length > 0
+				? inputText || '[附件消息]'
+				: ''
 		if (!messageId || !senderOpenId || !text) {
 			return null
 		}
 
 		return {
 			messageId,
+			messageLogId: context.currentInboundLogIds?.[0],
+			messageLogCreatedAt: context.historyBefore,
 			senderOpenId,
 			userId: context.mappedUserId,
 			senderName: context.senderName,
@@ -283,6 +291,17 @@ export class LarkGroupMentionWindowService implements OnModuleDestroy {
 	private buildFlushContext(state: LarkGroupMentionWindowState): ChatLarkContext<TLarkEvent> {
 		const groupWindow = this.toGroupWindow(state)
 		const firstItem = state.items[0]
+		const currentInboundLogIds = Array.from(
+			new Set(
+				[
+					...(state.baseContext.currentInboundLogIds ?? []),
+					...state.items.map((item) => item.messageLogId)
+				].filter((id): id is string => Boolean(id))
+			)
+		)
+		const historyBefore =
+			state.items.map((item) => item.messageLogCreatedAt).find((value) => Boolean(value)) ??
+			state.baseContext.historyBefore
 		return {
 			...state.baseContext,
 			userId: state.baseContext.userId,
@@ -294,7 +313,9 @@ export class LarkGroupMentionWindowService implements OnModuleDestroy {
 			groupWindowId: groupWindow.windowId,
 			scopeKey: groupWindow.scopeKey,
 			replyToMessageId: firstItem?.messageId ?? state.baseContext.replyToMessageId,
-			typingReaction: state.typingReaction
+			typingReaction: state.typingReaction,
+			...(currentInboundLogIds.length ? { currentInboundLogIds } : {}),
+			...(historyBefore ? { historyBefore } : {})
 		}
 	}
 
@@ -384,10 +405,17 @@ export class LarkGroupMentionWindowService implements OnModuleDestroy {
 			throw new Error('Lark conversation queue service is unavailable')
 		}
 		const scopeQueue = await conversationQueueService.getScopeQueue(scopeKey)
-		await scopeQueue.add({
-			...flushContext,
-			tenantId: flushContext.tenantId ?? flushContext.tenant?.id
-		})
+		const inboundIdentity = flushContext.currentInboundLogIds?.[0] ?? flushContext.groupWindowId ?? scopeKey
+		await scopeQueue.add(
+			{
+				...flushContext,
+				tenantId: flushContext.tenantId ?? flushContext.tenant?.id
+			},
+			{
+				jobId: buildLarkInboundJobId(inboundIdentity),
+				removeOnComplete: true
+			}
+		)
 	}
 
 	private async createTypingReaction(
@@ -453,7 +481,7 @@ export class LarkGroupMentionWindowService implements OnModuleDestroy {
 	}
 
 	private toFlushJobId(key: string): string {
-		return `flush:${key}`
+		return buildLarkGroupWindowFlushJobId(key)
 	}
 
 	private getBullRedisConfig(): Bull.QueueOptions['redis'] {

--- a/xpertai/integrations/lark/src/lib/lark-job-id.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-job-id.spec.ts
@@ -1,0 +1,26 @@
+import {
+  buildLarkCardActionJobId,
+  buildLarkGroupWindowFlushJobId,
+  buildLarkHistoryCleanupJobId,
+  buildLarkHistoryMaterializeJobId,
+  buildLarkInboundJobId
+} from './lark-job-id.js'
+
+describe('Lark queue job ids', () => {
+  it('builds deterministic colon-free ids for every Lark queue path', () => {
+    const buildAll = () => [
+      buildLarkHistoryCleanupJobId('integration:1', '2026-07-16', 4),
+      buildLarkHistoryMaterializeJobId('integration:1', ['log:1', 'log:2']),
+      buildLarkInboundJobId('log:1'),
+      buildLarkCardActionJobId('scope:1', 'xpert:1', 'approve:now', 'message:1'),
+      buildLarkGroupWindowFlushJobId('lark:mention-window:integration:1:chat:1')
+    ]
+
+    const first = buildAll()
+    expect(buildAll()).toEqual(first)
+    for (const jobId of first) {
+      expect(jobId).toMatch(/^[A-Za-z0-9_-]+$/)
+      expect(jobId).not.toContain(':')
+    }
+  })
+})

--- a/xpertai/integrations/lark/src/lib/lark-job-id.ts
+++ b/xpertai/integrations/lark/src/lib/lark-job-id.ts
@@ -1,0 +1,45 @@
+import { createHash } from 'node:crypto'
+
+const JOB_ID_DIGEST_LENGTH = 32
+
+function deterministicJobId(prefix: string, parts: readonly string[]): string {
+  const digest = createHash('sha256').update(parts.join('\u001f')).digest('hex').slice(0, JOB_ID_DIGEST_LENGTH)
+  return `${prefix}_${digest}`
+}
+
+export function buildLarkInboundJobId(messageLogId: string): string {
+  return deterministicJobId('lark_inbound', [messageLogId])
+}
+
+export function buildLarkCardActionJobId(
+  scopeKey: string,
+  xpertId: string,
+  action: string,
+  actionMessageId?: string
+): string {
+  return deterministicJobId('lark_card_action', [scopeKey, xpertId, actionMessageId ?? '', action])
+}
+
+export function buildLarkGroupWindowFlushJobId(windowKey: string): string {
+  return deterministicJobId('lark_group_window_flush', [windowKey])
+}
+
+export function buildLarkHistoryMaterializeJobId(
+  integrationId: string,
+  messageLogIds: readonly string[],
+  continuation = 0
+): string {
+  return deterministicJobId('plugin_lark_history_materialize', [
+    integrationId,
+    ...messageLogIds,
+    String(continuation)
+  ])
+}
+
+export function buildLarkHistoryCleanupJobId(
+  integrationId: string,
+  dayBucket: string,
+  continuation = 0
+): string {
+  return deterministicJobId('plugin_lark_history_cleanup', [integrationId, dayBucket, String(continuation)])
+}

--- a/xpertai/integrations/lark/src/lib/lark-message-history-queue.processor.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history-queue.processor.spec.ts
@@ -1,0 +1,237 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+  return createLarkPluginSdkMock(jest, {
+    PluginJobProcessor: () => (target: unknown) => target
+  })
+})
+
+import { LarkMessageHistoryQueueProcessor } from './lark-message-history-queue.processor.js'
+
+describe('LarkMessageHistoryQueueProcessor', () => {
+  function createFixture(params?: {
+    binding?: Record<string, unknown> | null
+    materializeResult?: Record<string, unknown>
+    cleanupResult?: Record<string, unknown>
+  }) {
+    const historyService = {
+      materializeFiles: jest.fn().mockResolvedValue(
+        params?.materializeResult ?? {
+          files: [],
+          failed: []
+        }
+      ),
+      cleanupExpired: jest.fn().mockResolvedValue(
+        params?.cleanupResult ?? {
+          deletedLogs: 0,
+          hasMore: false
+        }
+      )
+    }
+    const queueService = {
+      enqueueMaterialize: jest.fn().mockResolvedValue(undefined),
+      scheduleCleanup: jest.fn().mockResolvedValue(undefined)
+    }
+    const triggerBindingRepository = {
+      findOne: jest.fn().mockResolvedValue(
+        params?.binding === undefined
+          ? {
+              integrationId: 'integration-1',
+              tenantId: 'tenant-current',
+              organizationId: 'org-current',
+              config: { enabled: true, historyRetentionDays: 30 }
+            }
+          : params.binding
+      )
+    }
+    const processor = new LarkMessageHistoryQueueProcessor(
+      historyService as never,
+      queueService as never,
+      triggerBindingRepository as never
+    )
+    return { processor, historyService, queueService, triggerBindingRepository }
+  }
+
+  it('throws when attachment materialization has retryable failures', async () => {
+    const { processor } = createFixture({
+      materializeResult: {
+        files: [],
+        failed: [
+          {
+            fileId: 'file-1',
+            messageLogId: 'log-1',
+            resourceKey: 'resource-1',
+            error: 'storage unavailable',
+            retryable: true
+          }
+        ]
+      }
+    })
+
+    await expect(
+      processor.handle({
+        id: 'job-1',
+        name: 'materialize-files',
+        data: {
+          kind: 'materialize-files',
+          integrationId: 'integration-1',
+          xpertId: 'xpert-1',
+          messageLogIds: ['log-1'],
+          maxSizeMb: 10
+        }
+      } as never)
+    ).rejects.toThrow('resource-1')
+  })
+
+  it('does not retry permanent attachment failures', async () => {
+    const { processor } = createFixture({
+      materializeResult: {
+        files: [],
+        failed: [
+          {
+            fileId: 'file-1',
+            messageLogId: 'log-1',
+            resourceKey: 'resource-1',
+            error: 'file_size_exceeded:1:1',
+            retryable: false
+          }
+        ]
+      }
+    })
+
+    await expect(
+      processor.handle({
+        id: 'job-1',
+        name: 'materialize-files',
+        data: {
+          kind: 'materialize-files',
+          integrationId: 'integration-1',
+          xpertId: 'xpert-1',
+          messageLogIds: ['log-1'],
+          maxSizeMb: 10
+        }
+      } as never)
+    ).resolves.toBeUndefined()
+  })
+
+  it('schedules a delayed continuation when another worker still owns a fresh processing lease', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-16T00:00:00.000Z'))
+    const nextLeaseAt = new Date(Date.now() + 30_000)
+    const { processor, queueService } = createFixture({
+      materializeResult: { files: [], failed: [], nextLeaseAt }
+    })
+
+    await processor.handle({
+      id: 'job-1',
+      name: 'materialize-files',
+      data: {
+        kind: 'materialize-files',
+        integrationId: 'integration-1',
+        xpertId: 'xpert-1',
+        messageLogIds: ['log-1'],
+        maxSizeMb: 10,
+        continuation: 2
+      }
+    } as never)
+
+    expect(queueService.enqueueMaterialize).toHaveBeenCalledWith(
+      expect.objectContaining({ continuation: 3, messageLogIds: ['log-1'] }),
+      30_000
+    )
+    jest.useRealTimers()
+  })
+
+  it('stops a stale cleanup chain when current retention is permanent', async () => {
+    const { processor, historyService, queueService } = createFixture({
+      binding: {
+        integrationId: 'integration-1',
+        config: { enabled: true, historyRetentionDays: 0 }
+      }
+    })
+
+    await processor.handle({
+      id: 'cleanup-1',
+      name: 'cleanup-expired',
+      data: {
+        kind: 'cleanup-expired',
+        integrationId: 'integration-1',
+        retentionDays: 30
+      }
+    } as never)
+
+    expect(historyService.cleanupExpired).not.toHaveBeenCalled()
+    expect(queueService.scheduleCleanup).not.toHaveBeenCalled()
+  })
+
+  it('uses current retention and drains a large backlog in bounded continuation jobs', async () => {
+    const { processor, historyService, queueService } = createFixture({
+      binding: {
+        integrationId: 'integration-1',
+        tenantId: 'tenant-current',
+        organizationId: 'org-current',
+        config: { enabled: true, historyRetentionDays: 90 }
+      },
+      cleanupResult: {
+        deletedLogs: 500,
+        hasMore: true,
+        nextCursor: { createdAt: new Date('2026-01-01T00:00:00.000Z'), id: 'log-500' }
+      }
+    })
+
+    await processor.handle({
+      id: 'cleanup-1',
+      name: 'cleanup-expired',
+      data: {
+        kind: 'cleanup-expired',
+        integrationId: 'integration-1',
+        tenantId: 'tenant-stale',
+        organizationId: 'org-stale',
+        retentionDays: 30,
+        continuation: 2
+      }
+    } as never)
+
+    expect(historyService.cleanupExpired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        retentionDays: 90,
+        tenantId: 'tenant-current',
+        organizationId: 'org-current'
+      })
+    )
+    expect(queueService.scheduleCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({ retentionDays: 90, continuation: 3 }),
+      1000
+    )
+  })
+
+  it('continues past a poison cleanup batch even when no message was deleted', async () => {
+    const nextCreatedAt = new Date('2026-01-01T00:00:00.000Z')
+    const { processor, queueService } = createFixture({
+      cleanupResult: {
+        deletedLogs: 0,
+        failedFiles: 500,
+        hasMore: true,
+        nextCursor: { createdAt: nextCreatedAt, id: 'log-500' }
+      }
+    })
+
+    await processor.handle({
+      id: 'cleanup-1',
+      name: 'cleanup-expired',
+      data: {
+        kind: 'cleanup-expired',
+        integrationId: 'integration-1',
+        retentionDays: 30,
+        continuation: 4
+      }
+    } as never)
+
+    expect(queueService.scheduleCleanup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        continuation: 5,
+        afterCreatedAt: nextCreatedAt.toISOString(),
+        afterId: 'log-500'
+      }),
+      1000
+    )
+  })
+})

--- a/xpertai/integrations/lark/src/lib/lark-message-history-queue.processor.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history-queue.processor.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import { PluginJobProcessor, type ManagedQueueJob, type ManagedQueueJobProcessor } from '@xpert-ai/plugin-sdk'
+import type { Repository } from 'typeorm'
+import { LARK_PLUGIN_NAME } from './constants.js'
+import { LarkTriggerBindingEntity } from './entities/lark-trigger-binding.entity.js'
+import { LarkMessageHistoryService } from './lark-message-history.service.js'
+import {
+  LARK_HISTORY_CLEANUP_JOB,
+  LARK_HISTORY_MATERIALIZE_JOB,
+  LARK_HISTORY_QUEUE_NAME,
+  LarkMessageHistoryJobData,
+  LarkMessageHistoryQueueService
+} from './lark-message-history-queue.service.js'
+
+@Injectable()
+@PluginJobProcessor({
+  pluginName: LARK_PLUGIN_NAME,
+  queueName: LARK_HISTORY_QUEUE_NAME,
+  jobName: LARK_HISTORY_MATERIALIZE_JOB,
+  concurrency: 2
+})
+@PluginJobProcessor({
+  pluginName: LARK_PLUGIN_NAME,
+  queueName: LARK_HISTORY_QUEUE_NAME,
+  jobName: LARK_HISTORY_CLEANUP_JOB,
+  concurrency: 1
+})
+export class LarkMessageHistoryQueueProcessor implements ManagedQueueJobProcessor<LarkMessageHistoryJobData> {
+  private readonly logger = new Logger(LarkMessageHistoryQueueProcessor.name)
+
+  constructor(
+    private readonly historyService: LarkMessageHistoryService,
+    private readonly queueService: LarkMessageHistoryQueueService,
+    @InjectRepository(LarkTriggerBindingEntity)
+    private readonly triggerBindingRepository: Repository<LarkTriggerBindingEntity>
+  ) {}
+
+  async handle(job: ManagedQueueJob<LarkMessageHistoryJobData>): Promise<void> {
+    switch (job.name) {
+      case LARK_HISTORY_MATERIALIZE_JOB: {
+        const payload = job.data
+        if (payload.kind !== 'materialize-files') {
+          throw new Error('Invalid Lark history materialize payload')
+        }
+        const result = await this.historyService.materializeFiles(payload)
+        const retryableFailures = result.failed.filter((failure) => failure.retryable)
+        if (retryableFailures.length) {
+          throw new Error(
+            `Lark attachment materialization failed for ${retryableFailures.length} file(s): ${retryableFailures
+              .map((failure) => failure.resourceKey)
+              .join(', ')}`
+          )
+        }
+        if (result.nextLeaseAt) {
+          await this.queueService.enqueueMaterialize(
+            {
+              ...payload,
+              continuation: (payload.continuation ?? 0) + 1
+            },
+            Math.max(1000, result.nextLeaseAt.getTime() - Date.now())
+          )
+        }
+        return
+      }
+      case LARK_HISTORY_CLEANUP_JOB: {
+        const payload = job.data
+        if (payload.kind !== 'cleanup-expired') {
+          throw new Error('Invalid Lark history cleanup payload')
+        }
+        const current = await this.resolveCurrentCleanupConfig(payload.integrationId)
+        if (!current || current.retentionDays === 0) {
+          return
+        }
+        const cleanupPayload = {
+          ...payload,
+          tenantId: current.tenantId ?? payload.tenantId,
+          organizationId: current.organizationId ?? payload.organizationId,
+          retentionDays: current.retentionDays
+        }
+        const result = await this.historyService.cleanupExpired(cleanupPayload)
+        const shouldContinue = result.hasMore && Boolean(result.nextCursor)
+        await this.queueService.scheduleCleanup(
+          {
+            ...cleanupPayload,
+            continuation: shouldContinue ? (payload.continuation ?? 0) + 1 : 0,
+            ...(shouldContinue && result.nextCursor
+              ? {
+                  afterCreatedAt: result.nextCursor.createdAt.toISOString(),
+                  afterId: result.nextCursor.id
+                }
+              : { afterCreatedAt: undefined, afterId: undefined })
+          },
+          shouldContinue ? 1000 : undefined
+        )
+        return
+      }
+      default:
+        this.logger.warn(`Unknown Lark history job "${job.name}" (${job.id})`)
+    }
+  }
+
+  private async resolveCurrentCleanupConfig(integrationId: string): Promise<{
+    retentionDays: number
+    tenantId?: string
+    organizationId?: string
+  } | null> {
+    const binding = await this.triggerBindingRepository.findOne({ where: { integrationId } })
+    if (!binding?.config?.enabled || binding.config.historyRetentionDays === undefined) {
+      return null
+    }
+    const numeric = Number(binding.config.historyRetentionDays)
+    const retentionDays = Number.isFinite(numeric) && numeric >= 0 ? Math.floor(numeric) : 30
+    return {
+      retentionDays,
+      tenantId: binding.tenantId,
+      organizationId: binding.organizationId
+    }
+  }
+}

--- a/xpertai/integrations/lark/src/lib/lark-message-history-queue.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history-queue.service.spec.ts
@@ -1,0 +1,124 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  __esModule: true,
+  MANAGED_QUEUE_SERVICE_TOKEN: 'MANAGED_QUEUE_SERVICE_TOKEN'
+}))
+
+import { LarkMessageHistoryQueueService } from './lark-message-history-queue.service.js'
+import {
+  buildLarkHistoryCleanupJobId,
+  buildLarkHistoryMaterializeJobId
+} from './lark-job-id.js'
+
+describe('LarkMessageHistoryQueueService', () => {
+  it('queues attachment materialization using message log ids only', async () => {
+    const managedQueue = { enqueue: jest.fn().mockResolvedValue(undefined) }
+    const pluginContext = {
+      scopeKey: 'plugin-scope-1',
+      resolve: jest.fn().mockReturnValue(managedQueue)
+    }
+    const service = new LarkMessageHistoryQueueService(pluginContext as any)
+
+    await service.enqueueMaterialize({
+      integrationId: 'integration-1',
+      xpertId: 'xpert-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      messageLogIds: ['log-1', 'log-1', ' log-2 '],
+      maxSizeMb: 10
+    })
+
+    expect(managedQueue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queueName: 'lark-message-history',
+        jobName: 'materialize-files',
+        scopeKey: 'plugin-scope-1',
+        attempts: 5,
+        payload: {
+          kind: 'materialize-files',
+          integrationId: 'integration-1',
+          xpertId: 'xpert-1',
+          tenantId: 'tenant-1',
+          organizationId: 'org-1',
+          messageLogIds: ['log-1', 'log-2'],
+          maxSizeMb: 10
+        },
+        jobId: buildLarkHistoryMaterializeJobId('integration-1', ['log-1', 'log-2'])
+      })
+    )
+    expect(managedQueue.enqueue.mock.calls[0][0].jobId).not.toContain(':')
+  })
+
+  it('uses a new safe deterministic id for delayed materialization continuations', async () => {
+    const managedQueue = { enqueue: jest.fn().mockResolvedValue(undefined) }
+    const service = new LarkMessageHistoryQueueService({
+      resolve: jest.fn().mockReturnValue(managedQueue)
+    } as any)
+
+    await service.enqueueMaterialize(
+      {
+        integrationId: 'integration:1',
+        xpertId: 'xpert-1',
+        messageLogIds: ['log:1'],
+        maxSizeMb: 10,
+        continuation: 3
+      },
+      30_000
+    )
+
+    expect(managedQueue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: buildLarkHistoryMaterializeJobId('integration:1', ['log:1'], 3),
+        delayMs: 30_000
+      })
+    )
+    expect(managedQueue.enqueue.mock.calls[0][0].jobId).not.toContain(':')
+  })
+
+  it('does not schedule cleanup when retention is permanent', async () => {
+    const managedQueue = { enqueue: jest.fn() }
+    const service = new LarkMessageHistoryQueueService({
+      resolve: jest.fn().mockReturnValue(managedQueue)
+    } as any)
+
+    await service.scheduleCleanup({ integrationId: 'integration-1', retentionDays: 0 })
+
+    expect(managedQueue.enqueue).not.toHaveBeenCalled()
+  })
+
+  it('uses a retention-independent cleanup job id and unique continuation id', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-16T00:00:00.000Z'))
+    const managedQueue = { enqueue: jest.fn().mockResolvedValue(undefined) }
+    const service = new LarkMessageHistoryQueueService({
+      scopeKey: 'plugin-scope-1',
+      resolve: jest.fn().mockReturnValue(managedQueue)
+    } as any)
+
+    await service.scheduleCleanup(
+      {
+        integrationId: 'integration-1',
+        retentionDays: 90,
+        continuation: 4
+      },
+      1000
+    )
+    await service.scheduleCleanup(
+      {
+        integrationId: 'integration-1',
+        retentionDays: 30,
+        continuation: 4
+      },
+      1000
+    )
+
+    expect(managedQueue.enqueue).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        jobId: buildLarkHistoryCleanupJobId('integration-1', '2026-07-16', 4),
+        delayMs: 1000
+      })
+    )
+    expect(managedQueue.enqueue.mock.calls[0][0].jobId).toBe(managedQueue.enqueue.mock.calls[1][0].jobId)
+    expect(managedQueue.enqueue.mock.calls[0][0].jobId).not.toContain(':')
+    jest.useRealTimers()
+  })
+})

--- a/xpertai/integrations/lark/src/lib/lark-message-history-queue.service.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history-queue.service.ts
@@ -1,0 +1,137 @@
+import { Inject, Injectable } from '@nestjs/common'
+import { MANAGED_QUEUE_SERVICE_TOKEN, type ManagedQueueService, type PluginContext } from '@xpert-ai/plugin-sdk'
+import { LARK_PLUGIN_NAME } from './constants.js'
+import { buildLarkHistoryCleanupJobId, buildLarkHistoryMaterializeJobId } from './lark-job-id.js'
+import { LARK_PLUGIN_CONTEXT } from './tokens.js'
+
+export const LARK_HISTORY_QUEUE_NAME = 'lark-message-history'
+export const LARK_HISTORY_MATERIALIZE_JOB = 'materialize-files'
+export const LARK_HISTORY_CLEANUP_JOB = 'cleanup-expired'
+
+export type LarkHistoryMaterializeJobData = {
+  kind: 'materialize-files'
+  integrationId: string
+  xpertId: string
+  tenantId?: string
+  organizationId?: string
+  messageLogIds: string[]
+  maxSizeMb: number
+  continuation?: number
+}
+
+export type LarkHistoryCleanupJobData = {
+  kind: 'cleanup-expired'
+  integrationId: string
+  tenantId?: string
+  organizationId?: string
+  retentionDays: number
+  /** Deterministic continuation number used to drain large expired backlogs in bounded batches. */
+  continuation?: number
+  /** Keyset cursor lets one cleanup run advance past rows whose workspace files could not be deleted. */
+  afterCreatedAt?: string
+  afterId?: string
+}
+
+export type LarkMessageHistoryJobData = LarkHistoryMaterializeJobData | LarkHistoryCleanupJobData
+
+@Injectable()
+export class LarkMessageHistoryQueueService {
+  private _managedQueue?: ManagedQueueService
+
+  constructor(
+    @Inject(LARK_PLUGIN_CONTEXT)
+    private readonly pluginContext: PluginContext
+  ) {}
+
+  private get managedQueue(): ManagedQueueService {
+    if (!this._managedQueue) {
+      this._managedQueue = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN)
+    }
+    return this._managedQueue
+  }
+
+  async enqueueMaterialize(
+    payload: Omit<LarkHistoryMaterializeJobData, 'kind'>,
+    delayMs = 0
+  ): Promise<void> {
+    const messageLogIds = this.normalizeIds(payload.messageLogIds)
+    if (!messageLogIds.length) {
+      return
+    }
+    await this.managedQueue.enqueue<LarkHistoryMaterializeJobData>({
+      pluginName: LARK_PLUGIN_NAME,
+      queueName: LARK_HISTORY_QUEUE_NAME,
+      jobName: LARK_HISTORY_MATERIALIZE_JOB,
+      payload: {
+        ...payload,
+        kind: 'materialize-files',
+        messageLogIds
+      },
+      tenantId: payload.tenantId,
+      organizationId: payload.organizationId,
+      scopeKey: this.scopeKey,
+      jobId: buildLarkHistoryMaterializeJobId(
+        payload.integrationId,
+        messageLogIds,
+        normalizeContinuation(payload.continuation)
+      ),
+      ...(delayMs > 0 ? { delayMs } : {}),
+      attempts: 5,
+      backoffMs: {
+        type: 'exponential',
+        delay: 2000
+      },
+      removeOnComplete: { age: 24 * 60 * 60, count: 5000 },
+      removeOnFail: { age: 7 * 24 * 60 * 60, count: 5000 }
+    })
+  }
+
+  async scheduleCleanup(
+    payload: Omit<LarkHistoryCleanupJobData, 'kind'>,
+    delayMs = 24 * 60 * 60 * 1000
+  ): Promise<void> {
+    if (!Number.isFinite(payload.retentionDays) || payload.retentionDays <= 0) {
+      return
+    }
+    const dueAt = new Date(Date.now() + Math.max(0, delayMs))
+    const dayBucket = dueAt.toISOString().slice(0, 10)
+    const continuation = normalizeContinuation(payload.continuation)
+    await this.managedQueue.enqueue<LarkHistoryCleanupJobData>({
+      pluginName: LARK_PLUGIN_NAME,
+      queueName: LARK_HISTORY_QUEUE_NAME,
+      jobName: LARK_HISTORY_CLEANUP_JOB,
+      payload: {
+        ...payload,
+        kind: 'cleanup-expired'
+      },
+      tenantId: payload.tenantId,
+      organizationId: payload.organizationId,
+      scopeKey: this.scopeKey,
+      jobId: buildLarkHistoryCleanupJobId(payload.integrationId, dayBucket, continuation),
+      delayMs: Math.max(0, delayMs),
+      attempts: 5,
+      backoffMs: {
+        type: 'exponential',
+        delay: 5000
+      },
+      removeOnComplete: { age: 3 * 24 * 60 * 60, count: 1000 },
+      removeOnFail: { age: 14 * 24 * 60 * 60, count: 1000 }
+    })
+  }
+
+  private get scopeKey(): string | undefined {
+    return (this.pluginContext as { scopeKey?: string | null }).scopeKey ?? undefined
+  }
+
+  private normalizeIds(ids: string[]): string[] {
+    return Array.from(
+      new Set(
+        (ids ?? []).map((id) => (typeof id === 'string' ? id.trim() : '')).filter((id): id is string => Boolean(id))
+      )
+    )
+  }
+}
+
+function normalizeContinuation(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}

--- a/xpertai/integrations/lark/src/lib/lark-message-history-schema.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history-schema.service.spec.ts
@@ -1,0 +1,65 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+  return createLarkPluginSdkMock(jest, {
+    WorkspaceFilesRuntimeCapability: Symbol('WorkspaceFilesRuntimeCapability'),
+    XPERT_RUNTIME_CAPABILITIES_TOKEN: 'XPERT_RUNTIME_CAPABILITIES_TOKEN'
+  })
+})
+
+import { LarkMessageHistorySchemaService } from './lark-message-history-schema.service.js'
+
+describe('LarkMessageHistorySchemaService', () => {
+  function createFixture(queryError?: Error) {
+    const queryRunner = {
+      connect: jest.fn().mockResolvedValue(undefined),
+      hasTable: jest.fn().mockResolvedValue(true),
+      query: jest.fn().mockImplementation(async (sql: string) => {
+        if (queryError && sql.includes('CREATE EXTENSION')) {
+          throw queryError
+        }
+        return []
+      }),
+      release: jest.fn().mockResolvedValue(undefined)
+    }
+    const service = new LarkMessageHistorySchemaService({
+      isInitialized: true,
+      options: { type: 'postgres' },
+      createQueryRunner: jest.fn().mockReturnValue(queryRunner)
+    } as any)
+    return { service, queryRunner }
+  }
+
+  it('creates a plugin-owned trigram index for exact substring search at scale', async () => {
+    const { service, queryRunner } = createFixture()
+
+    await service.ensureSchema()
+
+    expect(queryRunner.query).toHaveBeenNthCalledWith(1, 'CREATE EXTENSION IF NOT EXISTS pg_trgm')
+    expect(queryRunner.query).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('plugin_lark_message_log_admin_search_trgm_idx')
+    )
+    expect(queryRunner.query.mock.calls[2][0]).toContain('CREATE INDEX CONCURRENTLY')
+    expect(queryRunner.query.mock.calls[2][0]).toContain('gin_trgm_ops')
+    expect(queryRunner.release).toHaveBeenCalled()
+  })
+
+  it('does not block plugin startup when pg_trgm cannot be installed', async () => {
+    const { service, queryRunner } = createFixture(new Error('permission denied'))
+
+    await expect(service.ensureSchema()).resolves.toBeUndefined()
+    expect(queryRunner.release).toHaveBeenCalled()
+  })
+
+  it('contains query-runner creation failures without rejecting bootstrap', async () => {
+    const service = new LarkMessageHistorySchemaService({
+      isInitialized: true,
+      options: { type: 'postgres' },
+      createQueryRunner: jest.fn().mockImplementation(() => {
+        throw new Error('data source is shutting down')
+      })
+    } as any)
+
+    await expect(service.ensureSchema()).resolves.toBeUndefined()
+  })
+})

--- a/xpertai/integrations/lark/src/lib/lark-message-history-schema.service.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history-schema.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectDataSource } from '@nestjs/typeorm'
+import type { DataSource } from 'typeorm'
+import { LarkMessageLogEntity } from './entities/lark-message-log.entity.js'
+import { LARK_ADMIN_SEARCH_FIELDS } from './lark-message-history.service.js'
+
+const ADMIN_SEARCH_INDEX = 'plugin_lark_message_log_admin_search_trgm_idx'
+
+@Injectable()
+export class LarkMessageHistorySchemaService {
+  private readonly logger = new Logger(LarkMessageHistorySchemaService.name)
+
+  constructor(
+    @InjectDataSource()
+    private readonly dataSource: DataSource
+  ) {}
+
+  async ensureSchema(): Promise<void> {
+    if (!this.dataSource?.isInitialized || this.dataSource.options.type !== 'postgres') {
+      return
+    }
+
+    let queryRunner: ReturnType<DataSource['createQueryRunner']> | undefined
+    try {
+      queryRunner = this.dataSource.createQueryRunner()
+      await queryRunner.connect()
+      if (!(await queryRunner.hasTable(LarkMessageLogEntity.tableName))) {
+        return
+      }
+      await queryRunner.query('CREATE EXTENSION IF NOT EXISTS pg_trgm')
+      const existingIndexes = (await queryRunner.query(
+        'SELECT i.indisvalid FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid WHERE c.relname = $1',
+        [ADMIN_SEARCH_INDEX]
+      )) as Array<{ indisvalid?: boolean }>
+      if (existingIndexes.some((index) => index.indisvalid === false)) {
+        await queryRunner.query(`DROP INDEX CONCURRENTLY IF EXISTS "${ADMIN_SEARCH_INDEX}"`)
+      }
+      const expression = `LOWER(${LARK_ADMIN_SEARCH_FIELDS.map(
+        (field) => `COALESCE(CAST("${field}" AS text), '')`
+      ).join(" || ' ' || ")})`
+      await queryRunner.query(
+        `CREATE INDEX CONCURRENTLY IF NOT EXISTS "${ADMIN_SEARCH_INDEX}" ON "${LarkMessageLogEntity.tableName}" USING GIN ((${expression}) gin_trgm_ops)`
+      )
+    } catch (error) {
+      // Search remains exact via the portable LIKE query; an unavailable extension
+      // only removes the PostgreSQL acceleration and must not block plugin startup.
+      this.logger.warn(`Unable to ensure Lark admin search index: ${getErrorMessage(error)}`)
+    } finally {
+      try {
+        await queryRunner?.release()
+      } catch (error) {
+        this.logger.warn(`Unable to release Lark schema query runner: ${getErrorMessage(error)}`)
+      }
+    }
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/xpertai/integrations/lark/src/lib/lark-message-history.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history.service.spec.ts
@@ -1,0 +1,799 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+  return createLarkPluginSdkMock(jest, {
+    WorkspaceFilesRuntimeCapability: Symbol('WorkspaceFilesRuntimeCapability'),
+    XPERT_RUNTIME_CAPABILITIES_TOKEN: 'XPERT_RUNTIME_CAPABILITIES_TOKEN'
+  })
+})
+
+import { LarkMessageHistoryService } from './lark-message-history.service.js'
+import { Readable } from 'node:stream'
+
+describe('LarkMessageHistoryService', () => {
+  function createFixture(params?: {
+    logs?: any[]
+    queryLogs?: any[]
+    queryCount?: number
+    files?: any[]
+    findOne?: jest.Mock
+    runtimeCapabilities?: any
+    cacheManager?: any
+  }) {
+    const queryBuilder: Record<string, jest.Mock> = {}
+    for (const method of ['where', 'andWhere', 'orWhere', 'orderBy', 'addOrderBy', 'take', 'skip']) {
+      queryBuilder[method] = jest.fn().mockReturnValue(queryBuilder)
+    }
+    queryBuilder.getMany = jest.fn().mockResolvedValue(params?.queryLogs ?? params?.logs ?? [])
+    queryBuilder.getManyAndCount = jest
+      .fn()
+      .mockResolvedValue([
+        params?.queryLogs ?? params?.logs ?? [],
+        params?.queryCount ?? params?.queryLogs?.length ?? params?.logs?.length ?? 0
+      ])
+    queryBuilder.getCount = jest
+      .fn()
+      .mockResolvedValue(params?.queryCount ?? params?.queryLogs?.length ?? params?.logs?.length ?? 0)
+    const messageLogRepository = {
+      findOne: params?.findOne ?? jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue(params?.logs ?? []),
+      createQueryBuilder: jest.fn().mockReturnValue(queryBuilder),
+      create: jest.fn((value) => ({ id: 'created-log', createdAt: new Date(), ...value })),
+      save: jest.fn(async (value) => value),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      count: jest.fn().mockResolvedValue(params?.logs?.length ?? 0),
+      delete: jest.fn().mockResolvedValue({ affected: 1 })
+    }
+    const messageFileRepository = {
+      findOne: jest.fn().mockResolvedValue(null),
+      find: jest.fn().mockResolvedValue(params?.files ?? []),
+      create: jest.fn((value) => ({ id: 'created-file', createdAt: new Date(), ...value })),
+      save: jest.fn(async (value) => value),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+      delete: jest.fn().mockResolvedValue({ affected: 1 })
+    }
+    const larkChannel = {
+      getOrCreateLarkClientById: jest.fn()
+    }
+    const cacheStore = new Map<string, unknown>()
+    const cacheManager =
+      params?.cacheManager ??
+      {
+        get: jest.fn(async (key: string) => cacheStore.get(key)),
+        set: jest.fn(async (key: string, value: unknown) => {
+          cacheStore.set(key, value)
+        })
+      }
+    const service = new LarkMessageHistoryService(
+      messageLogRepository as any,
+      messageFileRepository as any,
+      larkChannel as any,
+      params?.runtimeCapabilities,
+      cacheManager
+    )
+    return { service, messageLogRepository, messageFileRepository, larkChannel, queryBuilder, cacheManager }
+  }
+
+  it('deduplicates inbound callbacks by integration, direction, and message id', async () => {
+    const existing = {
+      id: 'log-1',
+      integrationId: 'integration-1',
+      direction: 'inbound',
+      messageId: 'message-1'
+    }
+    const findOne = jest.fn().mockResolvedValue(existing)
+    const { service, messageLogRepository } = createFixture({ findOne })
+
+    await expect(
+      service.captureInbound({
+        integrationId: 'integration-1',
+        scopeKey: 'group:chat-1',
+        xpertId: 'xpert-1',
+        messageId: 'message-1'
+      })
+    ).resolves.toEqual({ log: existing, created: false })
+
+    expect(findOne).toHaveBeenCalledWith({
+      where: {
+        integrationId: 'integration-1',
+        direction: 'inbound',
+        messageId: 'message-1'
+      }
+    })
+    expect(messageLogRepository.save).not.toHaveBeenCalled()
+  })
+
+  it('searches only the trusted tenant, organization, integration, xpert, and conversation scope', async () => {
+    const resetAt = new Date('2026-07-15T09:00:00.000Z')
+    const logs = [
+      {
+        id: 'current-log',
+        direction: 'inbound',
+        status: 'dispatched',
+        content: 'current',
+        createdAt: new Date('2026-07-15T09:04:00.000Z')
+      },
+      {
+        id: 'after-reset',
+        direction: 'inbound',
+        status: 'history_only',
+        content: 'after reset',
+        messageType: 'text',
+        createdAt: new Date('2026-07-15T09:03:00.000Z')
+      },
+      {
+        id: 'reset',
+        direction: 'system',
+        status: 'context_reset',
+        content: 'history_context_reset',
+        createdAt: resetAt
+      },
+      {
+        id: 'before-reset',
+        direction: 'inbound',
+        status: 'history_only',
+        content: 'before reset',
+        createdAt: new Date('2026-07-15T08:59:00.000Z')
+      }
+    ]
+    const { service, messageLogRepository, queryBuilder } = createFixture({ logs })
+    messageLogRepository.findOne.mockResolvedValue({ createdAt: resetAt })
+    messageLogRepository.createQueryBuilder().getMany.mockResolvedValue([logs[1]])
+
+    const result = await service.searchChatHistory({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      excludedLogIds: ['current-log'],
+      respectContextReset: true,
+      hasAttachments: true,
+      limit: 20
+    })
+
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(
+      'EXISTS (SELECT 1 FROM plugin_lark_message_file history_file WHERE history_file."messageLogId" = CAST(log.id AS text))'
+    )
+
+    expect(result.items.map((item) => item.id)).toEqual(['after-reset'])
+    expect(messageLogRepository.createQueryBuilder).toHaveBeenCalledWith('log')
+  })
+
+  it('upserts one outbound row per run id instead of appending stream patches', async () => {
+    const existing = {
+      id: 'outbound-1',
+      integrationId: 'integration-1',
+      direction: 'outbound',
+      runId: 'run-1',
+      status: 'queued',
+      content: ''
+    }
+    const findOne = jest.fn().mockResolvedValue(existing)
+    const { service, messageLogRepository } = createFixture({ findOne })
+
+    const result = await service.recordOutbound({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      runId: 'run-1',
+      status: 'sent',
+      content: 'final response'
+    })
+
+    expect(result.created).toBe(false)
+    expect(messageLogRepository.save).toHaveBeenCalledTimes(1)
+    expect(messageLogRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'sent', content: 'final response' })
+    )
+  })
+
+  it('can filter and return attachment-only local history messages', async () => {
+    const createdAt = new Date('2026-07-15T09:03:00.000Z')
+    const { service } = createFixture({
+      logs: [
+        {
+          id: 'attachment-log',
+          direction: 'inbound',
+          status: 'history_only',
+          content: '',
+          messageType: 'file',
+          createdAt
+        }
+      ],
+      files: [
+        {
+          id: 'attachment-file',
+          messageLogId: 'attachment-log',
+          status: 'ready',
+          fileAssetId: 'asset-1',
+          resourceKey: 'file-key-1',
+          createdAt
+        }
+      ]
+    })
+
+    const result = await service.searchChatHistory({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      hasAttachments: true,
+      includeFiles: true
+    })
+
+    expect(result.items.map((item) => item.id)).toEqual(['attachment-log'])
+    expect(result.files).toEqual([expect.objectContaining({ fileAssetId: 'asset-1' })])
+  })
+
+  it('pushes time, keyword, and pagination limits into the database query', async () => {
+    const { service, queryBuilder } = createFixture({ queryLogs: [] })
+
+    await service.searchChatHistory({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      before: '2026-07-15T09:00:00.000Z',
+      after: '2026-07-01T09:00:00.000Z',
+      keyword: 'quarterly_100%',
+      limit: 20
+    })
+
+    expect(queryBuilder.take).toHaveBeenCalledWith(21)
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('log.createdAt < :before', {
+      before: new Date('2026-07-15T09:00:00.000Z')
+    })
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith('log.createdAt > :lowerBound', {
+      lowerBound: new Date('2026-07-01T09:00:00.000Z')
+    })
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(expect.anything(), {
+      keyword: '%quarterly!_100!%%'
+    })
+  })
+
+  it('returns an opaque keyset cursor without confusing stored and provider timestamps', async () => {
+    const rows = [
+      {
+        id: 'log-3',
+        direction: 'inbound',
+        status: 'history_only',
+        content: 'third',
+        createdAt: new Date('2026-07-15T09:03:00.000Z'),
+        messageCreatedAt: new Date('2026-07-15T08:03:00.000Z')
+      },
+      {
+        id: 'log-2',
+        direction: 'inbound',
+        status: 'history_only',
+        content: 'second',
+        createdAt: new Date('2026-07-15T09:02:00.000Z')
+      },
+      {
+        id: 'log-1',
+        direction: 'inbound',
+        status: 'history_only',
+        content: 'first',
+        createdAt: new Date('2026-07-15T09:01:00.000Z')
+      }
+    ]
+    const { service, queryBuilder } = createFixture({ queryLogs: rows })
+
+    const firstPage = await service.searchChatHistory({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      limit: 2
+    })
+
+    expect(firstPage.items.map((item) => item.id)).toEqual(['log-2', 'log-3'])
+    expect(firstPage.items[1]).toEqual(
+      expect.objectContaining({
+        createdAt: rows[0].createdAt,
+        messageCreatedAt: rows[0].messageCreatedAt
+      })
+    )
+    expect(firstPage.nextCursor).toEqual(expect.any(String))
+
+    await service.searchChatHistory({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      limit: 2,
+      cursor: firstPage.nextCursor
+    })
+    expect(queryBuilder.andWhere).toHaveBeenCalledWith(expect.anything())
+  })
+
+  it('rejects malformed local history cursors', async () => {
+    const { service } = createFixture({ queryLogs: [] })
+
+    await expect(
+      service.searchChatHistory({
+        integrationId: 'integration-1',
+        scopeKey: 'group:chat-1',
+        xpertId: 'xpert-1',
+        cursor: 'not-a-cursor'
+      })
+    ).rejects.toThrow('Invalid Lark history cursor')
+  })
+
+  it('uses database count and page boundaries for the integration message view', async () => {
+    const rows = [{ id: 'log-101' }]
+    const { service, queryBuilder } = createFixture({ queryLogs: rows, queryCount: 250_001 })
+
+    const result = await service.listMessageLogs({
+      integrationId: 'integration-1',
+      page: 101,
+      pageSize: 100,
+      search: 'alice'
+    })
+
+    expect(queryBuilder.skip).toHaveBeenCalledWith(10_000)
+    expect(queryBuilder.take).toHaveBeenCalledWith(101)
+    expect(queryBuilder.getManyAndCount).toHaveBeenCalled()
+    expect(result).toEqual(expect.objectContaining({ items: rows, total: 250_001 }))
+  })
+
+  it('bounds automatic context by item length and excludes current batch ids in the query', async () => {
+    const createdAt = new Date('2026-07-15T09:03:00.000Z')
+    const { service, messageLogRepository } = createFixture({
+      logs: [
+        {
+          id: 'history-log',
+          direction: 'inbound',
+          status: 'history_only',
+          content: 'A'.repeat(1500),
+          createdAt
+        }
+      ]
+    })
+
+    const result = await service.buildHistoryBundle({
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      limit: 20,
+      windowSeconds: 3600,
+      before: new Date('2026-07-15T09:05:00.000Z'),
+      excludedLogIds: ['current-1', 'current-2']
+    })
+
+    expect(result.context?.match(/A/g)?.length).toBeLessThanOrEqual(1000)
+    expect(result.context).toContain('...[截断]')
+    expect(messageLogRepository.find).toHaveBeenCalledWith(expect.objectContaining({ take: 20 }))
+  })
+
+  it('retains expired rows when deleting the workspace object fails', async () => {
+    const log = {
+      id: 'expired-log',
+      createdAt: new Date('2026-01-01T00:00:00.000Z')
+    }
+    const file = {
+      id: 'expired-file',
+      messageLogId: 'expired-log',
+      filePath: 'files/lark/expired.txt',
+      xpertId: 'xpert-1',
+      status: 'ready',
+      createdAt: new Date('2026-01-01T00:00:00.000Z')
+    }
+    const workspaceFiles = {
+      deleteFile: jest.fn().mockRejectedValue(new Error('storage unavailable'))
+    }
+    const { service, messageLogRepository, messageFileRepository } = createFixture({
+      logs: [log],
+      files: [file],
+      runtimeCapabilities: { get: jest.fn().mockReturnValue(workspaceFiles) }
+    })
+
+    const result = await service.cleanupExpired({
+      olderThan: new Date('2026-02-01T00:00:00.000Z')
+    })
+
+    expect(result).toEqual(expect.objectContaining({ deletedLogs: 0, deletedFiles: 0, failedFiles: 1 }))
+    expect(messageFileRepository.delete).not.toHaveBeenCalled()
+    expect(messageLogRepository.delete).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['file', 'file'],
+    ['audio', 'file'],
+    ['media', 'file'],
+    ['image', 'image']
+  ] as const)(
+    'downloads a pending %s resource with Lark API type %s and persists its workspace references',
+    async (resourceType, expectedApiType) => {
+      const row = {
+        id: 'file-row-1',
+        messageLogId: 'log-1',
+        integrationId: 'integration-1',
+        scopeKey: 'group:chat-1',
+        xpertId: 'xpert-1',
+        messageId: 'message-1',
+        resourceKey: 'file-key-1',
+        resourceType,
+        originalName: 'report.txt',
+        status: 'pending',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        createdAt: new Date('2026-07-15T08:00:00.000Z')
+      }
+      const workspaceFiles = {
+        uploadBuffer: jest.fn().mockResolvedValue({
+          filePath: 'files/lark/report.txt',
+          workspacePath: 'workspace/report.txt',
+          catalog: 'xperts',
+          scopeId: 'xpert-1',
+          mimeType: 'text/plain'
+        }),
+        understandFile: jest.fn().mockResolvedValue({
+          fileAssetId: 'asset-1',
+          fileId: 'file-1',
+          storageFileId: 'storage-1',
+          filePath: 'files/lark/report.txt',
+          workspacePath: 'workspace/report.txt',
+          originalName: 'report.txt',
+          mimeType: 'text/plain',
+          size: 5,
+          catalog: 'xperts',
+          scopeId: 'xpert-1'
+        })
+      }
+      const { service, messageFileRepository, larkChannel } = createFixture({
+        files: [row],
+        runtimeCapabilities: { get: jest.fn().mockReturnValue(workspaceFiles) }
+      })
+      const getResource = jest.fn().mockResolvedValue({
+        headers: { 'content-length': '5', 'content-type': 'text/plain' },
+        getReadableStream: () => Readable.from(Buffer.from('hello'))
+      })
+      larkChannel.getOrCreateLarkClientById.mockResolvedValue({
+        im: {
+          messageResource: {
+            get: getResource
+          }
+        }
+      })
+
+      const result = await service.materializeFiles({
+        integrationId: 'integration-1',
+        xpertId: 'xpert-1',
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        messageLogIds: ['log-1'],
+        maxSizeMb: 10
+      })
+
+      expect(workspaceFiles.uploadBuffer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          xpertId: 'xpert-1',
+          fileName: 'report.txt',
+          size: 5,
+          buffer: Buffer.from('hello')
+        })
+      )
+      expect(workspaceFiles.understandFile).toHaveBeenCalled()
+      expect(getResource).toHaveBeenCalledWith({
+        params: { type: expectedApiType },
+        path: { message_id: 'message-1', file_key: 'file-key-1' }
+      })
+      expect(messageFileRepository.save).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'ready', fileAssetId: 'asset-1', fileId: 'file-1' })
+      )
+      expect(result.failed).toEqual([])
+      expect(result.files).toEqual([
+        expect.objectContaining({ fileAssetId: 'asset-1', fileId: 'file-1', workspacePath: 'workspace/report.txt' })
+      ])
+    }
+  )
+
+  it('returns inline image content for dispatch while retaining the workspace reference', async () => {
+    const row = {
+      id: 'image-row-1',
+      messageLogId: 'log-1',
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      messageId: 'message-1',
+      resourceKey: 'image-key-1',
+      resourceType: 'image',
+      originalName: 'photo.png',
+      status: 'pending',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      createdById: 'user-1',
+      createdAt: new Date('2026-07-15T08:00:00.000Z')
+    }
+    const workspaceUrl = 'http://localhost:3000/api/sandbox/volume/xpert/xpert-1/files/lark/photo.png'
+    const workspaceFiles = {
+      uploadBuffer: jest.fn().mockResolvedValue({
+        filePath: 'files/lark/photo.png',
+        workspacePath: 'files/lark/photo.png',
+        fileUrl: workspaceUrl,
+        url: workspaceUrl,
+        catalog: 'xperts',
+        scopeId: 'xpert-1',
+        mimeType: 'image/png'
+      }),
+      understandFile: jest.fn().mockResolvedValue({
+        fileAssetId: 'asset-1',
+        fileId: 'file-1',
+        filePath: 'files/lark/photo.png',
+        workspacePath: 'files/lark/photo.png',
+        fileUrl: workspaceUrl,
+        url: workspaceUrl,
+        originalName: 'photo.png',
+        mimeType: 'image/png',
+        size: 3,
+        catalog: 'xperts',
+        scopeId: 'xpert-1'
+      }),
+      readBuffer: jest.fn().mockResolvedValue({
+        filePath: 'files/lark/photo.png',
+        workspacePath: 'files/lark/photo.png',
+        mimeType: 'image/png',
+        size: 3,
+        buffer: Buffer.from('abc')
+      })
+    }
+    const { service, larkChannel } = createFixture({
+      files: [row],
+      runtimeCapabilities: { get: jest.fn().mockReturnValue(workspaceFiles) }
+    })
+    larkChannel.getOrCreateLarkClientById.mockResolvedValue({
+      im: {
+        messageResource: {
+          get: jest.fn().mockResolvedValue({
+            headers: { 'content-length': '3', 'content-type': 'image/png' },
+            getReadableStream: () => Readable.from(Buffer.from('abc'))
+          })
+        }
+      }
+    })
+
+    const result = await service.materializeFiles({
+      integrationId: 'integration-1',
+      xpertId: 'xpert-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      messageLogIds: ['log-1'],
+      inlineImageContent: true
+    })
+
+    expect(workspaceFiles.readBuffer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        catalog: 'xperts',
+        scopeId: 'xpert-1',
+        xpertId: 'xpert-1',
+        filePath: 'files/lark/photo.png'
+      })
+    )
+    expect(result.files).toEqual([
+      expect.objectContaining({
+        fileAssetId: 'asset-1',
+        fileUrl: 'data:image/png;base64,YWJj',
+        url: 'data:image/png;base64,YWJj',
+        mimeType: 'image/png',
+        size: 3
+      })
+    ])
+    expect(row.fileUrl).toBe(workspaceUrl)
+  })
+
+  it('reclaims an attachment whose processing lease expired', async () => {
+    const row = {
+      id: 'stale-processing-file',
+      messageLogId: 'log-1',
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      messageId: 'message-1',
+      resourceKey: 'file-key-1',
+      resourceType: 'file',
+      originalName: 'report.txt',
+      status: 'processing',
+      updatedAt: new Date(Date.now() - 16 * 60 * 1000)
+    }
+    const workspaceFiles = {
+      uploadBuffer: jest.fn().mockResolvedValue({ filePath: 'files/report.txt', catalog: 'xperts' }),
+      understandFile: jest.fn().mockResolvedValue({ fileAssetId: 'asset-1', filePath: 'files/report.txt' })
+    }
+    const { service, larkChannel, messageFileRepository } = createFixture({
+      files: [row],
+      runtimeCapabilities: { get: jest.fn().mockReturnValue(workspaceFiles) }
+    })
+    larkChannel.getOrCreateLarkClientById.mockResolvedValue({
+      im: {
+        messageResource: {
+          get: jest.fn().mockResolvedValue({
+            headers: { 'content-length': '5' },
+            getReadableStream: () => Readable.from(Buffer.from('hello'))
+          })
+        }
+      }
+    })
+
+    await service.materializeFiles({
+      integrationId: 'integration-1',
+      xpertId: 'xpert-1',
+      messageLogIds: ['log-1']
+    })
+
+    expect(messageFileRepository.update).toHaveBeenCalledWith(
+      expect.objectContaining({ id: row.id, status: 'processing', updatedAt: expect.anything() }),
+      expect.objectContaining({ status: 'processing' })
+    )
+    expect(row.status).toBe('ready')
+  })
+
+  it('retries workspace understanding without downloading or uploading the resource again', async () => {
+    const row = {
+      id: 'uploaded-file',
+      messageLogId: 'log-1',
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      messageId: 'message-1',
+      resourceKey: 'file-key-1',
+      resourceType: 'file',
+      originalName: 'report.txt',
+      status: 'failed',
+      error: 'understand temporarily unavailable',
+      filePath: 'files/lark/report.txt',
+      workspacePath: '/workspace/report.txt',
+      workspaceCatalog: 'xperts',
+      size: 5
+    }
+    const workspaceFiles = {
+      uploadBuffer: jest.fn(),
+      understandFile: jest.fn().mockResolvedValue({
+        fileAssetId: 'asset-1',
+        filePath: row.filePath,
+        workspacePath: row.workspacePath
+      })
+    }
+    const { service, larkChannel } = createFixture({
+      files: [row],
+      runtimeCapabilities: { get: jest.fn().mockReturnValue(workspaceFiles) }
+    })
+
+    await service.materializeFiles({
+      integrationId: 'integration-1',
+      xpertId: 'xpert-1',
+      messageLogIds: ['log-1']
+    })
+
+    expect(larkChannel.getOrCreateLarkClientById).not.toHaveBeenCalled()
+    expect(workspaceFiles.uploadBuffer).not.toHaveBeenCalled()
+    expect(workspaceFiles.understandFile).toHaveBeenCalledWith(expect.objectContaining({ filePath: row.filePath }))
+    expect(row.status).toBe('ready')
+  })
+
+  it('materializes every attachment while returning at most twenty context files', async () => {
+    const rows = Array.from({ length: 25 }, (_, index) => ({
+      id: `file-${index}`,
+      messageLogId: 'log-1',
+      integrationId: 'integration-1',
+      scopeKey: 'group:chat-1',
+      xpertId: 'xpert-1',
+      messageId: 'message-1',
+      resourceKey: `file-key-${index}`,
+      resourceType: 'file',
+      originalName: `report-${index}.txt`,
+      status: 'pending'
+    }))
+    const workspaceFiles = {
+      uploadBuffer: jest.fn().mockImplementation(async ({ fileName }) => ({
+        filePath: `files/${fileName}`,
+        catalog: 'xperts'
+      })),
+      understandFile: jest.fn().mockImplementation(async ({ filePath }) => ({
+        fileAssetId: `asset-${filePath}`,
+        filePath
+      }))
+    }
+    const { service, larkChannel } = createFixture({
+      files: rows,
+      runtimeCapabilities: { get: jest.fn().mockReturnValue(workspaceFiles) }
+    })
+    const getResource = jest.fn().mockResolvedValue({
+      headers: { 'content-length': '5' },
+      getReadableStream: () => Readable.from(Buffer.from('hello'))
+    })
+    larkChannel.getOrCreateLarkClientById.mockResolvedValue({
+      im: { messageResource: { get: getResource } }
+    })
+
+    const result = await service.materializeFiles({
+      integrationId: 'integration-1',
+      xpertId: 'xpert-1',
+      messageLogIds: ['log-1'],
+      maxFiles: 20
+    })
+
+    expect(getResource).toHaveBeenCalledTimes(25)
+    expect(workspaceFiles.uploadBuffer).toHaveBeenCalledTimes(25)
+    expect(rows.every((row) => row.status === 'ready')).toBe(true)
+    expect(result.files).toHaveLength(20)
+  })
+
+  it('returns a cleanup cursor even when the oldest poison batch cannot delete any file', async () => {
+    const logs = Array.from({ length: 501 }, (_, index) => ({
+      id: `log-${String(index).padStart(3, '0')}`,
+      createdAt: new Date(1_700_000_000_000 + index)
+    }))
+    const files = logs.slice(0, 500).map((log, index) => ({
+      id: `file-${index}`,
+      messageLogId: log.id,
+      filePath: `files/${index}.txt`,
+      status: 'ready',
+      createdAt: log.createdAt
+    }))
+    const { service } = createFixture({
+      logs,
+      files,
+      runtimeCapabilities: {
+        get: jest.fn().mockReturnValue({ deleteFile: jest.fn().mockRejectedValue(new Error('storage unavailable')) })
+      }
+    })
+
+    const result = await service.cleanupExpired({
+      olderThan: new Date('2030-01-01T00:00:00.000Z'),
+      batchSize: 500
+    })
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        deletedLogs: 0,
+        failedFiles: 500,
+        hasMore: true,
+        nextCursor: { createdAt: logs[499].createdAt, id: logs[499].id }
+      })
+    )
+  })
+
+  it('reuses the server-cached exact total for an admin keyset cursor', async () => {
+    const rows = [
+      { id: 'log-3', createdAt: new Date('2026-07-15T09:03:00.000Z') },
+      { id: 'log-2', createdAt: new Date('2026-07-15T09:02:00.000Z') },
+      { id: 'log-1', createdAt: new Date('2026-07-15T09:01:00.000Z') }
+    ]
+    const { service, queryBuilder } = createFixture({ queryLogs: rows, queryCount: 250_001 })
+    const first = await service.listMessageLogs({ integrationId: 'integration-1', pageSize: 2 })
+    expect(first.nextCursor).toEqual(expect.any(String))
+
+    queryBuilder.getManyAndCount.mockClear()
+    queryBuilder.getCount.mockClear()
+    const second = await service.listMessageLogs({
+      integrationId: 'integration-1',
+      page: 2,
+      pageSize: 2,
+      cursor: first.nextCursor
+    })
+
+    expect(second.total).toBe(250_001)
+    expect(queryBuilder.getManyAndCount).not.toHaveBeenCalled()
+    expect(queryBuilder.getCount).not.toHaveBeenCalled()
+  })
+
+  it('rejects an admin keyset cursor when filters change', async () => {
+    const rows = [
+      { id: 'log-2', createdAt: new Date('2026-07-15T09:02:00.000Z') },
+      { id: 'log-1', createdAt: new Date('2026-07-15T09:01:00.000Z') }
+    ]
+    const { service } = createFixture({ queryLogs: rows, queryCount: 2 })
+    const first = await service.listMessageLogs({
+      integrationId: 'integration-1',
+      pageSize: 1,
+      search: 'alpha'
+    })
+
+    await expect(
+      service.listMessageLogs({
+        integrationId: 'integration-1',
+        page: 2,
+        pageSize: 1,
+        search: 'beta',
+        cursor: first.nextCursor
+      })
+    ).rejects.toThrow('Invalid Lark message page cursor')
+  })
+})

--- a/xpertai/integrations/lark/src/lib/lark-message-history.service.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-history.service.ts
@@ -1,0 +1,1933 @@
+import type * as lark from '@larksuiteoapi/node-sdk'
+import { CACHE_MANAGER } from '@nestjs/cache-manager'
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
+import {
+  WorkspaceFilesRuntimeCapability,
+  XPERT_RUNTIME_CAPABILITIES_TOKEN,
+  type AgentMiddlewareRuntimeCapabilityRegistry,
+  type WorkspaceFileCatalog,
+  type WorkspaceFilesApi
+} from '@xpert-ai/plugin-sdk'
+import { Readable } from 'node:stream'
+import { createHash, randomUUID } from 'node:crypto'
+import type { Cache } from 'cache-manager'
+import {
+  And,
+  Brackets,
+  In,
+  LessThan,
+  LessThanOrEqual,
+  MoreThan,
+  Not,
+  type FindOptionsWhere,
+  type FindOperator,
+  type Repository,
+  type SelectQueryBuilder
+} from 'typeorm'
+import {
+  LarkMessageFileEntity,
+  LarkMessageLogEntity,
+  type LarkMessageDirection,
+  type LarkMessageLogStatus
+} from './entities/index.js'
+import { LarkChannelStrategy } from './lark-channel.strategy.js'
+import type { LarkInboundFile, LarkMessageResourceType, NormalizedMessageResourceRef } from './types.js'
+
+const DEFAULT_HISTORY_LIMIT = 20
+const MAX_HISTORY_LIMIT = 100
+const DEFAULT_HISTORY_WINDOW_SECONDS = 3600
+const DEFAULT_MAX_HISTORY_FILES = 20
+const MAX_HISTORY_FILES = 20
+const DEFAULT_MAX_FILE_SIZE_MB = 10
+const FILE_PROCESSING_LEASE_MS = 15 * 60 * 1000
+const MAX_CONTEXT_ITEM_CHARS = 1000
+const MAX_CONTEXT_TOTAL_CHARS = 12000
+const DEFAULT_RETENTION_DAYS = 30
+const CONTEXT_RESET_CONTENT = 'history_context_reset'
+const ADMIN_TOTAL_CACHE_TTL_MS = 15 * 60 * 1000
+const ADMIN_TOTAL_CACHE_PREFIX = 'plugin_lark:admin_message_total'
+export const LARK_ADMIN_SEARCH_FIELDS = [
+  'id',
+  'messageId',
+  'runId',
+  'scopeKey',
+  'chatId',
+  'senderOpenId',
+  'senderName',
+  'messageType',
+  'content',
+  'error',
+  'conversationId',
+  'xpertId',
+  'direction',
+  'status'
+] as const
+
+export function buildAdminSearchExpression(alias?: string): string {
+  const prefix = alias ? `${alias}.` : ''
+  return `LOWER(${LARK_ADMIN_SEARCH_FIELDS.map(
+    (field) => `COALESCE(CAST(${prefix}${field} AS text), '')`
+  ).join(" || ' ' || ")})`
+}
+
+export type LarkHistoryScope = {
+  integrationId: string
+  scopeKey: string
+  xpertId: string
+  tenantId?: string | null
+  organizationId?: string | null
+}
+
+export type CaptureLarkInboundInput = LarkHistoryScope & {
+  messageId: string
+  chatType?: 'p2p' | 'group' | null
+  chatId?: string | null
+  senderOpenId?: string | null
+  senderName?: string | null
+  messageType?: string | null
+  content?: string | null
+  botMentioned?: boolean
+  messageCreatedAt?: Date | string | number | null
+  resourceRefs?: NormalizedMessageResourceRef[] | null
+  status?: Extract<LarkMessageLogStatus, 'received' | 'history_only' | 'dispatched' | 'failed'>
+  conversationId?: string | null
+  createdById?: string | null
+}
+
+export type UpdateLarkInboundLogsPatch = {
+  status: LarkMessageLogStatus
+  error?: string | null
+  conversationId?: string | null
+}
+
+export type MaterializeLarkFilesInput = Pick<
+  LarkHistoryScope,
+  'integrationId' | 'xpertId' | 'tenantId' | 'organizationId'
+> & {
+  messageLogIds: string[]
+  maxSizeMb?: number | null
+  maxFiles?: number | null
+  inlineImageContent?: boolean
+}
+
+export type BuildLarkHistoryBundleInput = LarkHistoryScope & {
+  limit?: number | null
+  windowSeconds?: number | null
+  before?: Date | string | number | null
+  excludedLogIds?: string[] | null
+  maxFiles?: number | null
+  maxFileSizeMb?: number | null
+  respectContextReset?: boolean
+}
+
+export type LarkHistoryBundle = {
+  context?: string
+  files?: LarkInboundFile[]
+  messageLogIds: string[]
+  resetAt?: Date
+}
+
+export type RecordLarkOutboundInput = LarkHistoryScope & {
+  runId: string
+  status: Extract<LarkMessageLogStatus, 'queued' | 'dispatched' | 'sent' | 'failed'>
+  content?: string | null
+  messageId?: string | null
+  conversationId?: string | null
+  error?: string | null
+  sentAt?: Date | string | number | null
+  createdById?: string | null
+}
+
+export type MarkLarkContextResetInput = LarkHistoryScope & {
+  conversationId?: string | null
+  createdById?: string | null
+}
+
+export type SearchLarkHistoryInput = LarkHistoryScope & {
+  keyword?: string | null
+  direction?: 'inbound' | 'outbound' | 'both' | null
+  senderOpenId?: string | null
+  before?: Date | string | number | null
+  after?: Date | string | number | null
+  cursor?: string | null
+  limit?: number | null
+  excludedLogIds?: string[] | null
+  respectContextReset?: boolean
+  includeFiles?: boolean | null
+  hasAttachments?: boolean | null
+}
+
+export type LarkHistoryItem = {
+  id: string
+  direction: LarkMessageDirection
+  status: LarkMessageLogStatus
+  senderOpenId: string | null
+  senderName: string | null
+  content: string
+  messageId: string | null
+  messageType: string | null
+  createdAt: Date
+  messageCreatedAt: Date | null
+  sentAt: Date | null
+}
+
+export type ListLarkMessageLogsInput = {
+  integrationId: string
+  tenantId?: string | null
+  organizationId?: string | null
+  scopeKey?: string | null
+  xpertId?: string | null
+  direction?: LarkMessageDirection | null
+  status?: LarkMessageLogStatus | null
+  search?: string | null
+  cursor?: string | null
+  page?: number | null
+  pageSize?: number | null
+  sortBy?: 'createdAt' | 'messageCreatedAt' | 'direction' | 'status' | 'senderName' | 'botMentioned' | null
+  sortDirection?: 'asc' | 'desc' | null
+}
+
+type LarkAdminMessageSortBy = NonNullable<ListLarkMessageLogsInput['sortBy']>
+
+type LarkAdminMessageCursor = {
+  sortBy: LarkAdminMessageSortBy
+  sortDirection: 'ASC' | 'DESC'
+  sortValue: string | boolean | Date | null
+  id: string
+  queryFingerprint: string
+  sessionId: string
+}
+
+export type CleanupExpiredLarkHistoryInput = {
+  integrationId?: string | null
+  tenantId?: string | null
+  organizationId?: string | null
+  olderThan?: Date | string | number | null
+  retentionDays?: number | null
+  batchSize?: number | null
+  afterCreatedAt?: Date | string | number | null
+  afterId?: string | null
+}
+
+type LarkMessageResourceDownload = {
+  headers?: Record<string, unknown>
+  getReadableStream: () => Readable
+}
+
+export type MaterializeFailure = {
+  fileId: string
+  messageLogId: string
+  resourceKey: string
+  error: string
+  retryable: boolean
+}
+
+@Injectable()
+export class LarkMessageHistoryService {
+  private readonly logger = new Logger(LarkMessageHistoryService.name)
+
+  constructor(
+    @InjectRepository(LarkMessageLogEntity)
+    private readonly messageLogRepository: Repository<LarkMessageLogEntity>,
+    @InjectRepository(LarkMessageFileEntity)
+    private readonly messageFileRepository: Repository<LarkMessageFileEntity>,
+    private readonly larkChannel: LarkChannelStrategy,
+    @Optional()
+    @Inject(XPERT_RUNTIME_CAPABILITIES_TOKEN)
+    private readonly runtimeCapabilities?: AgentMiddlewareRuntimeCapabilityRegistry,
+    @Optional()
+    @Inject(CACHE_MANAGER)
+    private readonly cacheManager?: Cache
+  ) {}
+
+  /** Store every inbound event, including non-mention group messages, exactly once. */
+  async captureInbound(input: CaptureLarkInboundInput): Promise<{ log: LarkMessageLogEntity; created: boolean }> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const scopeKey = requireText(input.scopeKey, 'scopeKey')
+    const xpertId = requireText(input.xpertId, 'xpertId')
+    const messageId = requireText(input.messageId, 'messageId')
+
+    let existing = await this.messageLogRepository.findOne({
+      where: {
+        integrationId,
+        direction: 'inbound',
+        messageId
+      }
+    })
+    if (existing) {
+      await this.ensureResourceRows(existing, input)
+      return { log: existing, created: false }
+    }
+
+    const candidate = this.messageLogRepository.create({
+      integrationId,
+      messageId,
+      scopeKey,
+      xpertId,
+      conversationId: optionalText(input.conversationId),
+      chatType: input.chatType === 'p2p' || input.chatType === 'group' ? input.chatType : null,
+      chatId: optionalText(input.chatId),
+      senderOpenId: optionalText(input.senderOpenId),
+      senderName: optionalText(input.senderName),
+      messageType: optionalText(input.messageType),
+      botMentioned: input.botMentioned === true,
+      direction: 'inbound',
+      status: input.status ?? 'received',
+      content: optionalText(input.content),
+      messageCreatedAt: toDate(input.messageCreatedAt),
+      tenantId: optionalText(input.tenantId),
+      organizationId: optionalText(input.organizationId),
+      createdById: optionalText(input.createdById),
+      updatedById: optionalText(input.createdById)
+    })
+
+    let created = true
+    try {
+      existing = await this.messageLogRepository.save(candidate)
+    } catch (error) {
+      // Webhook and long-connection delivery can race. The unique key is the final arbiter.
+      existing = await this.messageLogRepository.findOne({
+        where: { integrationId, direction: 'inbound', messageId }
+      })
+      if (!existing) {
+        throw error
+      }
+      created = false
+    }
+
+    await this.ensureResourceRows(existing, input)
+    return { log: existing, created }
+  }
+
+  /** Update only inbound rows represented by the current dispatch/window. */
+  async updateLogs(ids: string[], patch: UpdateLarkInboundLogsPatch): Promise<LarkMessageLogEntity[]> {
+    const normalizedIds = uniqueTexts(ids)
+    if (!normalizedIds.length) {
+      return []
+    }
+
+    await this.messageLogRepository.update(
+      { id: In(normalizedIds), direction: 'inbound' },
+      {
+        status: patch.status,
+        ...(patch.error !== undefined ? { error: truncateText(patch.error, 1024) || null } : {}),
+        ...(patch.conversationId !== undefined ? { conversationId: optionalText(patch.conversationId) ?? null } : {})
+      }
+    )
+
+    return this.messageLogRepository.find({
+      where: { id: In(normalizedIds), direction: 'inbound' },
+      order: { createdAt: 'ASC', id: 'ASC' }
+    })
+  }
+
+  async updateInboundStatus(
+    ids: string[],
+    status: LarkMessageLogStatus,
+    error?: string | null,
+    conversationId?: string | null
+  ): Promise<LarkMessageLogEntity[]> {
+    return this.updateLogs(ids, {
+      status,
+      ...(error !== undefined ? { error } : {}),
+      ...(conversationId !== undefined ? { conversationId } : {})
+    })
+  }
+
+  /** Atomically claim captured rows so duplicate callbacks cannot enqueue the same message twice. */
+  async claimInboundStatus(
+    ids: string[],
+    fromStatuses: Array<Extract<LarkMessageLogStatus, 'received' | 'failed' | 'dispatched'>>,
+    status: Extract<LarkMessageLogStatus, 'queued' | 'history_only'>
+  ): Promise<boolean> {
+    const normalizedIds = uniqueTexts(ids)
+    if (!normalizedIds.length) {
+      return true
+    }
+    const result = await this.messageLogRepository.update(
+      {
+        id: In(normalizedIds),
+        direction: 'inbound',
+        status: In(fromStatuses)
+      },
+      { status, error: null }
+    )
+    return result.affected === normalizedIds.length
+  }
+
+  async areInboundLogsInStatus(ids: string[], status: LarkMessageLogStatus): Promise<boolean> {
+    const normalizedIds = uniqueTexts(ids)
+    if (!normalizedIds.length) {
+      return false
+    }
+    const count = await this.messageLogRepository.count({
+      where: {
+        id: In(normalizedIds),
+        direction: 'inbound',
+        status
+      }
+    })
+    return count === normalizedIds.length
+  }
+
+  async areInboundLogsInStatusWithError(
+    ids: string[],
+    status: LarkMessageLogStatus,
+    error: string
+  ): Promise<boolean> {
+    const normalizedIds = uniqueTexts(ids)
+    if (!normalizedIds.length) {
+      return false
+    }
+    const count = await this.messageLogRepository.count({
+      where: {
+        id: In(normalizedIds),
+        direction: 'inbound',
+        status,
+        error
+      }
+    })
+    return count === normalizedIds.length
+  }
+
+  /**
+   * Download pending message resources with the native Lark SDK, then register them
+   * in the platform workspace. This deliberately does not call LarkContextToolService.
+   */
+  async materializeFiles(input: MaterializeLarkFilesInput): Promise<{
+    files: LarkInboundFile[]
+    failed: MaterializeFailure[]
+    nextLeaseAt?: Date
+  }> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const xpertId = requireText(input.xpertId, 'xpertId')
+    const messageLogIds = uniqueTexts(input.messageLogIds)
+    if (!messageLogIds.length) {
+      return { files: [], failed: [] }
+    }
+
+    const maxFiles = normalizeMaxFiles(input.maxFiles)
+    const maxBytes = normalizeMaxFileBytes(input.maxSizeMb)
+    const rows = await this.messageFileRepository.find({
+      where: this.scopedFileWhere(
+        {
+          integrationId,
+          xpertId,
+          messageLogId: In(messageLogIds)
+        },
+        input
+      ),
+      order: { createdAt: 'ASC', id: 'ASC' }
+    })
+    const processingLeaseCutoff = new Date(Date.now() - FILE_PROCESSING_LEASE_MS)
+    const freshProcessing = rows.filter(
+      (row) => row.status === 'processing' && row.updatedAt && row.updatedAt > processingLeaseCutoff
+    )
+    const pending = rows.filter(
+      (row) =>
+        row.status === 'pending' ||
+        (row.status === 'failed' && !/^file_size_exceeded:/i.test(row.error ?? '')) ||
+        (row.status === 'processing' && (!row.updatedAt || row.updatedAt <= processingLeaseCutoff))
+    )
+    const failed: MaterializeFailure[] = []
+    let client: lark.Client | undefined
+    let workspaceFiles = pending.length ? this.requireWorkspaceFiles() : undefined
+
+    for (const row of pending) {
+      const claimWhere =
+        row.status === 'processing'
+          ? { id: row.id, status: 'processing' as const, updatedAt: LessThanOrEqual(processingLeaseCutoff) }
+          : { id: row.id, status: In(['pending', 'failed']) }
+      const claimed = await this.messageFileRepository.update(
+        claimWhere,
+        {
+          status: 'processing',
+          error: null
+        }
+      )
+      if (claimed.affected !== 1) {
+        continue
+      }
+      row.status = 'processing'
+      row.error = null
+      try {
+        if (!row.filePath) {
+          client ??= await this.larkChannel.getOrCreateLarkClientById(integrationId)
+        }
+        await this.materializeOneFile(client, workspaceFiles!, row, {
+          integrationId,
+          xpertId,
+          tenantId: optionalText(input.tenantId),
+          organizationId: optionalText(input.organizationId),
+          maxBytes
+        })
+      } catch (error) {
+        const message = truncateText(getErrorMessage(error), 1024) || 'lark_resource_materialization_failed'
+        const retryable = !isPermanentMaterializationError(message)
+        row.status = 'failed'
+        row.error = message
+        await this.messageFileRepository.save(row)
+        failed.push({
+          fileId: row.id,
+          messageLogId: row.messageLogId,
+          resourceKey: row.resourceKey,
+          error: message,
+          retryable
+        })
+      }
+    }
+
+    const readyRows = await this.messageFileRepository.find({
+      where: this.scopedFileWhere(
+        {
+          integrationId,
+          xpertId,
+          messageLogId: In(messageLogIds),
+          status: 'ready'
+        },
+        input
+      ),
+      order: { createdAt: 'ASC', id: 'ASC' },
+      take: maxFiles
+    })
+
+    const shouldInlineImages = Boolean(input.inlineImageContent && readyRows.some((row) => row.resourceType === 'image'))
+    if (shouldInlineImages) {
+      workspaceFiles ??= this.requireWorkspaceFiles()
+    }
+    const files = shouldInlineImages
+      ? await Promise.all(
+          readyRows.slice(0, maxFiles).map((row) => this.toDispatchInboundFile(workspaceFiles!, row))
+        )
+      : readyRows.slice(0, maxFiles).map((row) => this.toInboundFile(row))
+
+    return {
+      files,
+      failed,
+      ...(freshProcessing.length
+        ? {
+            nextLeaseAt: new Date(
+              Math.min(...freshProcessing.map((row) => row.updatedAt.getTime())) + FILE_PROCESSING_LEASE_MS
+            )
+          }
+        : {})
+    }
+  }
+
+  /** Build automatic local context bounded by scope, reset marker, time, count and files. */
+  async buildHistoryBundle(input: BuildLarkHistoryBundleInput): Promise<LarkHistoryBundle> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const scopeKey = requireText(input.scopeKey, 'scopeKey')
+    const xpertId = requireText(input.xpertId, 'xpertId')
+    const limit = normalizeHistoryLimit(input.limit)
+    const before = toDate(input.before) ?? new Date()
+    const maxFiles = normalizeMaxFiles(input.maxFiles)
+    if (!limit) {
+      return { messageLogIds: [] }
+    }
+
+    const scope = { ...input, integrationId, scopeKey, xpertId }
+    const resetMarker =
+      input.respectContextReset === false
+        ? null
+        : await this.messageLogRepository.findOne({
+            where: this.scopedLogWhere(
+              {
+                integrationId,
+                scopeKey,
+                xpertId,
+                direction: 'system',
+                status: 'context_reset',
+                createdAt: LessThan(before)
+              },
+              scope
+            ),
+            order: { createdAt: 'DESC', id: 'DESC' }
+          })
+
+    const lowerBound = this.resolveHistoryLowerBound(before, input.windowSeconds, resetMarker?.createdAt)
+    const createdAt = this.historyDateRange(before, lowerBound)
+    const excludedLogIds = uniqueTexts(input.excludedLogIds ?? [])
+    const commonWhere = {
+      integrationId,
+      scopeKey,
+      xpertId,
+      createdAt,
+      ...(excludedLogIds.length ? { id: Not(In(excludedLogIds)) } : {})
+    }
+    const logs = await this.messageLogRepository.find({
+      where: [
+        this.scopedLogWhere(
+          {
+            ...commonWhere,
+            direction: 'inbound',
+            status: In(['dispatched', 'history_only'] satisfies LarkMessageLogStatus[])
+          },
+          scope
+        ),
+        this.scopedLogWhere(
+          {
+            ...commonWhere,
+            direction: 'outbound',
+            status: 'sent'
+          },
+          scope
+        )
+      ],
+      order: { createdAt: 'DESC', id: 'DESC' },
+      take: limit
+    })
+    const chronologicalLogs = logs.reverse()
+    const messageLogIds = chronologicalLogs.map((log) => log.id)
+    if (!messageLogIds.length) {
+      return {
+        messageLogIds,
+        ...(resetMarker?.createdAt ? { resetAt: resetMarker.createdAt } : {})
+      }
+    }
+
+    try {
+      await this.materializeFiles({
+        integrationId,
+        xpertId,
+        tenantId: input.tenantId,
+        organizationId: input.organizationId,
+        messageLogIds,
+        maxFiles,
+        maxSizeMb: input.maxFileSizeMb
+      })
+    } catch (error) {
+      // Text history remains useful if the workspace capability is temporarily unavailable.
+      this.logger.warn(`Failed to materialize Lark history files: ${getErrorMessage(error)}`)
+    }
+
+    const fileRows = await this.messageFileRepository.find({
+      where: this.scopedFileWhere(
+        {
+          integrationId,
+          xpertId,
+          messageLogId: In(messageLogIds)
+        },
+        scope
+      ),
+      order: { createdAt: 'ASC', id: 'ASC' }
+    })
+    const filesByLogId = groupFilesByLogId(fileRows)
+    const readyFiles = fileRows
+      .filter((row) => row.status === 'ready')
+      .slice(0, maxFiles)
+      .map((row) => this.toInboundFile(row))
+    const context = this.formatHistoryContext(chronologicalLogs, filesByLogId)
+
+    return {
+      ...(context ? { context } : {}),
+      ...(readyFiles.length ? { files: readyFiles } : {}),
+      messageLogIds,
+      ...(resetMarker?.createdAt ? { resetAt: resetMarker.createdAt } : {})
+    }
+  }
+
+  /** Upsert one outbound row per Agent run id. */
+  async recordOutbound(input: RecordLarkOutboundInput): Promise<{ log: LarkMessageLogEntity; created: boolean }> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const scopeKey = requireText(input.scopeKey, 'scopeKey')
+    const xpertId = requireText(input.xpertId, 'xpertId')
+    const runId = requireText(input.runId, 'runId')
+    let existing = await this.messageLogRepository.findOne({
+      where: { integrationId, direction: 'outbound', runId }
+    })
+
+    if (existing) {
+      this.applyOutboundPatch(existing, input)
+      return { log: await this.messageLogRepository.save(existing), created: false }
+    }
+
+    const candidate = this.messageLogRepository.create({
+      integrationId,
+      runId,
+      messageId: optionalText(input.messageId),
+      scopeKey,
+      xpertId,
+      conversationId: optionalText(input.conversationId),
+      direction: 'outbound',
+      status: input.status,
+      content: optionalText(input.content),
+      error: truncateText(input.error, 1024) || null,
+      sentAt: toDate(input.sentAt) ?? (input.status === 'sent' ? new Date() : null),
+      tenantId: optionalText(input.tenantId),
+      organizationId: optionalText(input.organizationId),
+      createdById: optionalText(input.createdById),
+      updatedById: optionalText(input.createdById),
+      botMentioned: false
+    })
+
+    try {
+      return { log: await this.messageLogRepository.save(candidate), created: true }
+    } catch (error) {
+      existing = await this.messageLogRepository.findOne({
+        where: { integrationId, direction: 'outbound', runId }
+      })
+      if (!existing) {
+        throw error
+      }
+      this.applyOutboundPatch(existing, input)
+      return { log: await this.messageLogRepository.save(existing), created: false }
+    }
+  }
+
+  async markContextReset(input: MarkLarkContextResetInput): Promise<LarkMessageLogEntity> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const scopeKey = requireText(input.scopeKey, 'scopeKey')
+    const xpertId = requireText(input.xpertId, 'xpertId')
+    return this.messageLogRepository.save(
+      this.messageLogRepository.create({
+        integrationId,
+        scopeKey,
+        xpertId,
+        conversationId: optionalText(input.conversationId),
+        direction: 'system',
+        status: 'context_reset',
+        content: CONTEXT_RESET_CONTENT,
+        botMentioned: false,
+        tenantId: optionalText(input.tenantId),
+        organizationId: optionalText(input.organizationId),
+        createdById: optionalText(input.createdById),
+        updatedById: optionalText(input.createdById)
+      })
+    )
+  }
+
+  /** Search only the persisted local history for the exact current Lark/Xpert scope. */
+  async searchChatHistory(input: SearchLarkHistoryInput): Promise<{
+    items: LarkHistoryItem[]
+    totalScanned: number
+    hasMore: boolean
+    nextCursor?: string
+    files?: LarkInboundFile[]
+  }> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const scopeKey = requireText(input.scopeKey, 'scopeKey')
+    const xpertId = requireText(input.xpertId, 'xpertId')
+    const limit = normalizeHistoryLimit(input.limit)
+    if (!limit) {
+      return { items: [], totalScanned: 0, hasMore: false }
+    }
+
+    const before = toDate(input.before)
+    const after = toDate(input.after)
+    const cursor = decodeHistoryCursor(input.cursor)
+    const keyword = normalizeSearch(input.keyword)
+    const senderOpenId = optionalText(input.senderOpenId)
+    const direction = input.direction ?? 'both'
+    const excluded = uniqueTexts(input.excludedLogIds ?? [])
+    const resetMarker = input.respectContextReset
+      ? await this.messageLogRepository.findOne({
+          where: this.scopedLogWhere(
+            {
+              integrationId,
+              scopeKey,
+              xpertId,
+              direction: 'system',
+              status: 'context_reset',
+              ...(before ? { createdAt: LessThan(before) } : {})
+            },
+            input
+          ),
+          order: { createdAt: 'DESC', id: 'DESC' }
+        })
+      : null
+    const lowerBound =
+      after && resetMarker?.createdAt
+        ? after > resetMarker.createdAt
+          ? after
+          : resetMarker.createdAt
+        : after ?? resetMarker?.createdAt
+    // messageLogId is retained as varchar for compatibility with plugin-created tables,
+    // while the message log primary key is a PostgreSQL uuid. Cast the outer id to text
+    // so PostgreSQL can use the indexed varchar association without a schema migration.
+    const attachmentExists = `EXISTS (SELECT 1 FROM ${LarkMessageFileEntity.tableName} history_file WHERE history_file."messageLogId" = CAST(log.id AS text))`
+    const query = this.messageLogRepository.createQueryBuilder('log')
+    this.applyLogScopeQuery(query, { ...input, integrationId, scopeKey, xpertId })
+    query.andWhere(
+      new Brackets((statusQuery) => {
+        if (direction !== 'outbound') {
+          statusQuery.where('(log.direction = :inboundDirection AND log.status IN (:...inboundStatuses))', {
+            inboundDirection: 'inbound',
+            inboundStatuses: ['received', 'dispatched', 'history_only']
+          })
+        }
+        if (direction !== 'inbound') {
+          const clause = '(log.direction = :outboundDirection AND log.status = :sentStatus)'
+          const parameters = { outboundDirection: 'outbound', sentStatus: 'sent' }
+          if (direction === 'outbound') {
+            statusQuery.where(clause, parameters)
+          } else {
+            statusQuery.orWhere(clause, parameters)
+          }
+        }
+      })
+    )
+    if (senderOpenId) {
+      query.andWhere('log.senderOpenId = :senderOpenId', { senderOpenId })
+    }
+    if (before) {
+      query.andWhere('log.createdAt < :before', { before })
+    }
+    if (cursor) {
+      query.andWhere(
+        new Brackets((cursorQuery) => {
+          cursorQuery
+            .where('log.createdAt < :cursorCreatedAt', { cursorCreatedAt: cursor.createdAt })
+            .orWhere('(log.createdAt = :cursorCreatedAt AND log.id < :cursorId)', {
+              cursorCreatedAt: cursor.createdAt,
+              cursorId: cursor.id
+            })
+        })
+      )
+    }
+    if (lowerBound) {
+      query.andWhere('log.createdAt > :lowerBound', { lowerBound })
+    }
+    if (excluded.length) {
+      query.andWhere('log.id NOT IN (:...excluded)', { excluded })
+    }
+    if (keyword) {
+      query.andWhere(this.buildKeywordFilter('log'), {
+        keyword: `%${escapeLikePattern(keyword)}%`
+      })
+    }
+    if (typeof input.hasAttachments === 'boolean') {
+      query.andWhere(`${input.hasAttachments ? '' : 'NOT '}${attachmentExists}`)
+    }
+    query.andWhere(
+      new Brackets((contentQuery) => {
+        contentQuery.where("NULLIF(TRIM(log.content), '') IS NOT NULL").orWhere(attachmentExists)
+      })
+    )
+    query
+      .orderBy('log.createdAt', 'DESC')
+      .addOrderBy('log.id', 'DESC')
+      .take(limit + 1)
+
+    const matched = await query.getMany()
+    const hasMore = matched.length > limit
+    const pageRows = matched.slice(0, limit)
+    const selected = [...pageRows].reverse()
+    const candidateFiles =
+      input.includeFiles && selected.length
+        ? await this.messageFileRepository.find({
+            where: this.scopedFileWhere(
+              {
+                integrationId,
+                xpertId,
+                messageLogId: In(selected.map((log) => log.id)),
+                status: 'ready'
+              },
+              input
+            ),
+            order: { createdAt: 'ASC', id: 'ASC' },
+            take: 10
+          })
+        : []
+
+    const files = input.includeFiles && selected.length ? candidateFiles.slice(0, 10) : []
+
+    return {
+      items: selected.map((log) => this.toHistoryItem(log)),
+      totalScanned: matched.length,
+      hasMore,
+      ...(hasMore && pageRows.length ? { nextCursor: encodeHistoryCursor(pageRows[pageRows.length - 1]) } : {}),
+      ...(files.length ? { files: files.map((file) => this.toInboundFile(file)) } : {})
+    }
+  }
+
+  async searchHistory(input: SearchLarkHistoryInput) {
+    return this.searchChatHistory(input)
+  }
+
+  async listMessageLogs(input: ListLarkMessageLogsInput): Promise<{
+    items: LarkMessageLogEntity[]
+    total: number
+    page: number
+    pageSize: number
+    nextCursor?: string
+  }> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const page = normalizePositiveInteger(input.page, 1, 1, Number.MAX_SAFE_INTEGER)
+    const pageSize = normalizePositiveInteger(input.pageSize, 50, 1, 200)
+    const offset = (page - 1) * pageSize
+    if (!Number.isSafeInteger(offset)) {
+      throw new Error('Requested Lark message page is too large.')
+    }
+    const search = normalizeSearch(input.search)
+    const sortBy = input.sortBy ?? 'createdAt'
+    const sortDirection = input.sortDirection === 'asc' ? 'ASC' : 'DESC'
+    const queryFingerprint = buildAdminQueryFingerprint({
+      integrationId,
+      tenantId: optionalText(input.tenantId) ?? null,
+      organizationId: optionalText(input.organizationId) ?? null,
+      scopeKey: optionalText(input.scopeKey) ?? null,
+      xpertId: optionalText(input.xpertId) ?? null,
+      direction: input.direction ?? null,
+      status: input.status ?? null,
+      search,
+      pageSize,
+      sortBy,
+      sortDirection
+    })
+    const cursor = decodeAdminMessageCursor(input.cursor, sortBy, sortDirection, queryFingerprint)
+    const query = this.messageLogRepository.createQueryBuilder('log')
+    this.applyLogScopeQuery(query, { ...input, integrationId })
+    if (input.direction) {
+      query.andWhere('log.direction = :direction', { direction: input.direction })
+    }
+    if (input.status) {
+      query.andWhere('log.status = :status', { status: input.status })
+    }
+    if (search) {
+      query.andWhere(this.buildAdminKeywordFilter('log'), {
+        keyword: `%${escapeLikePattern(search)}%`
+      })
+    }
+    if (cursor) {
+      this.applyAdminMessageCursor(query, cursor)
+    }
+    query
+      .orderBy(`log.${sortBy}`, sortDirection, 'NULLS LAST')
+      .addOrderBy('log.id', sortDirection)
+      .take(pageSize + 1)
+
+    let rows: LarkMessageLogEntity[]
+    let total: number
+    let sessionId: string
+    if (cursor) {
+      rows = await query.getMany()
+      sessionId = cursor.sessionId
+      const cachedTotal = await this.readCachedAdminTotal(sessionId, queryFingerprint)
+      if (typeof cachedTotal === 'number' && Number.isSafeInteger(cachedTotal) && cachedTotal >= 0) {
+        total = cachedTotal
+      } else {
+        const countQuery = this.messageLogRepository.createQueryBuilder('log')
+        this.applyLogScopeQuery(countQuery, { ...input, integrationId })
+        if (input.direction) {
+          countQuery.andWhere('log.direction = :direction', { direction: input.direction })
+        }
+        if (input.status) {
+          countQuery.andWhere('log.status = :status', { status: input.status })
+        }
+        if (search) {
+          countQuery.andWhere(this.buildAdminKeywordFilter('log'), {
+            keyword: `%${escapeLikePattern(search)}%`
+          })
+        }
+        total = await countQuery.getCount()
+        await this.writeCachedAdminTotal(sessionId, queryFingerprint, total)
+      }
+    } else {
+      query.skip(offset)
+      ;[rows, total] = await query.getManyAndCount()
+      sessionId = randomUUID()
+      await this.writeCachedAdminTotal(sessionId, queryFingerprint, total)
+    }
+
+    const hasMore = rows.length > pageSize
+    const items = rows.slice(0, pageSize)
+    return {
+      items,
+      total,
+      page,
+      pageSize,
+      ...(hasMore && items.length
+        ? {
+            nextCursor: encodeAdminMessageCursor(
+              items[items.length - 1],
+              sortBy,
+              sortDirection,
+              queryFingerprint,
+              sessionId
+            )
+          }
+        : {})
+    }
+  }
+
+  private async readCachedAdminTotal(sessionId: string, queryFingerprint: string): Promise<number | undefined> {
+    try {
+      return await this.cacheManager?.get<number>(adminTotalCacheKey(sessionId, queryFingerprint))
+    } catch (error) {
+      this.logger.warn(`Unable to read cached Lark admin message total: ${String(error)}`)
+      return undefined
+    }
+  }
+
+  private async writeCachedAdminTotal(
+    sessionId: string,
+    queryFingerprint: string,
+    total: number
+  ): Promise<void> {
+    try {
+      await this.cacheManager?.set(
+        adminTotalCacheKey(sessionId, queryFingerprint),
+        total,
+        ADMIN_TOTAL_CACHE_TTL_MS
+      )
+    } catch (error) {
+      this.logger.warn(`Unable to cache Lark admin message total: ${String(error)}`)
+    }
+  }
+
+  async listMessageFiles(input: {
+    integrationId: string
+    messageLogIds: string[]
+    tenantId?: string | null
+    organizationId?: string | null
+  }): Promise<LarkMessageFileEntity[]> {
+    const integrationId = requireText(input.integrationId, 'integrationId')
+    const messageLogIds = [...new Set(input.messageLogIds.map(optionalText).filter(Boolean) as string[])]
+    if (!messageLogIds.length) {
+      return []
+    }
+
+    return this.messageFileRepository.find({
+      where: this.scopedFileWhere(
+        {
+          integrationId,
+          messageLogId: In(messageLogIds)
+        },
+        input
+      ),
+      order: { createdAt: 'ASC', id: 'ASC' }
+    })
+  }
+
+  /** Delete each workspace object before removing its file row and parent message log. */
+  async cleanupExpired(input: CleanupExpiredLarkHistoryInput = {}): Promise<{
+    cutoff: Date
+    deletedLogs: number
+    deletedFiles: number
+    failedFiles: number
+    errors: string[]
+    hasMore: boolean
+    nextCursor?: { createdAt: Date; id: string }
+  }> {
+    if (input.retentionDays === 0 && !input.olderThan) {
+      return {
+        cutoff: new Date(0),
+        deletedLogs: 0,
+        deletedFiles: 0,
+        failedFiles: 0,
+        errors: [],
+        hasMore: false
+      }
+    }
+    const cutoff =
+      toDate(input.olderThan) ??
+      new Date(
+        Date.now() -
+          normalizePositiveInteger(input.retentionDays, DEFAULT_RETENTION_DAYS, 1, 36500) * 24 * 60 * 60 * 1000
+      )
+    const batchSize = normalizePositiveInteger(input.batchSize, 500, 1, 1000)
+    const afterCreatedAt = toDate(input.afterCreatedAt)
+    const afterId = optionalText(input.afterId)
+    if ((afterCreatedAt && !afterId) || (!afterCreatedAt && afterId)) {
+      throw new Error('Both afterCreatedAt and afterId are required for Lark cleanup continuation.')
+    }
+    const baseWhere = {
+      ...(optionalText(input.integrationId) ? { integrationId: optionalText(input.integrationId)! } : {})
+    }
+    const where: FindOptionsWhere<LarkMessageLogEntity> | FindOptionsWhere<LarkMessageLogEntity>[] =
+      afterCreatedAt && afterId
+        ? [
+            this.scopedLogWhere(
+              { ...baseWhere, createdAt: And(MoreThan(afterCreatedAt), LessThan(cutoff)) },
+              input
+            ),
+            this.scopedLogWhere(
+              { ...baseWhere, createdAt: afterCreatedAt, id: MoreThan(afterId) },
+              input
+            )
+          ]
+        : this.scopedLogWhere({ ...baseWhere, createdAt: LessThan(cutoff) }, input)
+    const logs = await this.messageLogRepository.find({
+      where,
+      order: { createdAt: 'ASC', id: 'ASC' },
+      take: batchSize + 1
+    })
+    const hasMore = logs.length > batchSize
+    const batch = logs.slice(0, batchSize)
+    const logIds = batch.map((log) => log.id)
+    const files = logIds.length
+      ? await this.messageFileRepository.find({
+          where: { messageLogId: In(logIds) },
+          order: { createdAt: 'ASC', id: 'ASC' }
+        })
+      : []
+    const filesByLogId = groupFilesByLogId(files)
+    let deletedLogs = 0
+    let deletedFiles = 0
+    let failedFiles = 0
+    const errors: string[] = []
+
+    for (const log of batch) {
+      let canDeleteLog = true
+      for (const file of filesByLogId.get(log.id) ?? []) {
+        try {
+          await this.deleteWorkspaceFileFirst(file)
+          await this.messageFileRepository.delete(file.id)
+          deletedFiles += 1
+        } catch (error) {
+          canDeleteLog = false
+          failedFiles += 1
+          errors.push(`${file.id}: ${getErrorMessage(error)}`)
+        }
+      }
+      if (!canDeleteLog) {
+        continue
+      }
+      await this.messageLogRepository.delete(log.id)
+      deletedLogs += 1
+    }
+
+    const lastScanned = batch[batch.length - 1]
+    return {
+      cutoff,
+      deletedLogs,
+      deletedFiles,
+      failedFiles,
+      errors,
+      hasMore,
+      ...(hasMore && lastScanned
+        ? { nextCursor: { createdAt: lastScanned.createdAt, id: lastScanned.id } }
+        : {})
+    }
+  }
+
+  private async ensureResourceRows(log: LarkMessageLogEntity, input: CaptureLarkInboundInput): Promise<void> {
+    const refs = dedupeResourceRefs(input.resourceRefs ?? [])
+    for (const ref of refs) {
+      const existing = await this.messageFileRepository.findOne({
+        where: { messageLogId: log.id, resourceKey: ref.fileKey }
+      })
+      if (existing) {
+        continue
+      }
+
+      const candidate = this.messageFileRepository.create({
+        messageLogId: log.id,
+        integrationId: log.integrationId,
+        scopeKey: log.scopeKey,
+        xpertId: log.xpertId,
+        messageId: log.messageId,
+        resourceKey: ref.fileKey,
+        resourceType: normalizeResourceType(ref.type),
+        originalName: optionalText(ref.name),
+        status: 'pending',
+        tenantId: log.tenantId,
+        organizationId: log.organizationId,
+        createdById: log.createdById,
+        updatedById: log.updatedById
+      })
+      try {
+        await this.messageFileRepository.save(candidate)
+      } catch (error) {
+        const raced = await this.messageFileRepository.findOne({
+          where: { messageLogId: log.id, resourceKey: ref.fileKey }
+        })
+        if (!raced) {
+          throw error
+        }
+      }
+    }
+  }
+
+  private async materializeOneFile(
+    client: lark.Client | undefined,
+    workspaceFiles: WorkspaceFilesApi,
+    row: LarkMessageFileEntity,
+    scope: {
+      integrationId: string
+      xpertId: string
+      tenantId?: string
+      organizationId?: string
+      maxBytes: number
+    }
+  ): Promise<LarkMessageFileEntity> {
+    const messageId = requireText(row.messageId, 'messageId')
+    row.status = 'processing'
+    row.error = null
+    await this.messageFileRepository.save(row)
+
+    if (row.filePath) {
+      return this.understandWorkspaceFile(workspaceFiles, row, scope)
+    }
+
+    if (!client) {
+      throw new Error('Lark client is required to download a message resource')
+    }
+
+    const response = (await client.im.messageResource.get({
+      params: { type: toLarkDownloadResourceType(row.resourceType) },
+      path: { message_id: messageId, file_key: row.resourceKey }
+    })) as LarkMessageResourceDownload
+    const headers = normalizeHeaders(response.headers)
+    const declaredSize = parseHeaderNumber(headers['content-length'])
+    if (declaredSize !== undefined && declaredSize > scope.maxBytes) {
+      throw new Error(fileSizeExceededMessage(declaredSize, scope.maxBytes))
+    }
+    const stream = response.getReadableStream?.()
+    if (!stream) {
+      throw new Error(`Lark resource '${row.resourceKey}' did not return a readable stream`)
+    }
+    const buffer = await readStreamAsBuffer(stream, scope.maxBytes)
+    const mimeType = optionalText(headers['content-type'])?.split(';')[0]?.trim()
+    const originalName = normalizeFileName(
+      parseContentDispositionFilename(headers['content-disposition']) ??
+        row.originalName ??
+        `${row.resourceKey}.${extensionFor(row.resourceType, mimeType)}`
+    )
+    const userId = optionalText(row.createdById)
+    const workspaceScope = {
+      tenantId: scope.tenantId,
+      userId,
+      catalog: 'xperts' as const,
+      xpertId: scope.xpertId,
+      isolateByUser: false
+    }
+    const metadata = {
+      source: 'lark_message_resource',
+      integrationId: scope.integrationId,
+      organizationId: scope.organizationId,
+      messageId,
+      messageLogId: row.messageLogId,
+      resourceKey: row.resourceKey,
+      resourceType: row.resourceType,
+      scopeKey: row.scopeKey
+    }
+    const uploaded = await workspaceFiles.uploadBuffer({
+      ...workspaceScope,
+      folder: `files/lark/${safePathSegment(scope.integrationId)}/${safePathSegment(row.messageLogId)}`,
+      fileName: originalName,
+      originalName,
+      mimeType,
+      size: buffer.byteLength,
+      buffer,
+      metadata
+    })
+
+    row.filePath = uploaded.filePath
+    row.workspacePath = uploaded.workspacePath
+    row.fileUrl = uploaded.fileUrl ?? uploaded.url ?? null
+    row.originalName = originalName
+    row.mimeType = mimeType ?? uploaded.mimeType ?? null
+    row.size = buffer.byteLength
+    row.workspaceCatalog = uploaded.catalog
+    row.workspaceScopeId = uploaded.scopeId ?? null
+    row.workspaceUserId = userId ?? null
+    row.workspaceIsolateByUser = false
+    await this.messageFileRepository.save(row)
+
+    return this.understandWorkspaceFile(workspaceFiles, row, scope, metadata)
+  }
+
+  private async understandWorkspaceFile(
+    workspaceFiles: WorkspaceFilesApi,
+    row: LarkMessageFileEntity,
+    scope: {
+      integrationId: string
+      xpertId: string
+      tenantId?: string
+      organizationId?: string
+      maxBytes: number
+    },
+    existingMetadata?: Record<string, unknown>
+  ): Promise<LarkMessageFileEntity> {
+    const filePath = requireText(row.filePath, 'filePath')
+    const originalName = normalizeFileName(row.originalName ?? filePath.split('/').pop() ?? 'lark-file')
+    const userId = optionalText(row.workspaceUserId ?? row.createdById)
+    const workspaceScope = {
+      tenantId: scope.tenantId,
+      userId,
+      catalog: (row.workspaceCatalog ?? 'xperts') as WorkspaceFileCatalog,
+      ...(row.workspaceScopeId ? { scopeId: row.workspaceScopeId } : {}),
+      xpertId: scope.xpertId,
+      isolateByUser: row.workspaceIsolateByUser ?? false
+    }
+    const metadata =
+      existingMetadata ?? {
+        source: 'lark_message_resource',
+        integrationId: scope.integrationId,
+        organizationId: scope.organizationId,
+        messageId: row.messageId,
+        messageLogId: row.messageLogId,
+        resourceKey: row.resourceKey,
+        resourceType: row.resourceType,
+        scopeKey: row.scopeKey
+      }
+    const understood = await workspaceFiles.understandFile({
+      ...workspaceScope,
+      filePath,
+      originalName,
+      mimeType: row.mimeType,
+      size: row.size,
+      fileUrl: row.fileUrl ?? undefined,
+      purpose: 'chat_attachment',
+      parseMode: 'auto',
+      metadata
+    })
+
+    row.fileAssetId = understood.fileAssetId
+    row.fileId = understood.fileId
+    row.storageFileId = understood.storageFileId ?? null
+    row.filePath = understood.filePath || filePath
+    row.workspacePath = understood.workspacePath || row.workspacePath
+    row.fileUrl = understood.fileUrl ?? understood.url ?? row.fileUrl ?? null
+    row.originalName = understood.originalName || originalName
+    row.mimeType = understood.mimeType ?? row.mimeType
+    row.size = understood.size ?? row.size
+    row.workspaceCatalog = understood.catalog ?? row.workspaceCatalog ?? 'xperts'
+    row.workspaceScopeId = understood.scopeId ?? row.workspaceScopeId ?? null
+    row.status = 'ready'
+    row.error = null
+    return this.messageFileRepository.save(row)
+  }
+
+  private applyOutboundPatch(log: LarkMessageLogEntity, input: RecordLarkOutboundInput): void {
+    log.status = input.status
+    if (input.content !== undefined) {
+      log.content = optionalText(input.content) ?? null
+    }
+    if (input.messageId !== undefined) {
+      log.messageId = optionalText(input.messageId) ?? null
+    }
+    if (input.conversationId !== undefined) {
+      log.conversationId = optionalText(input.conversationId) ?? null
+    }
+    if (input.error !== undefined) {
+      log.error = truncateText(input.error, 1024) || null
+    }
+    if (input.sentAt !== undefined || input.status === 'sent') {
+      log.sentAt = toDate(input.sentAt) ?? new Date()
+    }
+    log.updatedById = optionalText(input.createdById) ?? log.updatedById
+  }
+
+  private resolveHistoryLowerBound(
+    before: Date,
+    windowSeconds: number | null | undefined,
+    resetAt?: Date | null
+  ): Date | undefined {
+    const seconds = normalizeHistoryWindow(windowSeconds)
+    const windowStart = seconds > 0 ? new Date(before.getTime() - seconds * 1000) : undefined
+    if (windowStart && resetAt) {
+      return windowStart > resetAt ? windowStart : resetAt
+    }
+    return windowStart ?? resetAt ?? undefined
+  }
+
+  private historyDateRange(before: Date, lowerBound?: Date): FindOperator<Date> {
+    return lowerBound ? And(MoreThan(lowerBound), LessThan(before)) : LessThan(before)
+  }
+
+  private formatHistoryContext(
+    logs: LarkMessageLogEntity[],
+    filesByLogId: Map<string, LarkMessageFileEntity[]>
+  ): string | undefined {
+    const lines: string[] = []
+    for (const log of logs) {
+      const content = truncateText(log.content, MAX_CONTEXT_ITEM_CHARS)
+      const fileLines = (filesByLogId.get(log.id) ?? []).map((file) => this.formatHistoryFile(file))
+      if (!content && !fileLines.length) {
+        continue
+      }
+      const timestamp = (log.sentAt ?? log.messageCreatedAt ?? log.createdAt).toISOString()
+      const actor =
+        log.direction === 'outbound'
+          ? 'Agent'
+          : `用户${log.senderName ? `(${log.senderName})` : log.senderOpenId ? `(${log.senderOpenId})` : ''}`
+      lines.push(`[${timestamp}] ${actor}: ${content || '[历史文件]'}`)
+      lines.push(...fileLines)
+    }
+    if (!lines.length) {
+      return undefined
+    }
+    return truncateText(
+      [
+        '[历史上下文，仅供背景参考，勿当作本次用户新消息。以下内容来自本地保存的飞书消息；历史附件已关联到当前 Xpert 工作区。]',
+        ...lines
+      ].join('\n'),
+      MAX_CONTEXT_TOTAL_CHARS
+    )
+  }
+
+  private formatHistoryFile(file: LarkMessageFileEntity): string {
+    const name = truncateText(
+      file.originalName || file.workspacePath || file.filePath || file.resourceKey || 'lark-file',
+      160
+    )
+    const identifiers = [
+      file.fileAssetId ? `fileAssetId=${file.fileAssetId}` : '',
+      file.fileId ? `fileId=${file.fileId}` : '',
+      file.workspacePath ? `workspacePath=${file.workspacePath}` : '',
+      file.filePath && file.filePath !== file.workspacePath ? `filePath=${file.filePath}` : '',
+      `status=${file.status}`
+    ].filter(Boolean)
+    return `  - 历史附件: ${name}${identifiers.length ? ` (${identifiers.join(', ')})` : ''}`
+  }
+
+  private toInboundFile(row: LarkMessageFileEntity): LarkInboundFile {
+    return {
+      id: row.fileAssetId ?? row.fileId ?? row.id,
+      fileAssetId: row.fileAssetId ?? undefined,
+      fileId: row.fileId ?? undefined,
+      storageFileId: row.storageFileId ?? undefined,
+      filePath: row.filePath ?? undefined,
+      workspacePath: row.workspacePath ?? undefined,
+      fileUrl: row.fileUrl ?? undefined,
+      url: row.fileUrl ?? undefined,
+      mimeType: row.mimeType ?? undefined,
+      mimetype: row.mimeType ?? undefined,
+      originalName: row.originalName ?? undefined,
+      name: row.originalName ?? undefined,
+      fileKey: row.resourceKey,
+      size: row.size ?? undefined
+    }
+  }
+
+  private async toDispatchInboundFile(
+    workspaceFiles: WorkspaceFilesApi,
+    row: LarkMessageFileEntity
+  ): Promise<LarkInboundFile> {
+    const file = this.toInboundFile(row)
+    if (row.resourceType !== 'image') {
+      return file
+    }
+
+    const workspaceFile = await workspaceFiles.readBuffer({
+      tenantId: row.tenantId,
+      userId: row.workspaceUserId,
+      catalog: row.workspaceCatalog ?? 'xperts',
+      scopeId: row.workspaceScopeId,
+      xpertId: row.xpertId,
+      isolateByUser: row.workspaceIsolateByUser,
+      filePath: requireText(row.filePath, 'filePath')
+    })
+    const mimeType = optionalText(row.mimeType) ?? optionalText(workspaceFile.mimeType)
+    if (!mimeType?.startsWith('image/')) {
+      throw new Error(`Lark image resource '${row.resourceKey}' has invalid mime type '${mimeType ?? 'unknown'}'`)
+    }
+    const fileUrl = `data:${mimeType};base64,${workspaceFile.buffer.toString('base64')}`
+
+    return {
+      ...file,
+      fileUrl,
+      url: fileUrl,
+      mimeType,
+      mimetype: mimeType,
+      size: workspaceFile.buffer.byteLength
+    }
+  }
+
+  private toHistoryItem(log: LarkMessageLogEntity): LarkHistoryItem {
+    return {
+      id: log.id,
+      direction: log.direction,
+      status: log.status,
+      senderOpenId: log.senderOpenId ?? null,
+      senderName: log.senderName ?? null,
+      content: truncateText(log.content, MAX_CONTEXT_ITEM_CHARS),
+      messageId: log.messageId ?? null,
+      messageType: log.messageType ?? null,
+      createdAt: log.createdAt,
+      messageCreatedAt: log.messageCreatedAt ?? null,
+      sentAt: log.sentAt ?? null
+    }
+  }
+
+  private scopedLogWhere(
+    where: FindOptionsWhere<LarkMessageLogEntity>,
+    scope: { tenantId?: string | null; organizationId?: string | null }
+  ): FindOptionsWhere<LarkMessageLogEntity> {
+    return {
+      ...where,
+      ...(optionalText(scope.tenantId) ? { tenantId: optionalText(scope.tenantId)! } : {}),
+      ...(optionalText(scope.organizationId) ? { organizationId: optionalText(scope.organizationId)! } : {})
+    }
+  }
+
+  private scopedFileWhere(
+    where: FindOptionsWhere<LarkMessageFileEntity>,
+    scope: { tenantId?: string | null; organizationId?: string | null }
+  ): FindOptionsWhere<LarkMessageFileEntity> {
+    return {
+      ...where,
+      ...(optionalText(scope.tenantId) ? { tenantId: optionalText(scope.tenantId)! } : {}),
+      ...(optionalText(scope.organizationId) ? { organizationId: optionalText(scope.organizationId)! } : {})
+    }
+  }
+
+  private applyLogScopeQuery(
+    query: SelectQueryBuilder<LarkMessageLogEntity>,
+    scope: {
+      integrationId: string
+      scopeKey?: string | null
+      xpertId?: string | null
+      tenantId?: string | null
+      organizationId?: string | null
+    }
+  ): void {
+    query.where('log.integrationId = :integrationId', { integrationId: scope.integrationId })
+    if (optionalText(scope.scopeKey)) {
+      query.andWhere('log.scopeKey = :scopeKey', { scopeKey: optionalText(scope.scopeKey) })
+    }
+    if (optionalText(scope.xpertId)) {
+      query.andWhere('log.xpertId = :xpertId', { xpertId: optionalText(scope.xpertId) })
+    }
+    if (optionalText(scope.tenantId)) {
+      query.andWhere('log.tenantId = :tenantId', { tenantId: optionalText(scope.tenantId) })
+    }
+    if (optionalText(scope.organizationId)) {
+      query.andWhere('log.organizationId = :organizationId', {
+        organizationId: optionalText(scope.organizationId)
+      })
+    }
+  }
+
+  private buildKeywordFilter(alias: string): Brackets {
+    return new Brackets((query) => {
+      for (const field of ['content', 'senderName', 'senderOpenId', 'messageId', 'messageType']) {
+        const clause = `LOWER(COALESCE(${alias}.${field}, '')) LIKE :keyword ESCAPE '!'`
+        field === 'content' ? query.where(clause) : query.orWhere(clause)
+      }
+    })
+  }
+
+  private applyAdminMessageCursor(
+    query: SelectQueryBuilder<LarkMessageLogEntity>,
+    cursor: LarkAdminMessageCursor
+  ): void {
+    const field = `log.${cursor.sortBy}`
+    const idOperator = cursor.sortDirection === 'ASC' ? '>' : '<'
+    if (cursor.sortValue === null) {
+      query.andWhere(`(${field} IS NULL AND log.id ${idOperator} :adminCursorId)`, {
+        adminCursorId: cursor.id
+      })
+      return
+    }
+
+    const valueOperator = cursor.sortDirection === 'ASC' ? '>' : '<'
+    query.andWhere(
+      new Brackets((cursorQuery) => {
+        cursorQuery
+          .where(`${field} ${valueOperator} :adminCursorValue`, {
+            adminCursorValue: cursor.sortValue
+          })
+          .orWhere(`(${field} = :adminCursorValue AND log.id ${idOperator} :adminCursorId)`, {
+            adminCursorValue: cursor.sortValue,
+            adminCursorId: cursor.id
+          })
+          .orWhere(`${field} IS NULL`)
+      })
+    )
+  }
+
+  private buildAdminKeywordFilter(alias: string): Brackets {
+    return new Brackets((query) => {
+      query.where(`${buildAdminSearchExpression(alias)} LIKE :keyword ESCAPE '!'`)
+    })
+  }
+
+  private requireWorkspaceFiles(): WorkspaceFilesApi {
+    const workspaceFiles = this.runtimeCapabilities?.get(WorkspaceFilesRuntimeCapability)
+    if (!workspaceFiles) {
+      throw new Error('Platform workspace files capability is not available')
+    }
+    return workspaceFiles
+  }
+
+  private async deleteWorkspaceFileFirst(file: LarkMessageFileEntity): Promise<void> {
+    if (!file.filePath) {
+      return
+    }
+    const workspaceFiles = this.requireWorkspaceFiles()
+    try {
+      await workspaceFiles.deleteFile({
+        tenantId: file.tenantId,
+        userId: file.workspaceUserId,
+        catalog: file.workspaceCatalog ?? 'xperts',
+        scopeId: file.workspaceScopeId,
+        xpertId: file.xpertId,
+        isolateByUser: file.workspaceIsolateByUser,
+        filePath: file.filePath
+      })
+    } catch (error) {
+      if (!isMissingWorkspaceFileError(error)) {
+        throw error
+      }
+    }
+  }
+}
+
+function requireText(value: unknown, fieldName: string): string {
+  const text = optionalText(value)
+  if (!text) {
+    throw new Error(`${fieldName} is required`)
+  }
+  return text
+}
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function uniqueTexts(values: readonly unknown[]): string[] {
+  return Array.from(new Set(values.map(optionalText).filter((value): value is string => Boolean(value))))
+}
+
+function normalizeSearch(value: unknown): string | undefined {
+  return optionalText(value)?.toLocaleLowerCase()
+}
+
+function toDate(value: unknown): Date | undefined {
+  if (value instanceof Date) {
+    return Number.isFinite(value.getTime()) ? value : undefined
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const milliseconds = value > 0 && value < 10_000_000_000 ? value * 1000 : value
+    const date = new Date(milliseconds)
+    return Number.isFinite(date.getTime()) ? date : undefined
+  }
+  if (typeof value !== 'string' || !value.trim()) {
+    return undefined
+  }
+  const normalized = value.trim()
+  if (/^\d+(?:\.\d+)?$/.test(normalized)) {
+    return toDate(Number(normalized))
+  }
+  const date = new Date(normalized)
+  return Number.isFinite(date.getTime()) ? date : undefined
+}
+
+type LarkHistoryCursor = {
+  createdAt: Date
+  id: string
+}
+
+function encodeHistoryCursor(log: Pick<LarkMessageLogEntity, 'createdAt' | 'id'>): string {
+  return Buffer.from(
+    JSON.stringify({
+      createdAt: log.createdAt.toISOString(),
+      id: log.id
+    }),
+    'utf8'
+  ).toString('base64url')
+}
+
+function decodeHistoryCursor(value: unknown): LarkHistoryCursor | undefined {
+  const cursor = optionalText(value)
+  if (!cursor) {
+    return undefined
+  }
+  if (cursor.length > 1024) {
+    throw new Error('Invalid Lark history cursor.')
+  }
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Record<string, unknown>
+    const createdAt = toDate(parsed.createdAt)
+    const id = optionalText(parsed.id)
+    if (!createdAt || !id) {
+      throw new Error('missing cursor fields')
+    }
+    return { createdAt, id }
+  } catch {
+    throw new Error('Invalid Lark history cursor.')
+  }
+}
+
+function encodeAdminMessageCursor(
+  log: LarkMessageLogEntity,
+  sortBy: LarkAdminMessageSortBy,
+  sortDirection: 'ASC' | 'DESC',
+  queryFingerprint: string,
+  sessionId: string
+): string {
+  const rawValue = log[sortBy]
+  const sortValue = rawValue instanceof Date ? rawValue.toISOString() : rawValue ?? null
+  return Buffer.from(
+    JSON.stringify({
+      sortBy,
+      sortDirection,
+      sortValue,
+      id: log.id,
+      queryFingerprint,
+      sessionId
+    }),
+    'utf8'
+  ).toString('base64url')
+}
+
+function decodeAdminMessageCursor(
+  value: unknown,
+  expectedSortBy: LarkAdminMessageSortBy,
+  expectedSortDirection: 'ASC' | 'DESC',
+  expectedQueryFingerprint: string
+): LarkAdminMessageCursor | undefined {
+  const cursor = optionalText(value)
+  if (!cursor) {
+    return undefined
+  }
+  if (cursor.length > 2048) {
+    throw new Error('Invalid Lark message page cursor.')
+  }
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as Record<string, unknown>
+    const id = optionalText(parsed.id)
+    const queryFingerprint = optionalText(parsed.queryFingerprint)
+    const sessionId = optionalText(parsed.sessionId)
+    if (
+      parsed.sortBy !== expectedSortBy ||
+      parsed.sortDirection !== expectedSortDirection ||
+      !id ||
+      queryFingerprint !== expectedQueryFingerprint ||
+      !sessionId
+    ) {
+      throw new Error('cursor does not match the active sort')
+    }
+
+    let sortValue: LarkAdminMessageCursor['sortValue']
+    if (parsed.sortValue === null) {
+      sortValue = null
+    } else if (expectedSortBy === 'createdAt' || expectedSortBy === 'messageCreatedAt') {
+      const date = toDate(parsed.sortValue)
+      if (!date) {
+        throw new Error('invalid cursor date')
+      }
+      sortValue = date
+    } else if (expectedSortBy === 'botMentioned') {
+      if (typeof parsed.sortValue !== 'boolean') {
+        throw new Error('invalid cursor boolean')
+      }
+      sortValue = parsed.sortValue
+    } else {
+      const text = optionalText(parsed.sortValue)
+      if (!text) {
+        throw new Error('invalid cursor text')
+      }
+      sortValue = text
+    }
+
+    return {
+      sortBy: expectedSortBy,
+      sortDirection: expectedSortDirection,
+      sortValue,
+      id,
+      queryFingerprint,
+      sessionId
+    }
+  } catch {
+    throw new Error('Invalid Lark message page cursor.')
+  }
+}
+
+function buildAdminQueryFingerprint(value: Record<string, unknown>): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('base64url')
+}
+
+function adminTotalCacheKey(sessionId: string, queryFingerprint: string): string {
+  return `${ADMIN_TOTAL_CACHE_PREFIX}:${sessionId}:${queryFingerprint}`
+}
+
+function truncateText(value: unknown, maxLength: number): string {
+  if (typeof value !== 'string') {
+    return ''
+  }
+  const text = value.trim().replace(/\r\n/g, '\n')
+  if (text.length <= maxLength) {
+    return text
+  }
+  return `${text.slice(0, Math.max(0, maxLength - 8)).trimEnd()}...[截断]`
+}
+
+function normalizeHistoryLimit(value: unknown): number {
+  if (value === undefined || value === null || value === '') {
+    return DEFAULT_HISTORY_LIMIT
+  }
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return DEFAULT_HISTORY_LIMIT
+  }
+  return Math.min(Math.floor(numeric), MAX_HISTORY_LIMIT)
+}
+
+function normalizeHistoryWindow(value: unknown): number {
+  if (value === undefined || value === null || value === '') {
+    return DEFAULT_HISTORY_WINDOW_SECONDS
+  }
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return DEFAULT_HISTORY_WINDOW_SECONDS
+  }
+  return Math.floor(numeric)
+}
+
+function normalizeMaxFiles(value: unknown): number {
+  if (value === undefined || value === null || value === '') {
+    return DEFAULT_MAX_HISTORY_FILES
+  }
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return DEFAULT_MAX_HISTORY_FILES
+  }
+  return Math.min(Math.floor(numeric), MAX_HISTORY_FILES)
+}
+
+function normalizeMaxFileBytes(value: unknown): number {
+  const numeric = value === undefined || value === null || value === '' ? DEFAULT_MAX_FILE_SIZE_MB : Number(value)
+  const megabytes = Number.isFinite(numeric) && numeric > 0 ? numeric : DEFAULT_MAX_FILE_SIZE_MB
+  return Math.floor(megabytes * 1024 * 1024)
+}
+
+function normalizePositiveInteger(value: unknown, fallback: number, minimum: number, maximum: number): number {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    return fallback
+  }
+  return Math.min(maximum, Math.max(minimum, Math.floor(numeric)))
+}
+
+function normalizeResourceType(value: unknown): LarkMessageResourceType {
+  return value === 'image' || value === 'audio' || value === 'media' || value === 'file' ? value : 'file'
+}
+
+function dedupeResourceRefs(refs: NormalizedMessageResourceRef[]): NormalizedMessageResourceRef[] {
+  const result = new Map<string, NormalizedMessageResourceRef>()
+  for (const ref of refs) {
+    const fileKey = optionalText(ref?.fileKey)
+    if (!fileKey || result.has(fileKey)) {
+      continue
+    }
+    result.set(fileKey, { ...ref, fileKey })
+  }
+  return Array.from(result.values())
+}
+
+function groupFilesByLogId(rows: LarkMessageFileEntity[]): Map<string, LarkMessageFileEntity[]> {
+  const grouped = new Map<string, LarkMessageFileEntity[]>()
+  for (const row of rows) {
+    const bucket = grouped.get(row.messageLogId) ?? []
+    bucket.push(row)
+    grouped.set(row.messageLogId, bucket)
+  }
+  return grouped
+}
+
+function toLarkDownloadResourceType(type: LarkMessageResourceType): 'image' | 'file' {
+  return type === 'image' ? 'image' : 'file'
+}
+
+function isPermanentMaterializationError(message: string): boolean {
+  return /^file_size_exceeded:/i.test(message)
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[!%_]/g, (character) => `!${character}`)
+}
+
+function normalizeHeaders(headers: Record<string, unknown> | undefined): Record<string, string> {
+  if (!headers) {
+    return {}
+  }
+  return Object.entries(headers).reduce<Record<string, string>>((result, [key, value]) => {
+    if (Array.isArray(value)) {
+      result[key.toLowerCase()] = value.map(String).join(', ')
+    } else if (value != null) {
+      result[key.toLowerCase()] = String(value)
+    }
+    return result
+  }, {})
+}
+
+function parseHeaderNumber(value: string | undefined): number | undefined {
+  const number = Number(value)
+  return Number.isFinite(number) && number >= 0 ? number : undefined
+}
+
+function parseContentDispositionFilename(value: string | undefined): string | undefined {
+  if (!value) {
+    return undefined
+  }
+  const utf8 = value.match(/filename\*=UTF-8''([^;]+)/i)?.[1]
+  if (utf8) {
+    try {
+      return decodeURIComponent(utf8)
+    } catch {
+      return utf8
+    }
+  }
+  return value.match(/filename="?([^";]+)"?/i)?.[1]
+}
+
+function normalizeFileName(value: string): string {
+  const withoutControlCharacters = Array.from(value, (character) =>
+    character.charCodeAt(0) < 32 ? '_' : character
+  ).join('')
+  const normalized = withoutControlCharacters.replace(/[\\/:*?"<>|]/g, '_').trim()
+  return (normalized || 'lark-resource').slice(0, 240)
+}
+
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 128) || 'unknown'
+}
+
+function extensionFor(type: LarkMessageResourceType, mimeType?: string): string {
+  const mime = mimeType?.toLowerCase()
+  if (mime === 'image/jpeg') return 'jpg'
+  if (mime === 'image/png') return 'png'
+  if (mime === 'image/gif') return 'gif'
+  if (mime === 'image/webp') return 'webp'
+  if (mime === 'audio/mpeg') return 'mp3'
+  if (mime === 'audio/wav') return 'wav'
+  if (mime === 'video/mp4') return 'mp4'
+  return type === 'image' ? 'png' : type === 'audio' ? 'mp3' : type === 'media' ? 'mp4' : 'bin'
+}
+
+function fileSizeExceededMessage(size: number, maxBytes: number): string {
+  return `file_size_exceeded: Lark resource size ${size} bytes exceeds the ${maxBytes} byte limit`
+}
+
+async function readStreamAsBuffer(stream: Readable, maxBytes: number): Promise<Buffer> {
+  const chunks: Buffer[] = []
+  let total = 0
+  return new Promise<Buffer>((resolve, reject) => {
+    stream.on('data', (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      total += buffer.byteLength
+      if (total > maxBytes) {
+        stream.destroy(new Error(fileSizeExceededMessage(total, maxBytes)))
+        return
+      }
+      chunks.push(buffer)
+    })
+    stream.on('error', reject)
+    stream.on('end', () => resolve(Buffer.concat(chunks, total)))
+  })
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+function isMissingWorkspaceFileError(error: unknown): boolean {
+  const message = getErrorMessage(error).toLowerCase()
+  return message.includes('not found') || message.includes('enoent') || message.includes('404')
+}

--- a/xpertai/integrations/lark/src/lib/lark-message-semantics.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-semantics.spec.ts
@@ -1,4 +1,7 @@
-import { extractLarkSemanticMessage } from './lark-message-semantics.js'
+import {
+  extractLarkMessageResourceRefs,
+  extractLarkSemanticMessage
+} from './lark-message-semantics.js'
 
 describe('lark-message-semantics', () => {
   it('extracts semantic message from real event envelope structure', () => {
@@ -99,5 +102,37 @@ describe('lark-message-semantics', () => {
         name: 'Tom'
       })
     )
+  })
+
+  it('extracts standalone and rich-post resource references locally', () => {
+    expect(
+      extractLarkMessageResourceRefs({
+        message: {
+          message_type: 'file',
+          content: JSON.stringify({ file_key: 'file-1', file_name: 'report.pdf' })
+        }
+      })
+    ).toEqual([{ fileKey: 'file-1', type: 'file', name: 'report.pdf' }])
+
+    expect(
+      extractLarkMessageResourceRefs({
+        event: {
+          message: {
+            message_type: 'post',
+            content: JSON.stringify({
+              zh_cn: {
+                content: [
+                  [{ tag: 'img', image_key: 'img-1' }],
+                  [{ tag: 'media', file_key: 'media-1', name: 'clip.mp4' }]
+                ]
+              }
+            })
+          }
+        }
+      })
+    ).toEqual([
+      { fileKey: 'img-1', type: 'image', name: undefined },
+      { fileKey: 'media-1', type: 'file', name: 'clip.mp4' }
+    ])
   })
 })

--- a/xpertai/integrations/lark/src/lib/lark-message-semantics.ts
+++ b/xpertai/integrations/lark/src/lib/lark-message-semantics.ts
@@ -1,4 +1,11 @@
-import { LarkMentionIdentity, LarkSemanticMessage, TLarkEvent, TLarkEventMention } from './types.js'
+import {
+  LarkMentionIdentity,
+  LarkMessageResourceType,
+  LarkSemanticMessage,
+  NormalizedMessageResourceRef,
+  TLarkEvent,
+  TLarkEventMention
+} from './types.js'
 
 type TLarkEventEnvelope = {
   header?: TLarkEvent['header']
@@ -44,6 +51,79 @@ export function getLarkMessageContent(message: unknown): string | null {
   }
 
   return isRecord(message.body) ? normalizeString(message.body.content) : null
+}
+
+/**
+ * Extract stable Lark resource keys from an inbound event without calling the
+ * remote history/context API. The same parser covers standalone resources and
+ * images embedded in post messages.
+ */
+export function extractLarkMessageResourceRefs(event: unknown): NormalizedMessageResourceRef[] {
+  const payload = unwrapLarkEventPayload(event)
+  const message = payload?.message
+  const messageType = getLarkMessageType(message)
+  const rawContent = getLarkMessageContent(message)
+  if (!message || !messageType || !rawContent) {
+    return []
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(rawContent)
+  } catch {
+    return []
+  }
+
+  const refs = new Map<string, NormalizedMessageResourceRef>()
+  const visit = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(visit)
+      return
+    }
+    if (!isRecord(value)) {
+      return
+    }
+
+    const name =
+      normalizeString(value.file_name) ??
+      normalizeString(value.name) ??
+      normalizeString(value.title) ??
+      undefined
+    const candidates: Array<{ key: string; type: LarkMessageResourceType }> = []
+    const fileKey = normalizeString(value.file_key)
+    const imageKey = normalizeString(value.image_key)
+    const audioKey = normalizeString(value.audio_key)
+    const mediaKey = normalizeString(value.media_key) ?? normalizeString(value.video_key)
+    if (fileKey) {
+      candidates.push({
+        key: fileKey,
+        type: messageType === 'audio' ? 'audio' : messageType === 'media' ? 'media' : 'file'
+      })
+    }
+    if (imageKey) {
+      candidates.push({ key: imageKey, type: 'image' })
+    }
+    if (audioKey) {
+      candidates.push({ key: audioKey, type: 'audio' })
+    }
+    if (mediaKey) {
+      candidates.push({ key: mediaKey, type: 'media' })
+    }
+
+    for (const candidate of candidates) {
+      if (!refs.has(candidate.key)) {
+        refs.set(candidate.key, {
+          fileKey: candidate.key,
+          type: candidate.type,
+          name
+        })
+      }
+    }
+    Object.values(value).forEach(visit)
+  }
+
+  visit(parsed)
+  return Array.from(refs.values())
 }
 
 function collectPostInlineText(value: unknown): string[] {

--- a/xpertai/integrations/lark/src/lib/lark-send-file.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-send-file.spec.ts
@@ -1,0 +1,203 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+	const { createLarkPluginSdkMock } = require('../../../../test-utils/larkPluginSdkMock.cjs')
+	return createLarkPluginSdkMock(jest, {
+		WORKSPACE_FILES_SOURCE: 'platform.workspace.files',
+		WorkspaceFilesRuntimeCapability: Symbol.for('WorkspaceFilesRuntimeCapability')
+	})
+})
+
+import { createHash } from 'node:crypto'
+import { WORKSPACE_FILES_SOURCE } from '@xpert-ai/plugin-sdk'
+import {
+	buildLarkFileSendUuid,
+	readLarkUploadedFileKey,
+	resolveLarkSendFileFromBuffer,
+	resolveLarkSendFileFromWorkspace,
+	sanitizeLarkSendFileName,
+	toLarkSendFileMetadata
+} from './lark-send-file.js'
+
+describe('lark-send-file', () => {
+	it.each([
+		[{ filePath: 'files/report.pdf' }, 'files/report.pdf'],
+		[{ workspacePath: '/workspace/files/report.pdf' }, '/workspace/files/report.pdf'],
+		[
+			{
+				fileRef: {
+					source: WORKSPACE_FILES_SOURCE,
+					filePath: 'files/history-report.pdf',
+					workspacePath: '/workspace/files/history-report.pdf'
+				}
+			},
+			'files/history-report.pdf'
+		]
+	] as const)('reads workspace path aliases without forwarding hidden scope fields', async (descriptor, expectedPath) => {
+		const buffer = Buffer.from('workspace report')
+		const readRuntimeBuffer = jest.fn(async () => ({
+			name: 'report.pdf',
+			filePath: 'files/report.pdf',
+			workspacePath: '/workspace/files/report.pdf',
+			mimeType: 'application/pdf',
+			size: buffer.length,
+			buffer,
+			reference: {
+				source: WORKSPACE_FILES_SOURCE,
+				filePath: 'files/report.pdf',
+				workspacePath: '/workspace/files/report.pdf',
+				catalog: 'xperts',
+				scopeId: 'xpert-1'
+			}
+		}))
+
+		const result = await resolveLarkSendFileFromWorkspace(
+			{
+				...descriptor,
+				originalName: 'report.pdf',
+				// These fields are deliberately outside the typed contract and must not
+				// be forwarded to the runtime locator.
+				tenantId: 'tenant-other',
+				catalog: 'users',
+				scopeId: 'scope-other'
+			} as any,
+			{ workspaceFiles: { readRuntimeBuffer } as any }
+		)
+
+		expect(readRuntimeBuffer).toHaveBeenCalledWith({
+			path: expectedPath,
+			originalName: 'report.pdf',
+			name: undefined,
+			mimeType: undefined,
+			mimetype: undefined,
+			size: undefined
+		})
+		expect(result).toEqual(
+			expect.objectContaining({
+				buffer,
+				fileName: 'report.pdf',
+				mimeType: 'application/pdf',
+				size: buffer.length,
+				fileType: 'pdf',
+				messageType: 'file'
+			})
+		)
+	})
+
+	it.each([
+		['voice.opus', 'audio/opus', 'opus', 'audio'],
+		['video.mp4', 'video/mp4', 'mp4', 'media'],
+		['report.pdf', 'application/pdf', 'pdf', 'file'],
+		['report.doc', 'application/msword', 'doc', 'file'],
+		['sheet.xls', 'application/vnd.ms-excel', 'xls', 'file'],
+		['slides.ppt', 'application/vnd.ms-powerpoint', 'ppt', 'file'],
+		[
+			'report.docx',
+			'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+			'stream',
+			'file'
+		],
+		['image.png', 'image/png', 'stream', 'file']
+	] as const)('maps %s to Lark upload and message types', (fileName, mimeType, fileType, messageType) => {
+		const result = resolveLarkSendFileFromBuffer(Buffer.from('content'), {
+			descriptor: {
+				path: `files/${fileName}`,
+				originalName: fileName,
+				mimeType
+			}
+		})
+
+		expect(result.fileType).toBe(fileType)
+		expect(result.messageType).toBe(messageType)
+	})
+
+	it('uses actual bytes for size and SHA-256 and returns only safe metadata', () => {
+		const buffer = Buffer.from('actual file bytes')
+		const file = resolveLarkSendFileFromBuffer(buffer, {
+			descriptor: {
+				path: 'files/report.txt',
+				originalName: 'report.txt',
+				size: 999999
+			}
+		})
+
+		expect(file.size).toBe(buffer.length)
+		expect(file.sha256).toBe(createHash('sha256').update(buffer).digest('hex'))
+		expect(toLarkSendFileMetadata(file)).toEqual({
+			fileName: 'report.txt',
+			mimeType: 'text/plain',
+			size: buffer.length,
+			sha256: file.sha256,
+			messageType: 'file'
+		})
+		expect(toLarkSendFileMetadata(file)).not.toHaveProperty('buffer')
+		expect(toLarkSendFileMetadata(file)).not.toHaveProperty('fileType')
+	})
+
+	it('rejects empty, oversized, unsupported, and unsafe workspace inputs', async () => {
+		expect(() =>
+			resolveLarkSendFileFromBuffer(Buffer.alloc(0), {
+				descriptor: { path: 'files/empty.txt' }
+			})
+		).toThrow('does not support empty files')
+		expect(() =>
+			resolveLarkSendFileFromBuffer(Buffer.alloc(5), {
+				descriptor: { path: 'files/large.txt' },
+				maxBytes: 4
+			})
+		).toThrow('maximum is 4 bytes')
+
+		const readRuntimeBuffer = jest.fn()
+		for (const descriptor of [
+			{},
+			{ path: '../secret.txt' },
+			{ path: '/etc/passwd' },
+			{ path: 'C:\\secret.txt' },
+			{ path: 'https://example.com/report.pdf' },
+			{ path: 'data:text/plain;base64,SGVsbG8=' },
+			{ fileRef: { source: 'remote.file', filePath: 'files/report.pdf' } }
+		]) {
+			await expect(
+				resolveLarkSendFileFromWorkspace(descriptor as any, {
+					workspaceFiles: { readRuntimeBuffer } as any
+				})
+			).rejects.toThrow()
+		}
+		expect(readRuntimeBuffer).not.toHaveBeenCalled()
+	})
+
+	it('sanitizes portable file names', () => {
+		expect(sanitizeLarkSendFileName('../folder/bad:name?.txt')).toBe('bad_name_.txt')
+		expect(sanitizeLarkSendFileName('   ', 'fallback.txt')).toBe('fallback.txt')
+		expect(sanitizeLarkSendFileName('a'.repeat(300))).toHaveLength(250)
+	})
+
+	it('builds stable per-target UUIDs from the tool invocation', () => {
+		const input = {
+			toolCallId: 'tool-call-1',
+			integrationId: 'integration-1',
+			recipientType: 'chat_id',
+			recipientId: 'chat-1',
+			sha256: 'abc123'
+		}
+		const first = buildLarkFileSendUuid(input)
+
+		expect(first).toBe(buildLarkFileSendUuid(input))
+		expect(first).toMatch(/^lfs_[a-f0-9]+$/)
+		expect(first!.length).toBeLessThanOrEqual(50)
+		expect(
+			buildLarkFileSendUuid({
+				...input,
+				recipientId: 'chat-2'
+			})
+		).not.toBe(first)
+		expect(buildLarkFileSendUuid({ ...input, toolCallId: '' })).toBeUndefined()
+	})
+
+	it('reads direct and wrapped upload keys without exposing response data', () => {
+		expect(readLarkUploadedFileKey({ file_key: 'file-direct' })).toBe('file-direct')
+		expect(readLarkUploadedFileKey({ data: { file_key: 'file-wrapped' } })).toBe(
+			'file-wrapped'
+		)
+		expect(readLarkUploadedFileKey({ data: {} })).toBeUndefined()
+		expect(readLarkUploadedFileKey(null)).toBeUndefined()
+	})
+})

--- a/xpertai/integrations/lark/src/lib/lark-send-file.ts
+++ b/xpertai/integrations/lark/src/lib/lark-send-file.ts
@@ -1,0 +1,306 @@
+import { createHash } from 'node:crypto'
+import { extname } from 'node:path'
+import {
+	WORKSPACE_FILES_SOURCE,
+	type WorkspaceFileLocator,
+	type WorkspaceFilesApi
+} from '@xpert-ai/plugin-sdk'
+
+export const LARK_MAX_SEND_FILE_BYTES = 25 * 1024 * 1024
+
+export type LarkFileUploadType = 'opus' | 'mp4' | 'pdf' | 'doc' | 'xls' | 'ppt' | 'stream'
+export type LarkFileMessageType = 'audio' | 'media' | 'file'
+
+export type LarkSendFileReference = {
+	source?: string | null
+	filePath?: string | null
+	workspacePath?: string | null
+	originalName?: string | null
+	name?: string | null
+	mimeType?: string | null
+	size?: number | null
+}
+
+export type LarkSendFileDescriptor = {
+	path?: string | null
+	filePath?: string | null
+	workspacePath?: string | null
+	fileRef?: LarkSendFileReference | null
+	originalName?: string | null
+	name?: string | null
+	mimeType?: string | null
+	mimetype?: string | null
+	extension?: string | null
+	size?: number | null
+}
+
+export type LarkResolvedSendFile = {
+	buffer: Buffer
+	fileName: string
+	mimeType: string
+	extension?: string
+	size: number
+	sha256: string
+	fileType: LarkFileUploadType
+	messageType: LarkFileMessageType
+}
+
+export type LarkSendFileMetadata = Pick<
+	LarkResolvedSendFile,
+	'fileName' | 'mimeType' | 'size' | 'sha256' | 'messageType'
+>
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+	csv: 'text/csv',
+	doc: 'application/msword',
+	docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+	gif: 'image/gif',
+	html: 'text/html',
+	jpeg: 'image/jpeg',
+	jpg: 'image/jpeg',
+	json: 'application/json',
+	md: 'text/markdown',
+	mp4: 'video/mp4',
+	opus: 'audio/opus',
+	pdf: 'application/pdf',
+	png: 'image/png',
+	ppt: 'application/vnd.ms-powerpoint',
+	pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+	txt: 'text/plain',
+	xls: 'application/vnd.ms-excel',
+	xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+	zip: 'application/zip'
+}
+
+export async function resolveLarkSendFileFromWorkspace(
+	descriptor: LarkSendFileDescriptor,
+	options: {
+		workspaceFiles: Pick<WorkspaceFilesApi, 'readRuntimeBuffer'>
+		maxBytes?: number
+	}
+): Promise<LarkResolvedSendFile> {
+	const locator = toWorkspaceFileLocator(descriptor)
+	const file = await options.workspaceFiles.readRuntimeBuffer(locator)
+	return resolveLarkSendFileFromBuffer(file.buffer, {
+		descriptor,
+		fallbackName: file.name,
+		fallbackMimeType: file.mimeType,
+		fallbackPath: file.workspacePath || file.filePath,
+		maxBytes: options.maxBytes
+	})
+}
+
+export function resolveLarkSendFileFromBuffer(
+	buffer: Buffer,
+	options: {
+		descriptor: LarkSendFileDescriptor
+		fallbackName?: string | null
+		fallbackMimeType?: string | null
+		fallbackPath?: string | null
+		maxBytes?: number
+	}
+): LarkResolvedSendFile {
+	const maxBytes = options.maxBytes ?? LARK_MAX_SEND_FILE_BYTES
+	if (!buffer.length) {
+		throw new Error('Lark file send does not support empty files.')
+	}
+	if (buffer.length > maxBytes) {
+		throw new Error(
+			`Lark file send file is too large: ${buffer.length} bytes; maximum is ${maxBytes} bytes.`
+		)
+	}
+
+	const descriptor = options.descriptor
+	const fallbackPath = normalizeString(options.fallbackPath) || resolveDescriptorPath(descriptor)
+	const fileName = sanitizeLarkSendFileName(
+		descriptor.originalName || descriptor.name,
+		options.fallbackName || basenamePortable(fallbackPath) || 'file'
+	)
+	const extension = resolveFileExtension(fileName, fallbackPath, descriptor.extension)
+	const mimeType =
+		normalizeString(descriptor.mimeType || descriptor.mimetype) ||
+		normalizeString(options.fallbackMimeType) ||
+		(extension ? MIME_BY_EXTENSION[extension] : '') ||
+		'application/octet-stream'
+	const delivery = resolveLarkFileDelivery(extension, mimeType)
+
+	return {
+		buffer,
+		fileName,
+		mimeType,
+		...(extension ? { extension } : {}),
+		size: buffer.length,
+		sha256: createHash('sha256').update(buffer).digest('hex'),
+		...delivery
+	}
+}
+
+export function toLarkSendFileMetadata(file: LarkResolvedSendFile): LarkSendFileMetadata {
+	return {
+		fileName: file.fileName,
+		mimeType: file.mimeType,
+		size: file.size,
+		sha256: file.sha256,
+		messageType: file.messageType
+	}
+}
+
+export function buildLarkFileSendUuid(input: {
+	toolCallId?: string | null
+	integrationId: string
+	recipientType: string
+	recipientId: string
+	sha256: string
+}): string | undefined {
+	const toolCallId = normalizeString(input.toolCallId)
+	if (!toolCallId) {
+		return undefined
+	}
+	const digest = createHash('sha256')
+		.update(
+			[
+				toolCallId,
+				input.integrationId,
+				input.recipientType,
+				input.recipientId,
+				input.sha256
+			].join('\0')
+		)
+		.digest('hex')
+	return `lfs_${digest.slice(0, 46)}`
+}
+
+export function readLarkUploadedFileKey(value: unknown): string | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		return undefined
+	}
+	const record = value as Record<string, unknown>
+	const direct = normalizeString(record.file_key)
+	if (direct) {
+		return direct
+	}
+	const data = record.data
+	if (!data || typeof data !== 'object' || Array.isArray(data)) {
+		return undefined
+	}
+	return normalizeString((data as Record<string, unknown>).file_key) || undefined
+}
+
+export function sanitizeLarkSendFileName(value?: string | null, fallback?: string | null): string {
+	const raw = normalizeString(value) || normalizeString(fallback) || 'file'
+	const base = basenamePortable(raw.replace(/\0/g, ''))
+	const sanitized = base.replace(/[\\/:*?"<>|\u0000-\u001f]/g, '_').trim()
+	return sanitized.slice(0, 250) || 'file'
+}
+
+function toWorkspaceFileLocator(descriptor: LarkSendFileDescriptor): WorkspaceFileLocator {
+	const source = normalizeString(descriptor.fileRef?.source)
+	if (source && source !== WORKSPACE_FILES_SOURCE) {
+		throw new Error(`Unsupported Lark file reference source: ${source}`)
+	}
+	const path = validateWorkspaceFilePath(resolveDescriptorPath(descriptor))
+	return {
+		path,
+		originalName: descriptor.originalName,
+		name: descriptor.name,
+		mimeType: descriptor.mimeType,
+		mimetype: descriptor.mimetype,
+		size: descriptor.size
+	}
+}
+
+function resolveDescriptorPath(descriptor: LarkSendFileDescriptor): string {
+	return (
+		normalizeString(descriptor.fileRef?.filePath) ||
+		normalizeString(descriptor.fileRef?.workspacePath) ||
+		normalizeString(descriptor.path) ||
+		normalizeString(descriptor.filePath) ||
+		normalizeString(descriptor.workspacePath)
+	)
+}
+
+function validateWorkspaceFilePath(value: string): string {
+	const path = normalizeString(value)
+	if (!path) {
+		throw new Error(
+			'Lark file send requires file.path, file.filePath, file.workspacePath, or a workspace fileRef.'
+		)
+	}
+	if (path.includes('\0')) {
+		throw new Error('Lark file send path contains an invalid null byte.')
+	}
+
+	const normalized = path.replace(/\\/g, '/')
+	if (/^[a-z][a-z0-9+.-]*:/i.test(normalized)) {
+		throw new Error('Lark file send only supports files in the current Xpert workspace.')
+	}
+	if (/^[a-z]:\//i.test(normalized) || normalized.startsWith('//')) {
+		throw new Error('Lark file send does not support host absolute paths.')
+	}
+	if (normalized.startsWith('/') && !normalized.startsWith('/workspace/')) {
+		throw new Error('Lark file send does not support host absolute paths.')
+	}
+
+	const workspaceRelative = normalized.startsWith('/workspace/')
+		? normalized.slice('/workspace/'.length)
+		: normalized.replace(/^\.\//, '')
+	const segments = workspaceRelative.split('/').filter(Boolean)
+	if (!segments.length) {
+		throw new Error('Lark file send requires a file path, not the workspace root.')
+	}
+	if (segments.includes('..')) {
+		throw new Error('Lark file send path cannot escape the current workspace.')
+	}
+	return normalized
+}
+
+function resolveLarkFileDelivery(
+	extension: string | undefined,
+	mimeType: string
+): Pick<LarkResolvedSendFile, 'fileType' | 'messageType'> {
+	const normalizedMimeType = mimeType.toLowerCase()
+	if (extension === 'opus' || normalizedMimeType === 'audio/opus') {
+		return { fileType: 'opus', messageType: 'audio' }
+	}
+	if (extension === 'mp4' || normalizedMimeType === 'video/mp4') {
+		return { fileType: 'mp4', messageType: 'media' }
+	}
+	if (extension === 'pdf' || normalizedMimeType === 'application/pdf') {
+		return { fileType: 'pdf', messageType: 'file' }
+	}
+	if (extension === 'doc' || normalizedMimeType === 'application/msword') {
+		return { fileType: 'doc', messageType: 'file' }
+	}
+	if (extension === 'xls' || normalizedMimeType === 'application/vnd.ms-excel') {
+		return { fileType: 'xls', messageType: 'file' }
+	}
+	if (extension === 'ppt' || normalizedMimeType === 'application/vnd.ms-powerpoint') {
+		return { fileType: 'ppt', messageType: 'file' }
+	}
+	return { fileType: 'stream', messageType: 'file' }
+}
+
+function resolveFileExtension(
+	fileName: string,
+	fallbackPath: string,
+	explicit?: string | null
+): string | undefined {
+	const normalizedExplicit = normalizeString(explicit).replace(/^\./, '').toLowerCase()
+	if (normalizedExplicit) {
+		return normalizedExplicit
+	}
+	return (
+		extname(fileName).replace(/^\./, '').toLowerCase() ||
+		extname(fallbackPath).replace(/^\./, '').toLowerCase() ||
+		undefined
+	)
+}
+
+function basenamePortable(value?: string | null): string {
+	const normalized = normalizeString(value).replace(/\\/g, '/')
+	return normalized.split('/').filter(Boolean).pop() || ''
+}
+
+function normalizeString(value: unknown): string {
+	return typeof value === 'string' ? value.trim() : ''
+}

--- a/xpertai/integrations/lark/src/lib/lark.templates.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark.templates.spec.ts
@@ -1,0 +1,36 @@
+import { LARK_ADMIN_TEMPLATE_KEY, LARK_CONVERSATION_TEMPLATE_KEY, LARK_RUNTIME_MIDDLEWARE_NAME } from './constants.js'
+import { larkTemplates } from './lark.templates.js'
+
+describe('larkTemplates', () => {
+  it('does not attach the trigger-bound runtime to the non-triggered admin template', () => {
+    const template = larkTemplates.find((item) => item.key === LARK_ADMIN_TEMPLATE_KEY)
+
+    expect(template?.targetAppMeta?.xpert?.defaultConfig?.middlewareProviders).toEqual([])
+  })
+
+  it('uses one Lark runtime for local history, message sending, and remote messages', () => {
+    const template = larkTemplates.find((item) => item.key === LARK_CONVERSATION_TEMPLATE_KEY)
+
+    expect(template?.targetAppMeta?.xpert?.defaultConfig?.middlewareProviders).toEqual([LARK_RUNTIME_MIDDLEWARE_NAME])
+    expect(template?.dslContent).toContain('provider: LarkRuntimeMiddleware')
+    expect(template?.dslContent).toContain('required: false')
+    expect(template?.dslContent).toContain('lark_search_chat_history')
+    expect(template?.dslContent).toContain('includeFiles=true')
+    expect(template?.dslContent).toContain('lark_send_file')
+    expect(template?.dslContent).toContain('Never paste a local path or workspace path')
+    expect(template?.dslContent).toContain('lark_list_messages')
+    expect(template?.dslContent).not.toContain('provider: LarkLocalHistoryMiddleware')
+    expect(template?.dslContent).not.toContain('provider: LarkNotifyMiddleware')
+    expect(template?.dslContent).not.toContain('provider: LarkConversationContextMiddleware')
+  })
+
+  it('stores unmentioned group messages with explicit local history limits', () => {
+    const template = larkTemplates.find((item) => item.key === LARK_CONVERSATION_TEMPLATE_KEY)
+
+    expect(template?.dslContent).toContain('captureUnmentionedGroupMessages: true')
+    expect(template?.dslContent).toContain('historyContextLimit: 20')
+    expect(template?.dslContent).toContain('historyContextWindowSeconds: 3600')
+    expect(template?.dslContent).toContain('historyRetentionDays: 30')
+    expect(template?.dslContent).toContain('historyAttachmentMaxSizeMb: 10')
+  })
+})

--- a/xpertai/integrations/lark/src/lib/lark.templates.ts
+++ b/xpertai/integrations/lark/src/lib/lark.templates.ts
@@ -6,13 +6,13 @@ import {
   LARK_ADMIN_TEMPLATE_KEY,
   LARK_ADMIN_VIEW_FEATURE,
   LARK_ASSISTANT_TEMPLATE_FEATURE,
-  LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME,
   LARK_CONVERSATION_TEMPLATE_KEY,
   LARK_DOCUMENT_SOURCE_FEATURE,
   LARK_FEATURE,
+  LARK_LOCAL_HISTORY_FEATURE,
   LARK_LONG_CONNECTION_FEATURE,
   LARK_MESSAGING_FEATURE,
-  LARK_NOTIFY_MIDDLEWARE_NAME,
+  LARK_RUNTIME_MIDDLEWARE_NAME,
   LARK_PLUGIN_NAME,
   LARK_TEMPLATE_PROVIDER_KEY,
   LARK_VIEW_PROVIDER_KEY
@@ -67,7 +67,7 @@ export const larkTemplates: LarkXpertTemplateContribution[] = [
           businessDomain: 'lark',
           role: 'admin',
           managedBy: 'xpert',
-          middlewareProviders: [LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME],
+          middlewareProviders: [],
           viewProvider: LARK_VIEW_PROVIDER_KEY
         }
       }
@@ -88,7 +88,7 @@ export const larkTemplates: LarkXpertTemplateContribution[] = [
     key: LARK_CONVERSATION_TEMPLATE_KEY,
     name: 'Lark Conversation Assistant',
     title: '飞书会话助手',
-    description: '通过飞书/Lark 接收消息、理解会话上下文，并自然回复或发送通知的助手模板。',
+    description: '通过飞书/Lark 接收消息、读取本地会话附件，并自然回复或发送消息与文件的助手模板。',
     category: 'Integration',
     type: XpertTypeEnum.Agent,
     targetApps: ['xpert'],
@@ -100,6 +100,7 @@ export const larkTemplates: LarkXpertTemplateContribution[] = [
           LARK_MESSAGING_FEATURE,
           LARK_LONG_CONNECTION_FEATURE,
           LARK_DOCUMENT_SOURCE_FEATURE,
+          LARK_LOCAL_HISTORY_FEATURE,
           LARK_ASSISTANT_TEMPLATE_FEATURE
         ],
         requiredPlugins: [LARK_PLUGIN_NAME],
@@ -108,7 +109,7 @@ export const larkTemplates: LarkXpertTemplateContribution[] = [
           businessDomain: 'lark',
           role: 'conversation',
           managedBy: 'xpert',
-          middlewareProviders: [LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME, LARK_NOTIFY_MIDDLEWARE_NAME],
+          middlewareProviders: [LARK_RUNTIME_MIDDLEWARE_NAME],
           viewProvider: LARK_VIEW_PROVIDER_KEY
         }
       }
@@ -119,9 +120,10 @@ export const larkTemplates: LarkXpertTemplateContribution[] = [
     startPrompts: [
       '请作为飞书会话助手，帮我自然回复当前飞书消息。',
       '请查看当前群聊最近消息，再回答用户刚才的问题。',
-      '请给刚才提到的同事发送一条简短的飞书提醒。'
+      '请给刚才提到的同事发送一条简短的飞书提醒。',
+      '请生成一份简短报告并作为文件发回当前飞书会话。'
     ],
-    releaseNotes: '创建飞书消息收发与会话上下文助手。',
+    releaseNotes: '创建飞书消息、文件收发与本地会话历史助手。',
     xpertName: '飞书会话助手',
     providerKey: LARK_TEMPLATE_PROVIDER_KEY
   } as LarkXpertTemplateContribution

--- a/xpertai/integrations/lark/src/lib/message.ts
+++ b/xpertai/integrations/lark/src/lib/message.ts
@@ -72,7 +72,7 @@ export class ChatLarkMessage extends Serializable implements ChatLarkMessageFiel
     img_key: ChatLarkMessage.logoImgKey,
     corner_radius: '30%'
   }
-  static readonly helpUrl = 'https://docs.xpertai.cn/en/ai/toolset/chatbi-toolset/bot'
+  static readonly helpUrl = 'https://docs.xpertai.cn/zh-Hans/ai/plugin/trigger/lark-trigger'
   static readonly cardConfig = {
     wide_screen_mode: true
   }

--- a/xpertai/integrations/lark/src/lib/middlewares/index.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/index.ts
@@ -1,3 +1,5 @@
 export * from './chatbi-lark.middleware.js'
 export * from './lark-conversation-context.middleware.js'
+export * from './lark-local-history.middleware.js'
 export * from './lark-notify.middleware.js'
+export * from './lark-runtime.middleware.js'

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-conversation-context.middleware.spec.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-conversation-context.middleware.spec.ts
@@ -1,9 +1,17 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  const { createLarkPluginSdkMock } = require('../../../../../test-utils/larkPluginSdkMock.cjs')
+  return createLarkPluginSdkMock(jest, {
+    AgentMiddlewareStrategy: () => (target: unknown) => target
+  })
+})
+
 import { ToolMessage } from '@langchain/core/messages'
 import { Command, getCurrentTaskInput } from '@langchain/langgraph'
 import {
   LarkConversationContextMiddleware,
   LarkConversationContextMiddlewareConfig
 } from './lark-conversation-context.middleware.js'
+import { LarkApplicationPermissionError } from '../lark-context-tool.service.js'
 
 jest.mock('@langchain/langgraph', () => {
   const actual = jest.requireActual('@langchain/langgraph')
@@ -25,6 +33,14 @@ function createBaseConfig(): LarkConversationContextMiddlewareConfig {
 }
 
 async function createFixture(config?: Partial<LarkConversationContextMiddlewareConfig>) {
+  ;(getCurrentTaskInput as jest.Mock).mockReturnValue({
+    lark_current_context: {
+      chatId: 'oc_123',
+      chatType: 'group'
+    },
+    lark_conversation_context_allowed_message_ids: ['om_1']
+  })
+
   const contextToolService = {
     listMessages: jest.fn().mockResolvedValue({
       items: [{ messageId: 'om_1', msgType: 'text', text: 'hello' }],
@@ -36,6 +52,10 @@ async function createFixture(config?: Partial<LarkConversationContextMiddlewareC
     }),
     getMessageResource: jest.fn().mockResolvedValue({
       item: { messageId: 'om_1', fileKey: 'file_1', type: 'file', name: 'report.pdf' }
+    }),
+    sendApplicationPermissionGuideCard: jest.fn().mockResolvedValue({
+      messageId: 'permission-card-1',
+      consoleUrl: 'https://open.feishu.cn/app'
     })
   }
 
@@ -71,6 +91,7 @@ function getTool(middleware: any, name: string) {
 describe('LarkConversationContextMiddleware', () => {
   afterEach(() => {
     jest.clearAllMocks()
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({})
   })
 
   it('exposes the three required Lark conversation context tools', async () => {
@@ -111,11 +132,100 @@ describe('LarkConversationContextMiddleware', () => {
       sortType: 'ByCreateTimeDesc',
       pageSize: 30,
       pageToken: undefined,
-      timeoutMs: 1000
+      timeoutMs: 1000,
+      expectedChatId: 'oc_123'
     })
     expect(result).toBeInstanceOf(Command)
     expect(result.update.lark_conversation_context_last_result.tool).toBe('lark_list_messages')
     expect(result.update.messages[0]).toBeInstanceOf(ToolMessage)
+  })
+
+  it('sends an administrator permission card and stops retrying when the app scope is missing', async () => {
+    const { middleware, contextToolService } = await createFixture({ currentChatOnly: true })
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({
+      lark_current_context: {
+        integrationId: 'integration-1',
+        chatId: 'oc_chat_current',
+        chatType: 'group'
+      }
+    })
+    contextToolService.listMessages.mockRejectedValue(
+      new LarkApplicationPermissionError(
+        99991679,
+        ['im:message.group_msg'],
+        '[lark_list_messages] missing permission'
+      )
+    )
+
+    const result = await getTool(middleware, 'lark_list_messages').invoke(
+      {},
+      { metadata: { tool_call_id: 'tool-call-permission' } }
+    )
+
+    expect(contextToolService.sendApplicationPermissionGuideCard).toHaveBeenCalledWith({
+      integrationId: 'integration-1',
+      chatId: 'oc_chat_current',
+      scopes: ['im:message.group_msg'],
+      toolCallId: 'tool-call-permission'
+    })
+    expect(result).toBeInstanceOf(Command)
+    expect(result.update.lark_conversation_context_last_result).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: 'lark_application_permission_required',
+        requiredScopes: ['im:message.group_msg'],
+        permissionGuideSent: true
+      })
+    )
+    expect((result as any).goto).toEqual(['end'])
+  })
+
+  it('keeps the agent response available when the administrator permission card cannot be sent', async () => {
+    const { middleware, contextToolService } = await createFixture({ currentChatOnly: true })
+    contextToolService.sendApplicationPermissionGuideCard.mockRejectedValue(new Error('send failed'))
+    contextToolService.listMessages.mockRejectedValue(
+      new LarkApplicationPermissionError(
+        99991679,
+        ['im:message.group_msg'],
+        '[lark_list_messages] missing permission'
+      )
+    )
+
+    const result = await getTool(middleware, 'lark_list_messages').invoke(
+      {},
+      { metadata: { tool_call_id: 'tool-call-permission-failed' } }
+    )
+
+    expect((result as any).goto).toEqual([])
+    expect(result.update.lark_conversation_context_last_result).toEqual(
+      expect.objectContaining({
+        permissionGuideSent: false,
+        permissionGuideError: 'send failed'
+      })
+    )
+  })
+
+  it('uses the trigger runtime integration before a stored middleware integration', async () => {
+    const { middleware, contextToolService } = await createFixture({
+      integrationId: 'integration-stored'
+    })
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({
+      lark_conversation_context_current_integration_id: 'integration-trigger',
+      lark_current_context: {
+        chatId: 'oc_123',
+        chatType: 'group'
+      }
+    })
+
+    await getTool(middleware, 'lark_list_messages').invoke({
+      containerIdType: 'chat',
+      containerId: 'oc_123'
+    })
+
+    expect(contextToolService.listMessages).toHaveBeenCalledWith(
+      expect.objectContaining({ integrationId: 'integration-trigger' })
+    )
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({})
   })
 
   it('routes lark_get_message_resource and respects the configured default content mode', async () => {
@@ -144,7 +254,8 @@ describe('LarkConversationContextMiddleware', () => {
       fileKey: 'file_1',
       type: 'file',
       contentMode: 'base64',
-      timeoutMs: 1000
+      timeoutMs: 1000,
+      expectedChatId: 'oc_123'
     })
     expect(result).toBeInstanceOf(Command)
     expect(result.update.messages[0]).toBeInstanceOf(ToolMessage)
@@ -178,8 +289,91 @@ describe('LarkConversationContextMiddleware', () => {
       sortType: 'ByCreateTimeDesc',
       pageSize: 20,
       pageToken: undefined,
-      timeoutMs: 1000
+      timeoutMs: 1000,
+      expectedChatId: 'oc_chat_current'
     })
     expect(result).toBeInstanceOf(Command)
+  })
+
+  it('hard-locks remote list queries to the current chat in unified runtime mode', async () => {
+    const { middleware, contextToolService } = await createFixture({
+      currentChatOnly: true
+    })
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({
+      lark_current_context: {
+        chatId: 'oc_chat_current',
+        chatType: 'group'
+      }
+    })
+
+    const listTool = getTool(middleware, 'lark_list_messages')
+    const result = await listTool.invoke({
+      containerIdType: 'chat',
+      containerId: 'oc_chat_other'
+    })
+
+    expect(listTool.schema.shape).not.toHaveProperty('containerIdType')
+    expect(listTool.schema.shape).not.toHaveProperty('containerId')
+    expect(contextToolService.listMessages).toHaveBeenCalledWith(
+      expect.objectContaining({
+        containerIdType: 'chat',
+        containerId: 'oc_chat_current',
+        expectedChatId: 'oc_chat_current'
+      })
+    )
+    expect(result.update.lark_conversation_context_allowed_message_ids).toEqual(['om_1'])
+  })
+
+  it('rejects arbitrary message ids before calling Lark in current-chat-only mode', async () => {
+    const { middleware, contextToolService } = await createFixture({
+      currentChatOnly: true
+    })
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({
+      lark_current_context: {
+        chatId: 'oc_chat_current',
+        chatType: 'group'
+      },
+      lark_conversation_context_allowed_message_ids: ['om_current']
+    })
+
+    await expect(
+      getTool(middleware, 'lark_get_message').invoke({ messageId: 'om_other_chat' })
+    ).rejects.toThrow('messageId must come from lark_list_messages for the current Lark chat')
+    await expect(
+      getTool(middleware, 'lark_get_message_resource').invoke({
+        messageId: 'om_other_chat',
+        fileKey: 'file_1',
+        type: 'file'
+      })
+    ).rejects.toThrow('messageId must come from lark_list_messages for the current Lark chat')
+    expect(contextToolService.getMessage).not.toHaveBeenCalled()
+    expect(contextToolService.getMessageResource).not.toHaveBeenCalled()
+  })
+
+  it('passes the trusted current chat to message and resource reads after listing', async () => {
+    const { middleware, contextToolService } = await createFixture({
+      currentChatOnly: true
+    })
+    ;(getCurrentTaskInput as jest.Mock).mockReturnValue({
+      lark_current_context: {
+        chatId: 'oc_chat_current',
+        chatType: 'group'
+      },
+      lark_conversation_context_allowed_message_ids: ['om_1']
+    })
+
+    await getTool(middleware, 'lark_get_message').invoke({ messageId: 'om_1' })
+    await getTool(middleware, 'lark_get_message_resource').invoke({
+      messageId: 'om_1',
+      fileKey: 'file_1',
+      type: 'file'
+    })
+
+    expect(contextToolService.getMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'om_1', expectedChatId: 'oc_chat_current' })
+    )
+    expect(contextToolService.getMessageResource).toHaveBeenCalledWith(
+      expect.objectContaining({ messageId: 'om_1', expectedChatId: 'oc_chat_current' })
+    )
   })
 })

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-conversation-context.middleware.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-conversation-context.middleware.ts
@@ -14,14 +14,21 @@ import {
 import { z } from 'zod/v3'
 import { LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME } from '../constants.js'
 import { getToolCallIdFromConfig } from '../contracts-compat.js'
-import { LarkContextToolService } from '../lark-context-tool.service.js'
+import {
+  LarkApplicationPermissionError,
+  LarkContextToolService
+} from '../lark-context-tool.service.js'
 import { iconImage } from '../types.js'
+import { resolveLarkTrustedRuntimeContext } from './lark-trusted-runtime-context.js'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const DEFAULT_PAGE_SIZE = 20
+const MAX_ALLOWED_MESSAGE_IDS = 500
 
 const middlewareConfigSchema = z.object({
   integrationId: z.string().optional().nullable(),
+  currentChatOnly: z.literal(true).optional().default(true),
+  trustedTriggerOnly: z.boolean().optional().default(false),
   defaults: z
     .object({
       timeoutMs: z.number().int().min(100).default(DEFAULT_TIMEOUT_MS),
@@ -31,12 +38,14 @@ const middlewareConfigSchema = z.object({
     .default({})
 })
 
-const middlewareStateSchema = z.object({
+export const larkConversationContextStateSchema = z.object({
   lark_conversation_context_last_result: z.record(z.any()).nullable().default(null),
+  lark_conversation_context_current_integration_id: z.string().default(''),
   lark_conversation_context_current_chat_id: z.string().default(''),
   lark_conversation_context_current_chat_type: z.string().default(''),
   lark_conversation_context_current_sender_open_id: z.string().default(''),
   lark_conversation_context_current_sender_name: z.string().default(''),
+  lark_conversation_context_allowed_message_ids: z.array(z.string()).default([]),
   lark_conversation_context_agent_guidance: z.string().default('')
 })
 
@@ -62,9 +71,21 @@ const listMessagesSchema = z.object({
     .optional()
     .nullable()
     .describe('Message order, default is descending by create time.'),
-  pageSize: z.number().int().min(1).max(100).optional().nullable().describe('Page size, default comes from middleware config.'),
+  pageSize: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .nullable()
+    .describe('Page size, default comes from middleware config.'),
   pageToken: z.string().optional().nullable().describe('Pagination token from the previous response.'),
   timeoutMs: z.number().int().min(100).optional().nullable().describe('Request timeout in milliseconds.')
+})
+
+const currentChatListMessagesSchema = listMessagesSchema.omit({
+  containerIdType: true,
+  containerId: true
 })
 
 const getMessageSchema = z.object({
@@ -92,6 +113,7 @@ const getMessageResourceSchema = z.object({
 type LarkConversationContextMiddlewareConfig = InferInteropZodInput<typeof middlewareConfigSchema>
 
 type ResolvedCurrentLarkContext = {
+  integrationId: string | null
   chatId: string | null
   chatType: string | null
   senderOpenId: string | null
@@ -201,6 +223,7 @@ function findLarkContextDeep(
 ): ResolvedCurrentLarkContext {
   if (!source || typeof source !== 'object' || maxDepth < 0) {
     return {
+      integrationId: null,
       chatId: null,
       chatType: null,
       senderOpenId: null,
@@ -211,6 +234,7 @@ function findLarkContextDeep(
   const record = source as Record<string, unknown>
   if (visited.has(record)) {
     return {
+      integrationId: null,
       chatId: null,
       chatType: null,
       senderOpenId: null,
@@ -219,6 +243,20 @@ function findLarkContextDeep(
   }
   visited.add(record)
 
+  const integrationId = resolveFirstStringByPaths(record, [
+    'sourceIntegrationId',
+    'integrationId',
+    'runtime.sourceIntegrationId',
+    'runtime.integrationId',
+    'callback.context.sourceIntegrationId',
+    'callback.context.integrationId',
+    'message.sourceIntegrationId',
+    'message.integrationId',
+    'lark_current_context.sourceIntegrationId',
+    'lark_current_context.integrationId',
+    'lark_conversation_context_current_integration_id'
+  ])
+
   const chatId = resolveFirstStringByPaths(record, [
     'chatId',
     'runtime.chatId',
@@ -226,6 +264,7 @@ function findLarkContextDeep(
     'message.chatId',
     'options.chatId',
     'lark_group_window.chatId',
+    'lark_current_context.chatId',
     'lark_conversation_context_current_chat_id'
   ])
   const chatType = resolveFirstStringByPaths(record, [
@@ -234,6 +273,7 @@ function findLarkContextDeep(
     'callback.context.chatType',
     'message.chatType',
     'options.chatType',
+    'lark_current_context.chatType',
     'lark_conversation_context_current_chat_type'
   ])
   const senderOpenId = resolveFirstStringByPaths(record, [
@@ -254,8 +294,9 @@ function findLarkContextDeep(
     'lark_current_context.senderName'
   ])
 
-  if (chatId || chatType || senderOpenId || senderName) {
+  if (integrationId || chatId || chatType || senderOpenId || senderName) {
     return {
+      integrationId,
       chatId,
       chatType,
       senderOpenId,
@@ -268,12 +309,13 @@ function findLarkContextDeep(
       continue
     }
     const nested = findLarkContextDeep(value, maxDepth - 1, visited)
-    if (nested.chatId || nested.chatType || nested.senderOpenId || nested.senderName) {
+    if (nested.integrationId || nested.chatId || nested.chatType || nested.senderOpenId || nested.senderName) {
       return nested
     }
   }
 
   return {
+    integrationId: null,
     chatId: null,
     chatType: null,
     senderOpenId: null,
@@ -283,6 +325,14 @@ function findLarkContextDeep(
 
 function resolveCurrentLarkContext(state: Record<string, unknown>): ResolvedCurrentLarkContext {
   return findLarkContextDeep(state)
+}
+
+function getAllowedMessageIds(state: Record<string, unknown>): Set<string> {
+  const values = state.lark_conversation_context_allowed_message_ids
+  if (!Array.isArray(values)) {
+    return new Set()
+  }
+  return new Set(values.map((value) => normalizeString(value)).filter((value): value is string => Boolean(value)))
 }
 
 function validateChatContainerId(containerId: string, source: ResolvedListMessagesContainer['source']) {
@@ -338,18 +388,30 @@ function resolveListMessagesContainer(
   )
 }
 
-function buildConversationContextGuidance(context: ResolvedCurrentLarkContext): string {
-  const lines = [
-    'Lark conversation context rules:',
-    '- Use lark_list_messages to inspect message history.',
-    '- If you do not explicitly specify containerIdType/containerId, default to the current Lark chat.',
-    '- In group chats, this means the current group chat.',
-    '- When the user asks who they are, what was said earlier, what this group discussed before, or why you made a judgment, inspect the current group history first.',
-    '- In group chats, you may inspect the current group context before answering context-dependent questions.',
-    '- Treat open_id values as internal identifiers. Do not present open_id as a person name in user-facing answers.',
-    "- For chat containers, use chat_id (usually starts with 'oc_'), not message_id (usually starts with 'om_').",
-    '- Only override containerIdType/containerId when the user explicitly asks about another chat or another user.'
-  ]
+function buildConversationContextGuidance(
+  context: ResolvedCurrentLarkContext,
+  currentChatOnly: boolean
+): string {
+  const lines = currentChatOnly
+    ? [
+        'Lark conversation context rules:',
+        '- Remote Lark message tools may only read the current Lark chat.',
+        '- Use lark_list_messages without a chat or user identifier to inspect the current chat history.',
+        '- Never attempt to query another chat or user container.',
+        '- lark_get_message and lark_get_message_resource only accept message ids returned by lark_list_messages for the current chat.',
+        '- Treat open_id values as internal identifiers. Do not present open_id as a person name in user-facing answers.'
+      ]
+    : [
+        'Lark conversation context rules:',
+        '- Use lark_list_messages to inspect message history.',
+        '- If you do not explicitly specify containerIdType/containerId, default to the current Lark chat.',
+        '- In group chats, this means the current group chat.',
+        '- When the user asks who they are, what was said earlier, what this group discussed before, or why you made a judgment, inspect the current group history first.',
+        '- In group chats, you may inspect the current group context before answering context-dependent questions.',
+        '- Treat open_id values as internal identifiers. Do not present open_id as a person name in user-facing answers.',
+        "- For chat containers, use chat_id (usually starts with 'oc_'), not message_id (usually starts with 'om_').",
+        '- Only override containerIdType/containerId when the user explicitly asks about another chat or another user.'
+      ]
 
   if (context.chatId) {
     lines.push(`- Current chat_id available in context: ${context.chatId}`)
@@ -377,10 +439,7 @@ function enrichCurrentSpeakerName<T>(result: T, context: ResolvedCurrentLarkCont
     }
 
     const record = { ...(value as Record<string, unknown>) }
-    if (
-      record.senderOpenId === context.senderOpenId &&
-      !normalizeString(record.senderName)
-    ) {
+    if (record.senderOpenId === context.senderOpenId && !normalizeString(record.senderName)) {
       record.senderName = context.senderName
     }
     return record
@@ -403,6 +462,7 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
 
   meta: TAgentMiddlewareMeta = {
     name: LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME,
+    builtin: true,
     icon: {
       type: 'image',
       value: iconImage
@@ -506,10 +566,52 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
 
     const parsed = data!
 
-    const requireIntegrationId = (toolName: string) => {
-      const integrationId = normalizeString(parsed.integrationId)
+    const resolveToolContext = (config: unknown, state: Record<string, unknown>): ResolvedCurrentLarkContext => {
+      const trusted = resolveLarkTrustedRuntimeContext(config)
+      const legacy = parsed.trustedTriggerOnly ? null : resolveCurrentLarkContext(state)
+      return {
+        integrationId: trusted.integrationId ?? legacy?.integrationId ?? null,
+        chatId: trusted.chatId ?? legacy?.chatId ?? null,
+        chatType: trusted.chatType ?? legacy?.chatType ?? null,
+        senderOpenId: trusted.senderOpenId ?? legacy?.senderOpenId ?? null,
+        senderName: trusted.senderName ?? legacy?.senderName ?? null
+      }
+    }
+
+    const requireCurrentChatId = (toolName: string, state: Record<string, unknown>, config: unknown) => {
+      const chatId = resolveToolContext(config, state).chatId
+      if (!chatId) {
+        throw new Error(
+          `[${toolName}] no trusted current Lark chat was found. Run this tool from a Lark-triggered conversation.`
+        )
+      }
+      validateChatContainerId(chatId, 'current-chat')
+      return chatId
+    }
+
+    const requireAllowedCurrentChatMessage = (
+      toolName: string,
+      messageId: string,
+      state: Record<string, unknown>,
+      config: unknown
+    ) => {
+      const chatId = requireCurrentChatId(toolName, state, config)
+      if (!getAllowedMessageIds(state).has(messageId)) {
+        throw new Error(
+          `[${toolName}] messageId must come from lark_list_messages for the current Lark chat.`
+        )
+      }
+      return chatId
+    }
+
+    const requireIntegrationId = (toolName: string, config: unknown) => {
+      const integrationId =
+        resolveToolContext(config, getCurrentStateSafe()).integrationId ??
+        (parsed.trustedTriggerOnly ? null : normalizeString(parsed.integrationId))
       if (!integrationId) {
-        throw new Error(`[${toolName}] integrationId is required. Configure middleware integration first.`)
+        throw new Error(
+          `[${toolName}] no trusted Lark trigger integration was found. Run this tool from a Lark-triggered conversation.`
+        )
       }
       return integrationId
     }
@@ -518,7 +620,8 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
       toolName: string,
       toolCallId: string | undefined,
       integrationId: string,
-      data: Record<string, unknown>
+      data: Record<string, unknown>,
+      stateUpdate: Record<string, unknown> = {}
     ) => {
       const result = {
         tool: toolName,
@@ -529,6 +632,7 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
 
       return new Command({
         update: {
+          ...stateUpdate,
           lark_conversation_context_last_result: result,
           messages: [
             new ToolMessage({
@@ -542,57 +646,174 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
       })
     }
 
+    const buildApplicationPermissionCommand = async (params: {
+      error: unknown
+      toolName: string
+      toolCallId?: string
+      integrationId: string
+      state: Record<string, unknown>
+      config: unknown
+    }): Promise<Command | null> => {
+      if (!(params.error instanceof LarkApplicationPermissionError)) {
+        return null
+      }
+      const chatId = resolveToolContext(params.config, params.state).chatId
+      let permissionGuideSent = false
+      let permissionGuideError: string | undefined
+      if (chatId) {
+        try {
+          await this.contextToolService.sendApplicationPermissionGuideCard({
+            integrationId: params.integrationId,
+            chatId,
+            scopes: params.error.scopes,
+            toolCallId: params.toolCallId
+          })
+          permissionGuideSent = true
+        } catch (error) {
+          permissionGuideError = error instanceof Error ? error.message : String(error)
+        }
+      } else {
+        permissionGuideError = 'No trusted current Lark chat was available for the permission guide.'
+      }
+      const result = {
+        tool: params.toolName,
+        integrationId: params.integrationId,
+        success: false,
+        error: 'lark_application_permission_required',
+        requiredScopes: params.error.scopes,
+        permissionGuideSent,
+        ...(permissionGuideError ? { permissionGuideError } : {}),
+        message: permissionGuideSent
+          ? 'An administrator permission guide card was sent to the current Lark chat. Do not retry this tool until an administrator enables the permissions and publishes the app.'
+          : 'The Lark application is missing required permissions. Ask an administrator to enable the listed scopes and publish the app before retrying.'
+      }
+      return new Command({
+        update: {
+          lark_conversation_context_last_result: result,
+          messages: [
+            new ToolMessage({
+              content: toToolMessageContent(result),
+              name: params.toolName,
+              tool_call_id: params.toolCallId,
+              status: 'success'
+            })
+          ]
+        },
+        ...(permissionGuideSent ? { goto: 'end' } : {})
+      })
+    }
+
     const tools = [
       tool(
         async (parameters, config) => {
           const toolName = 'lark_list_messages'
-          const integrationId = requireIntegrationId(toolName)
+          const integrationId = requireIntegrationId(toolName, config)
           const toolCallId = getToolCallIdFromConfig(config)
           const timeoutMs = normalizeTimeout(parameters.timeoutMs, parsed.defaults.timeoutMs)
           const state = getCurrentStateSafe()
-          const currentContext = resolveCurrentLarkContext(state)
-          const resolvedContainer = resolveListMessagesContainer(parameters, state)
+          const currentContext = resolveToolContext(config, state)
+          const listParameters: z.infer<typeof listMessagesSchema> = parameters
+          const resolvedContainer = parsed.currentChatOnly
+            ? {
+                containerIdType: 'chat' as const,
+                containerId: requireCurrentChatId(toolName, state, config),
+                source: 'current-chat' as const
+              }
+            : resolveListMessagesContainer(listParameters, state)
 
-          const result = await this.contextToolService.listMessages({
-            integrationId,
-            containerIdType: resolvedContainer.containerIdType,
-            containerId: resolvedContainer.containerId,
-            startTime: parameters.startTime,
-            endTime: parameters.endTime,
-            sortType: parameters.sortType ?? 'ByCreateTimeDesc',
-            pageSize: normalizePageSize(parameters.pageSize, parsed.defaults.pageSize),
-            pageToken: parameters.pageToken,
-            timeoutMs
-          })
+          let result: Awaited<ReturnType<LarkContextToolService['listMessages']>>
+          try {
+            result = await this.contextToolService.listMessages({
+              integrationId,
+              containerIdType: resolvedContainer.containerIdType,
+              containerId: resolvedContainer.containerId,
+              startTime: parameters.startTime,
+              endTime: parameters.endTime,
+              sortType: parameters.sortType ?? 'ByCreateTimeDesc',
+              pageSize: normalizePageSize(parameters.pageSize, parsed.defaults.pageSize),
+              pageToken: parameters.pageToken,
+              timeoutMs,
+              expectedChatId: parsed.currentChatOnly ? resolvedContainer.containerId : undefined
+            })
+          } catch (error) {
+            const permissionCommand = await buildApplicationPermissionCommand({
+              error,
+              toolName,
+              toolCallId,
+              integrationId,
+              state,
+              config
+            })
+            if (permissionCommand) {
+              return permissionCommand
+            }
+            throw error
+          }
           const enrichedResult = enrichCurrentSpeakerName(result, currentContext)
+          const allowedMessageIds = parsed.currentChatOnly
+            ? Array.from(
+                new Set([
+                  ...getAllowedMessageIds(state),
+                  ...result.items.map((item) => item.messageId).filter(Boolean)
+                ])
+              ).slice(-MAX_ALLOWED_MESSAGE_IDS)
+            : undefined
 
-          return buildCommand(toolName, toolCallId, integrationId, {
-            ...enrichedResult,
-            resolvedContainer
-          } as Record<string, unknown>)
+          return buildCommand(
+            toolName,
+            toolCallId,
+            integrationId,
+            {
+              ...enrichedResult,
+              resolvedContainer
+            } as Record<string, unknown>,
+            allowedMessageIds ? { lark_conversation_context_allowed_message_ids: allowedMessageIds } : {}
+          )
         },
         {
           name: 'lark_list_messages',
-          description:
-            "List historical messages from a Lark conversation. If containerIdType/containerId are omitted, this tool defaults to the current Lark chat. In group chats, that means the current group. Only override the container when the user explicitly asks about another chat or another user.",
-          schema: listMessagesSchema,
+          description: parsed.currentChatOnly
+            ? 'List historical messages from the current Lark chat. The chat is fixed by the trusted trigger runtime and cannot be overridden.'
+            : 'List historical messages from a Lark conversation. If containerIdType/containerId are omitted, this tool defaults to the current Lark chat. In group chats, that means the current group. Only override the container when the user explicitly asks about another chat or another user.',
+          schema: parsed.currentChatOnly ? currentChatListMessagesSchema : listMessagesSchema,
           verboseParsingErrors: true
         }
       ),
       tool(
         async (parameters, config) => {
           const toolName = 'lark_get_message'
-          const integrationId = requireIntegrationId(toolName)
+          const integrationId = requireIntegrationId(toolName, config)
           const toolCallId = getToolCallIdFromConfig(config)
           const timeoutMs = normalizeTimeout(parameters.timeoutMs, parsed.defaults.timeoutMs)
-          const currentContext = resolveCurrentLarkContext(getCurrentStateSafe())
+          const state = getCurrentStateSafe()
+          const currentContext = resolveToolContext(config, state)
+          const expectedChatId = parsed.currentChatOnly
+            ? requireAllowedCurrentChatMessage(toolName, parameters.messageId, state, config)
+            : undefined
 
-          const result = await this.contextToolService.getMessage({
-            integrationId,
-            messageId: parameters.messageId,
-            userIdType: parameters.userIdType,
-            timeoutMs
-          })
+          let result: Awaited<ReturnType<LarkContextToolService['getMessage']>>
+          try {
+            result = await this.contextToolService.getMessage({
+              integrationId,
+              messageId: parameters.messageId,
+              userIdType: parameters.userIdType,
+              timeoutMs,
+              expectedChatId
+            })
+          } catch (error) {
+            const permissionCommand = await buildApplicationPermissionCommand({
+              error,
+              toolName,
+              toolCallId,
+              integrationId,
+              state,
+              config
+            })
+            if (permissionCommand) {
+              return permissionCommand
+            }
+            throw error
+          }
 
           return buildCommand(
             toolName,
@@ -603,8 +824,9 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
         },
         {
           name: 'lark_get_message',
-          description:
-            'Fetch a single Lark message by message id and return a normalized message shape instead of the raw Lark payload.',
+          description: parsed.currentChatOnly
+            ? 'Fetch a message previously returned by lark_list_messages for the current Lark chat.'
+            : 'Fetch a single Lark message by message id and return a normalized message shape instead of the raw Lark payload.',
           schema: getMessageSchema,
           verboseParsingErrors: true
         }
@@ -612,25 +834,47 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
       tool(
         async (parameters, config) => {
           const toolName = 'lark_get_message_resource'
-          const integrationId = requireIntegrationId(toolName)
+          const integrationId = requireIntegrationId(toolName, config)
           const toolCallId = getToolCallIdFromConfig(config)
           const timeoutMs = normalizeTimeout(parameters.timeoutMs, parsed.defaults.timeoutMs)
+          const state = getCurrentStateSafe()
+          const expectedChatId = parsed.currentChatOnly
+            ? requireAllowedCurrentChatMessage(toolName, parameters.messageId, state, config)
+            : undefined
 
-          const result = await this.contextToolService.getMessageResource({
-            integrationId,
-            messageId: parameters.messageId,
-            fileKey: parameters.fileKey,
-            type: parameters.type,
-            contentMode: parameters.contentMode ?? parsed.defaults.resourceContentMode,
-            timeoutMs
-          })
+          let result: Awaited<ReturnType<LarkContextToolService['getMessageResource']>>
+          try {
+            result = await this.contextToolService.getMessageResource({
+              integrationId,
+              messageId: parameters.messageId,
+              fileKey: parameters.fileKey,
+              type: parameters.type,
+              contentMode: parameters.contentMode ?? parsed.defaults.resourceContentMode,
+              timeoutMs,
+              expectedChatId
+            })
+          } catch (error) {
+            const permissionCommand = await buildApplicationPermissionCommand({
+              error,
+              toolName,
+              toolCallId,
+              integrationId,
+              state,
+              config
+            })
+            if (permissionCommand) {
+              return permissionCommand
+            }
+            throw error
+          }
 
           return buildCommand(toolName, toolCallId, integrationId, result as unknown as Record<string, unknown>)
         },
         {
           name: 'lark_get_message_resource',
-          description:
-            'Fetch a resource referenced by a Lark message and return normalized metadata, with optional inline base64 content.',
+          description: parsed.currentChatOnly
+            ? 'Fetch a resource from a message previously returned by lark_list_messages for the current Lark chat.'
+            : 'Fetch a resource referenced by a Lark message and return normalized metadata, with optional inline base64 content.',
           schema: getMessageResourceSchema,
           verboseParsingErrors: true
         }
@@ -639,7 +883,7 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
 
     return {
       name: LARK_CONVERSATION_CONTEXT_MIDDLEWARE_NAME,
-      stateSchema: middlewareStateSchema,
+      stateSchema: larkConversationContextStateSchema,
       beforeAgent: async (state, runtime) => {
         const rootState =
           ((runtime as Record<string, unknown> | undefined)?.state as Record<string, unknown> | undefined) ?? {}
@@ -647,9 +891,10 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
           ...rootState,
           ...((state ?? {}) as Record<string, unknown>)
         })
-        const guidance = buildConversationContextGuidance(currentContext)
+        const guidance = buildConversationContextGuidance(currentContext, parsed.currentChatOnly)
 
         return {
+          lark_conversation_context_current_integration_id: currentContext.integrationId ?? '',
           lark_conversation_context_current_chat_id: currentContext.chatId ?? '',
           lark_conversation_context_current_chat_type: currentContext.chatType ?? '',
           lark_conversation_context_current_sender_open_id: currentContext.senderOpenId ?? '',
@@ -658,13 +903,20 @@ export class LarkConversationContextMiddleware implements IAgentMiddlewareStrate
         }
       },
       wrapModelCall: async (request, handler) => {
-        const guidance = normalizeString((request.state as Record<string, unknown>)?.lark_conversation_context_agent_guidance)
+        const guidance = normalizeString(
+          (request.state as Record<string, unknown>)?.lark_conversation_context_agent_guidance
+        )
         if (!guidance) {
           return handler(request)
         }
 
         const baseSystemContent = toSystemMessageText(request.systemMessage?.content).trim()
-        const mergedSystemContent = [baseSystemContent, '<lark_conversation_context_guidance>', guidance, '</lark_conversation_context_guidance>']
+        const mergedSystemContent = [
+          baseSystemContent,
+          '<lark_conversation_context_guidance>',
+          guidance,
+          '</lark_conversation_context_guidance>'
+        ]
           .filter(Boolean)
           .join('\n\n')
 

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-local-history.middleware.spec.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-local-history.middleware.spec.ts
@@ -1,0 +1,96 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+	const { createLarkPluginSdkMock } = require('../../../../../test-utils/larkPluginSdkMock.cjs')
+	const mock = createLarkPluginSdkMock(jest, {
+		AgentMiddlewareStrategy: () => (target: unknown) => target,
+		WorkspaceFilesRuntimeCapability: Symbol('WorkspaceFilesRuntimeCapability'),
+		XPERT_RUNTIME_CAPABILITIES_TOKEN: 'XPERT_RUNTIME_CAPABILITIES_TOKEN'
+	})
+	mock.RequestContext.currentTenantId.mockReturnValue('tenant-fallback')
+	mock.RequestContext.getOrganizationId.mockReturnValue('org-fallback')
+	return mock
+})
+
+import { LarkLocalHistoryMiddleware } from './lark-local-history.middleware.js'
+
+describe('LarkLocalHistoryMiddleware', () => {
+	it('uses only runtime-injected scope and returns at most ten workspace artifacts', async () => {
+		const files = Array.from({ length: 12 }, (_, index) => ({
+			id: `file-${index}`,
+			originalName: `file-${index}.txt`,
+			workspacePath: `files/file-${index}.txt`,
+			mimeType: 'text/plain'
+		}))
+		const historyService = {
+			searchChatHistory: jest.fn().mockResolvedValue({
+				items: [{ id: 'history-1', content: 'matched history' }],
+				totalScanned: 1,
+				hasMore: true,
+				nextCursor: 'next-page-cursor',
+				files
+			})
+		}
+		const middleware = new LarkLocalHistoryMiddleware(historyService as any).createMiddleware(
+			{},
+			{ xpertId: 'context-xpert' } as any
+		) as any
+		const searchTool = middleware.tools[0]
+
+		const response = await searchTool.invoke(
+			{
+				name: 'lark_search_chat_history',
+				args: { keyword: 'matched', includeFiles: true, cursor: 'current-page-cursor' },
+				id: 'tool-call-1',
+				type: 'tool_call'
+			},
+			{
+			configurable: {
+				runtimePrincipal: {
+					sourceIntegrationId: 'integration-1'
+				},
+				context: {
+						scopeKey: 'group:chat-1',
+						xpertId: 'xpert-1',
+						tenantId: 'tenant-1',
+						organizationId: 'org-1',
+						currentInboundLogIds: ['current-log']
+					}
+				}
+			}
+		)
+
+		expect(historyService.searchChatHistory).toHaveBeenCalledWith({
+			integrationId: 'integration-1',
+			scopeKey: 'group:chat-1',
+			xpertId: 'xpert-1',
+			tenantId: 'tenant-1',
+			organizationId: 'org-1',
+			keyword: 'matched',
+			direction: undefined,
+			before: undefined,
+			after: undefined,
+			cursor: 'current-page-cursor',
+			limit: undefined,
+			includeFiles: true,
+			hasAttachments: undefined,
+			excludedLogIds: ['current-log'],
+			respectContextReset: false
+		})
+		expect(response.artifact.files).toHaveLength(10)
+		expect(response.content).toContain('next-page-cursor')
+		expect(searchTool.schema.keyof().options).not.toContain('integrationId')
+		expect(searchTool.schema.keyof().options).not.toContain('scopeKey')
+	})
+
+	it('rejects calls without a runtime-injected Lark conversation scope', async () => {
+		const historyService = { searchChatHistory: jest.fn() }
+		const middleware = new LarkLocalHistoryMiddleware(historyService as any).createMiddleware(
+			{},
+			{ xpertId: 'xpert-1' } as any
+		) as any
+
+		await expect(middleware.tools[0].invoke({}, {})).rejects.toThrow(
+			'only available inside a captured Lark conversation'
+		)
+		expect(historyService.searchChatHistory).not.toHaveBeenCalled()
+	})
+})

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-local-history.middleware.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-local-history.middleware.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common'
+import { tool } from '@langchain/core/tools'
+import type { TAgentMiddlewareMeta } from '@xpert-ai/contracts'
+import {
+  AgentMiddleware,
+  AgentMiddlewareStrategy,
+  IAgentMiddlewareContext,
+  IAgentMiddlewareStrategy,
+  PromiseOrValue,
+  RequestContext
+} from '@xpert-ai/plugin-sdk'
+import { z } from 'zod/v3'
+import { LARK_LOCAL_HISTORY_MIDDLEWARE_NAME, LARK_SEARCH_CHAT_HISTORY_TOOL_NAME } from '../constants.js'
+import { LarkMessageHistoryService } from '../lark-message-history.service.js'
+import { iconImage, type LarkInboundFile } from '../types.js'
+import { resolveLarkTrustedRuntimeContext } from './lark-trusted-runtime-context.js'
+
+const searchHistorySchema = z.object({
+  keyword: z.string().optional().describe('Optional keyword contained in the stored message text.'),
+  direction: z.enum(['inbound', 'outbound', 'both']).optional().describe('Message direction. Defaults to both.'),
+  before: z.string().optional().describe('Only messages before this ISO timestamp.'),
+  after: z.string().optional().describe('Only messages after this ISO timestamp.'),
+  cursor: z.string().max(1024).optional().describe('Opaque nextCursor returned by the previous search page.'),
+  limit: z.number().int().min(1).max(100).optional().describe('Maximum messages. Defaults to 20.'),
+  includeFiles: z
+    .boolean()
+    .optional()
+    .describe('Return up to 10 ready workspace file artifacts from matched messages.'),
+  hasAttachments: z
+    .boolean()
+    .optional()
+    .describe('Filter to messages with attachments (true) or without attachments (false).')
+})
+
+type RuntimeHistoryScope = {
+  integrationId?: string
+  scopeKey?: string
+  xpertId?: string
+  tenantId?: string
+  organizationId?: string
+  excludedLogIds: string[]
+}
+
+@Injectable()
+@AgentMiddlewareStrategy(LARK_LOCAL_HISTORY_MIDDLEWARE_NAME)
+export class LarkLocalHistoryMiddleware implements IAgentMiddlewareStrategy {
+  constructor(private readonly historyService: LarkMessageHistoryService) {}
+
+  meta: TAgentMiddlewareMeta = {
+    name: LARK_LOCAL_HISTORY_MIDDLEWARE_NAME,
+    builtin: true,
+    icon: { type: 'image', value: iconImage },
+    label: {
+      en_US: 'Lark Local Message History',
+      zh_Hans: '飞书本地消息历史'
+    },
+    description: {
+      en_US: 'Search locally retained messages and workspace files for the current Lark conversation only.',
+      zh_Hans: '仅检索当前飞书会话在本地保留的消息和工作区附件。'
+    },
+    configSchema: {
+      type: 'object',
+      properties: {}
+    }
+  }
+
+  createMiddleware(_options: Record<string, never>, context: IAgentMiddlewareContext): PromiseOrValue<AgentMiddleware> {
+    return {
+      name: LARK_LOCAL_HISTORY_MIDDLEWARE_NAME,
+      tools: [
+        tool(
+          async (input, config) => {
+            const scope = this.resolveRuntimeScope(config, context)
+            if (!scope.integrationId || !scope.scopeKey || !scope.xpertId) {
+              throw new Error('lark_search_chat_history is only available inside a captured Lark conversation.')
+            }
+            const result = await this.historyService.searchChatHistory({
+              integrationId: scope.integrationId,
+              scopeKey: scope.scopeKey,
+              xpertId: scope.xpertId,
+              tenantId: scope.tenantId,
+              organizationId: scope.organizationId,
+              keyword: input.keyword,
+              direction: input.direction,
+              before: input.before,
+              after: input.after,
+              cursor: input.cursor,
+              limit: input.limit,
+              includeFiles: input.includeFiles,
+              hasAttachments: input.hasAttachments,
+              excludedLogIds: scope.excludedLogIds,
+              respectContextReset: false
+            })
+            const text = JSON.stringify({
+              items: result.items,
+              totalScanned: result.totalScanned,
+              hasMore: result.hasMore,
+              nextCursor: result.nextCursor,
+              fileCount: result.files?.length ?? 0
+            })
+            return [text, { files: (result.files ?? []).slice(0, 10).map(toFileArtifact) }]
+          },
+          {
+            name: LARK_SEARCH_CHAT_HISTORY_TOOL_NAME,
+            description:
+              'Search locally stored historical messages for the current Lark private chat or group. The conversation scope is injected by the runtime and cannot be overridden. It never calls the Lark history API or returns raw webhook payloads.',
+            schema: searchHistorySchema,
+            responseFormat: 'content_and_artifact',
+            verboseParsingErrors: true
+          }
+        )
+      ]
+    }
+  }
+
+  private resolveRuntimeScope(config: unknown, context: IAgentMiddlewareContext): RuntimeHistoryScope {
+    const trusted = resolveLarkTrustedRuntimeContext(config)
+    return {
+      integrationId: trusted.integrationId,
+      scopeKey: trusted.scopeKey,
+      xpertId: trusted.xpertId ?? normalizeString(context.xpertId),
+      tenantId: trusted.tenantId ?? RequestContext.currentTenantId() ?? undefined,
+      organizationId: trusted.organizationId ?? RequestContext.getOrganizationId() ?? undefined,
+      excludedLogIds: trusted.sourceMessageLogIds
+    }
+  }
+}
+
+function toFileArtifact(file: LarkInboundFile) {
+  return {
+    fileName: file.originalName ?? file.name ?? 'lark-history-file',
+    filePath: file.workspacePath ?? file.filePath ?? '',
+    fileUrl: file.fileUrl ?? file.url ?? '',
+    mimeType: file.mimeType ?? file.mimetype ?? 'application/octet-stream'
+  }
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.spec.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.spec.ts
@@ -1,10 +1,18 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  const { createLarkPluginSdkMock } = require('../../../../../test-utils/larkPluginSdkMock.cjs')
+  return createLarkPluginSdkMock(jest, {
+    AgentMiddlewareStrategy: () => (target: unknown) => target,
+    WORKSPACE_FILES_SOURCE: 'platform.workspace.files',
+    WorkspaceFilesRuntimeCapability: Symbol.for('WorkspaceFilesRuntimeCapability')
+  })
+})
+
 import { SystemMessage } from '@langchain/core/messages'
 import { Command } from '@langchain/langgraph'
 import * as langgraph from '@langchain/langgraph'
-import {
-  LarkNotifyMiddleware,
-  LarkNotifyMiddlewareConfig
-} from './lark-notify.middleware.js'
+import { WORKSPACE_FILES_SOURCE, WorkspaceFilesRuntimeCapability } from '@xpert-ai/plugin-sdk'
+import { LARK_SEND_FILE_TOOL_NAME } from '../constants.js'
+import { LarkNotifyMiddleware, LarkNotifyMiddlewareConfig } from './lark-notify.middleware.js'
 
 function createBaseConfig(): LarkNotifyMiddlewareConfig {
   return {
@@ -45,7 +53,7 @@ function mergeConfig(partial?: Partial<LarkNotifyMiddlewareConfig>): LarkNotifyM
   }
 }
 
-async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>) {
+async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>, context: Record<string, unknown> = {}) {
   const messageCreate = jest.fn().mockResolvedValue({
     data: {
       message_id: 'msg-default'
@@ -53,6 +61,9 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>) {
   })
   const messagePatch = jest.fn().mockResolvedValue({})
   const messageDelete = jest.fn().mockResolvedValue({})
+  const fileCreate = jest.fn().mockResolvedValue({
+    file_key: 'file-default'
+  })
   const listUsers = jest.fn().mockResolvedValue({
     data: {
       items: [
@@ -103,6 +114,9 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>) {
         patch: messagePatch,
         delete: messageDelete
       },
+      file: {
+        create: fileCreate
+      },
       chat: {
         list: listChats
       }
@@ -117,7 +131,8 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>) {
   }
 
   const larkChannel = {
-    getOrCreateLarkClientById: jest.fn().mockResolvedValue(client)
+    getOrCreateLarkClientById: jest.fn().mockResolvedValue(client),
+    assertCardPayloadSupportedByIntegrationId: jest.fn().mockResolvedValue(undefined)
   }
   const conversationService = {
     setConversation: jest.fn().mockResolvedValue(undefined)
@@ -132,7 +147,7 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>) {
     conversationService as any,
     recipientDirectoryService as any
   )
-  const middleware = await Promise.resolve(strategy.createMiddleware(mergeConfig(config), {} as any))
+  const middleware = await Promise.resolve(strategy.createMiddleware(mergeConfig(config), context as any))
 
   return {
     middleware,
@@ -140,6 +155,7 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>) {
     messageCreate,
     messagePatch,
     messageDelete,
+    fileCreate,
     listUsers,
     listChats,
     conversationService,
@@ -155,6 +171,51 @@ function getTool(middleware: any, name: string) {
   return tool
 }
 
+function createWorkspaceFiles(
+  options: {
+    content?: string
+    name?: string
+    mimeType?: string
+    filePath?: string
+  } = {}
+) {
+  const buffer = Buffer.from(options.content ?? 'workspace file content')
+  const name = options.name ?? 'report.docx'
+  const filePath = options.filePath ?? `files/${name}`
+  return {
+    buffer,
+    api: {
+      readRuntimeBuffer: jest.fn(async (_input: unknown) => ({
+        name,
+        filePath,
+        workspacePath: `/workspace/${filePath}`,
+        mimeType: options.mimeType ?? 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        size: buffer.length,
+        buffer,
+        reference: {
+          source: WORKSPACE_FILES_SOURCE,
+          filePath,
+          workspacePath: `/workspace/${filePath}`,
+          originalName: name,
+          mimeType: options.mimeType ?? 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        }
+      }))
+    }
+  }
+}
+
+function createWorkspaceContext(workspaceFiles: { readRuntimeBuffer: jest.Mock }) {
+  return {
+    xpertId: 'xpert-1',
+    conversationId: 'conversation-1',
+    runtime: {
+      capabilities: {
+        get: jest.fn((key) => (key === WorkspaceFilesRuntimeCapability ? workspaceFiles : undefined))
+      }
+    }
+  }
+}
+
 describe('LarkNotifyMiddleware', () => {
   beforeEach(() => {
     jest.restoreAllMocks()
@@ -166,6 +227,7 @@ describe('LarkNotifyMiddleware', () => {
 
     expect(middleware.tools.map((tool) => tool.name)).toEqual([
       'lark_send_text_notification',
+      LARK_SEND_FILE_TOOL_NAME,
       'lark_send_rich_notification',
       'lark_update_message',
       'lark_recall_message'
@@ -181,12 +243,344 @@ describe('LarkNotifyMiddleware', () => {
 
     expect(middleware.tools.map((tool) => tool.name)).toEqual([
       'lark_send_text_notification',
+      LARK_SEND_FILE_TOOL_NAME,
       'lark_send_rich_notification',
       'lark_update_message',
       'lark_recall_message',
       'lark_list_users',
       'lark_list_chats'
     ])
+  })
+
+  it('does not expose integration, recipient, or workspace scope overrides in the file tool schema', async () => {
+    const { middleware } = await createFixture()
+    const schemaKeys = Object.keys(getTool(middleware, LARK_SEND_FILE_TOOL_NAME).schema.shape)
+
+    expect(schemaKeys).toEqual(
+      expect.arrayContaining(['file', 'fileRef', 'path', 'filePath', 'workspacePath', 'fileName', 'mimeType'])
+    )
+    expect(schemaKeys).not.toEqual(
+      expect.arrayContaining([
+        'integrationId',
+        'chatId',
+        'recipient_id',
+        'userId',
+        'tenantId',
+        'catalog',
+        'scopeId',
+        'xpertId'
+      ])
+    )
+  })
+
+  it('uploads once and sends a workspace file to the current Lark group with runtime integration priority', async () => {
+    const workspace = createWorkspaceFiles()
+    const { middleware, larkChannel, fileCreate, messageCreate } = await createFixture(
+      {
+        integrationId: 'integration-config',
+        recipient_type: 'chat_id',
+        recipient_id: 'chat-config'
+      },
+      createWorkspaceContext(workspace.api)
+    )
+
+    const result = await getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+      {
+        file: {
+          fileRef: {
+            source: WORKSPACE_FILES_SOURCE,
+            filePath: 'files/report.docx',
+            workspacePath: '/workspace/files/report.docx',
+            tenantId: 'tenant-attacker',
+            catalog: 'users',
+            scopeId: 'scope-attacker'
+          }
+        },
+        file_name: '业务报告.docx',
+        mime_type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        integrationId: 'integration-attacker',
+        chatId: 'chat-attacker',
+        recipient_id: 'user-attacker'
+      } as any,
+      {
+        configurable: {
+          context: {
+            from: 'lark',
+            channelType: 'lark',
+            sourceIntegrationId: 'integration-runtime',
+            chatId: 'chat-runtime',
+            chatType: 'group',
+            senderOpenId: 'ou-sender'
+          }
+        },
+        metadata: {
+          tool_call_id: 'tool-file-1'
+        }
+      }
+    )
+
+    expect(larkChannel.getOrCreateLarkClientById).toHaveBeenCalledWith('integration-runtime')
+    const runtimeLocator = workspace.api.readRuntimeBuffer.mock.calls[0][0]
+    expect(runtimeLocator).toEqual(
+      expect.objectContaining({
+        path: 'files/report.docx',
+        originalName: '业务报告.docx',
+        mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+      })
+    )
+    expect(runtimeLocator).not.toHaveProperty('tenantId')
+    expect(runtimeLocator).not.toHaveProperty('catalog')
+    expect(runtimeLocator).not.toHaveProperty('scopeId')
+    expect(fileCreate).toHaveBeenCalledTimes(1)
+    expect(fileCreate).toHaveBeenCalledWith({
+      data: {
+        file_type: 'stream',
+        file_name: '业务报告.docx',
+        file: workspace.buffer
+      }
+    })
+    expect(messageCreate).toHaveBeenCalledTimes(1)
+    expect(messageCreate).toHaveBeenCalledWith({
+      params: {
+        receive_id_type: 'chat_id'
+      },
+      data: {
+        receive_id: 'chat-runtime',
+        msg_type: 'file',
+        content: JSON.stringify({ file_key: 'file-default' }),
+        uuid: expect.stringMatching(/^lfs_[a-f0-9]+$/)
+      }
+    })
+
+    const safeFile = result.update.lark_notify_last_result.file
+    expect(safeFile).toEqual({
+      fileName: '业务报告.docx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      size: workspace.buffer.length,
+      sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      messageType: 'file'
+    })
+    const serializedResult = JSON.stringify(result.update.lark_notify_last_result)
+    expect(serializedResult).not.toContain('file-default')
+    expect(serializedResult).not.toContain('/workspace/')
+    expect(serializedResult).not.toContain(workspace.buffer.toString('base64'))
+    expect(serializedResult).not.toContain('integration-runtime')
+    expect(serializedResult).not.toContain('chat-runtime')
+  })
+
+  it('falls back to the current sender open_id only for a private Lark chat without chatId', async () => {
+    const workspace = createWorkspaceFiles({ name: 'voice.opus', mimeType: 'audio/opus' })
+    const { middleware, fileCreate, messageCreate } = await createFixture(
+      {
+        integrationId: 'integration-config',
+        recipient_type: 'chat_id',
+        recipient_id: 'chat-config'
+      },
+      createWorkspaceContext(workspace.api)
+    )
+
+    await getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+      {
+        path: '/workspace/files/voice.opus'
+      },
+      {
+        configurable: {
+          runtimePrincipal: {
+            sourceIntegrationId: 'integration-runtime'
+          },
+          context: {
+            from: 'lark',
+            chatType: 'p2p',
+            senderOpenId: 'ou-current-user'
+          }
+        },
+        metadata: {
+          tool_call_id: 'tool-file-p2p'
+        }
+      }
+    )
+
+    expect(fileCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          file_type: 'opus'
+        })
+      })
+    )
+    expect(messageCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: { receive_id_type: 'open_id' },
+        data: expect.objectContaining({
+          receive_id: 'ou-current-user',
+          msg_type: 'audio'
+        })
+      })
+    )
+  })
+
+  it('does not combine a runtime chat target with a configured integration', async () => {
+    const workspace = createWorkspaceFiles()
+    const { middleware } = await createFixture(
+      {
+        integrationId: 'integration-config',
+        recipient_type: 'chat_id',
+        recipient_id: 'chat-config'
+      },
+      createWorkspaceContext(workspace.api)
+    )
+
+    await expect(
+      getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+        {
+          path: 'files/report.docx'
+        },
+        {
+          configurable: {
+            context: {
+              from: 'lark',
+              chatId: 'chat-runtime',
+              chatType: 'group'
+            }
+          }
+        }
+      )
+    ).rejects.toThrow('missing its trusted runtime integrationId')
+    expect(workspace.api.readRuntimeBuffer).not.toHaveBeenCalled()
+  })
+
+  it('uses only configured recipients for proactive file sends and reuses one upload for a batch', async () => {
+    const workspace = createWorkspaceFiles({ name: 'report.pdf', mimeType: 'application/pdf' })
+    const { middleware, fileCreate, messageCreate } = await createFixture(
+      {
+        integrationId: 'integration-config',
+        recipient_type: 'chat_id',
+        recipient_id: '{{runtime.chatIds}}'
+      },
+      createWorkspaceContext(workspace.api)
+    )
+    jest.spyOn(langgraph, 'getCurrentTaskInput').mockReturnValue({
+      runtime: {
+        chatIds: ['chat-ok', 'chat-failed']
+      }
+    } as any)
+    messageCreate.mockImplementation(({ data }) => {
+      if (data.receive_id === 'chat-failed') {
+        return Promise.reject(new Error('mock send failure'))
+      }
+      return Promise.resolve({
+        data: {
+          message_id: 'message-ok'
+        }
+      })
+    })
+
+    const result = await getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+      {
+        filePath: 'files/report.pdf'
+      },
+      {
+        metadata: {
+          tool_call_id: 'tool-file-batch'
+        }
+      }
+    )
+
+    expect(workspace.api.readRuntimeBuffer).toHaveBeenCalledTimes(1)
+    expect(fileCreate).toHaveBeenCalledTimes(1)
+    expect(messageCreate).toHaveBeenCalledTimes(2)
+    expect(messageCreate.mock.calls.map(([request]) => request.data.uuid)).toHaveLength(2)
+    expect(messageCreate.mock.calls[0][0].data.uuid).not.toBe(messageCreate.mock.calls[1][0].data.uuid)
+    expect(result.update.lark_notify_last_result).toEqual(
+      expect.objectContaining({
+        successCount: 1,
+        failureCount: 1,
+        results: expect.arrayContaining([
+          expect.objectContaining({ index: 1, success: true, messageId: 'message-ok' }),
+          expect.objectContaining({ index: 2, success: false, error: 'mock send failure' })
+        ])
+      })
+    )
+    expect(result.update.lark_notify_last_result.results.every((item) => item.target === undefined)).toBe(true)
+  })
+
+  it('does not let file tool arguments select a Lark target', async () => {
+    const workspace = createWorkspaceFiles()
+    const { middleware } = await createFixture(
+      {
+        integrationId: 'integration-config',
+        recipient_type: null,
+        recipient_id: null
+      },
+      createWorkspaceContext(workspace.api)
+    )
+
+    await expect(
+      getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke({
+        path: 'files/report.docx',
+        integrationId: 'integration-attacker',
+        chatId: 'chat-attacker',
+        recipient_id: 'ou-attacker',
+        userId: 'ou-attacker'
+      } as any)
+    ).rejects.toThrow('No trusted Lark file recipient was found')
+    expect(workspace.api.readRuntimeBuffer).not.toHaveBeenCalled()
+  })
+
+  it('fails before upload when workspace capability is missing', async () => {
+    const { middleware, larkChannel, fileCreate, messageCreate } = await createFixture()
+
+    await expect(
+      getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+        {
+          path: 'files/report.docx'
+        },
+        {
+          configurable: {
+            context: {
+              sourceIntegrationId: 'integration-runtime',
+              chatId: 'chat-runtime',
+              chatType: 'group'
+            }
+          }
+        }
+      )
+    ).rejects.toThrow('platform.workspace.files runtime capability is required')
+    expect(larkChannel.getOrCreateLarkClientById).not.toHaveBeenCalled()
+    expect(fileCreate).not.toHaveBeenCalled()
+    expect(messageCreate).not.toHaveBeenCalled()
+  })
+
+  it('does not send when upload fails or returns no file_key', async () => {
+    const workspace = createWorkspaceFiles()
+    const { middleware, fileCreate, messageCreate } = await createFixture(
+      undefined,
+      createWorkspaceContext(workspace.api)
+    )
+    const sendFile = getTool(middleware, LARK_SEND_FILE_TOOL_NAME)
+    const runtimeConfig = {
+      configurable: {
+        context: {
+          sourceIntegrationId: 'integration-runtime',
+          chatId: 'chat-runtime',
+          chatType: 'group'
+        }
+      },
+      metadata: {
+        tool_call_id: 'tool-file-upload'
+      }
+    }
+
+    fileCreate.mockRejectedValueOnce(new Error('mock upload failure'))
+    await expect(sendFile.invoke({ path: 'files/report.docx' }, runtimeConfig)).rejects.toThrow(
+      "Failed to upload 'report.docx'"
+    )
+    expect(messageCreate).not.toHaveBeenCalled()
+
+    fileCreate.mockResolvedValueOnce({})
+    await expect(sendFile.invoke({ path: 'files/report.docx' }, runtimeConfig)).rejects.toThrow(
+      'did not return file_key'
+    )
+    expect(messageCreate).not.toHaveBeenCalled()
   })
 
   it('resolves recipient_name from callback context directory key', async () => {
@@ -243,6 +637,21 @@ describe('LarkNotifyMiddleware', () => {
     )
   })
 
+  it('uses the trigger runtime integration before a stored notification integration', async () => {
+    const { middleware, larkChannel } = await createFixture({
+      integrationId: 'integration-stored',
+      recipient_type: 'chat_id',
+      recipient_id: 'chat-current'
+    })
+    jest.spyOn(langgraph, 'getCurrentTaskInput').mockReturnValue({
+      lark_conversation_context_current_integration_id: 'integration-trigger'
+    } as any)
+
+    await getTool(middleware, 'lark_send_text_notification').invoke({ content: 'hello' })
+
+    expect(larkChannel.getOrCreateLarkClientById).toHaveBeenCalledWith('integration-trigger')
+  })
+
   it('asks user to mention first when recipient_name is missing from directory', async () => {
     const { middleware, recipientDirectoryService } = await createFixture({
       recipient_id: null,
@@ -265,7 +674,7 @@ describe('LarkNotifyMiddleware', () => {
         recipient_name: 'Unknown User',
         content: 'hello'
       })
-    ).rejects.toThrow('请先在群里 @ Unknown User 一次')
+    ).rejects.toThrow('请先让用户在当前会话中 @ Unknown User')
   })
 
   it('resolves recipient_name when recipientDirectoryKey is nested under an agent channel state', async () => {
@@ -891,7 +1300,7 @@ describe('LarkNotifyMiddleware', () => {
       typeof middleware.beforeAgent === 'function' ? middleware.beforeAgent : middleware.beforeAgent?.hook
     expect(beforeAgent).toBeDefined()
 
-    const stateUpdate = await beforeAgent?.(
+    const stateUpdate = (await beforeAgent?.(
       {
         lark_notify_known_recipients_summary: '',
         lark_notify_agent_guidance: ''
@@ -905,12 +1314,16 @@ describe('LarkNotifyMiddleware', () => {
           }
         }
       } as any
-    )
+    )) as any
 
     expect(recipientDirectoryService.get).toHaveBeenCalledWith('lark:recipient-dir:integration-1:chat:chat-1')
     expect(stateUpdate?.lark_notify_known_recipients_summary).toContain('Tom Jerry')
     expect(stateUpdate?.lark_notify_known_recipients_summary).toContain('Alice')
-    expect(stateUpdate?.lark_notify_agent_guidance).toContain('Do not call lark_list_users as the default discovery step.')
+    expect(stateUpdate?.lark_notify_agent_guidance).toContain(
+      'Do not call lark_list_users as the default discovery step.'
+    )
+    expect(stateUpdate?.lark_notify_agent_guidance).toContain('Use lark_send_file')
+    expect(stateUpdate?.lark_notify_agent_guidance).toContain('Never paste a local or workspace path')
     expect(stateUpdate?.lark_notify_recipient_directory_key).toBe('lark:recipient-dir:integration-1:chat:chat-1')
 
     const handler = jest.fn().mockResolvedValue('ok')
@@ -965,6 +1378,6 @@ describe('LarkNotifyMiddleware', () => {
       getTool(noRecipients.middleware, 'lark_send_text_notification').invoke({
         content: 'no recipients'
       })
-    ).rejects.toThrow('recipients is required')
+    ).rejects.toThrow('No valid Lark recipient was found')
   })
 })

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.ts
@@ -10,17 +10,27 @@ import {
   IAgentMiddlewareContext,
   IAgentMiddlewareStrategy,
   PromiseOrValue,
+  WORKSPACE_FILES_SOURCE,
+  WorkspaceFilesRuntimeCapability,
   getErrorMessage
 } from '@xpert-ai/plugin-sdk'
 import { z } from 'zod/v3'
 import { getToolCallIdFromConfig } from '../contracts-compat.js'
 import { LarkConversationService } from '../conversation.service.js'
 import { toRecipientConversationUserKey } from '../conversation-user-key.js'
-import { LARK_NOTIFY_MIDDLEWARE_NAME } from '../constants.js'
+import { LARK_NOTIFY_MIDDLEWARE_NAME, LARK_SEND_FILE_TOOL_NAME } from '../constants.js'
 import { LarkChannelStrategy } from '../lark-channel.strategy.js'
 import { LarkRecipientDirectoryService } from '../lark-recipient-directory.service.js'
+import {
+  buildLarkFileSendUuid,
+  readLarkUploadedFileKey,
+  resolveLarkSendFileFromWorkspace,
+  toLarkSendFileMetadata,
+  type LarkSendFileDescriptor
+} from '../lark-send-file.js'
 import { iconImage } from '../types.js'
 import { toLarkApiErrorMessage } from '../utils.js'
+import { resolveLarkTrustedRuntimeContext } from './lark-trusted-runtime-context.js'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const DEFAULT_POST_LOCALE = 'en_us'
@@ -35,6 +45,7 @@ const PostLocaleSchema = z.enum(['en_us', 'zh_cn', 'ja_jp'])
 
 const middlewareConfigSchema = z.object({
   integrationId: z.string().optional().nullable(),
+  trustedTriggerOnly: z.boolean().optional().default(false),
   // recipient_type 和 recipient_id 作为中间件级默认接收人配置
   recipient_type: RecipientTypeSchema.optional().nullable().describe('Lark receive_id_type (optional)'),
   recipient_id: z.string().optional().nullable().describe('Lark receive_id value (optional)'),
@@ -57,7 +68,7 @@ const middlewareConfigSchema = z.object({
     .default({})
 })
 
-const larkNotifyStateSchema = z.object({
+export const larkNotifyStateSchema = z.object({
   lark_notify_last_result: z.record(z.any()).nullable().default(null),
   lark_notify_last_message_ids: z.array(z.string()).default([]),
   lark_notify_known_recipients_summary: z.string().default(''),
@@ -79,7 +90,13 @@ const sendTextNotificationSchema = z.object({
   recipient_names: z.array(z.string()).optional().nullable().describe(RECIPIENT_NAMES_FIELD_DESCRIPTION),
   // 兜底 ID：当中间件没有配置 recipient_id 时使用。
   // 当前 recipient_id 默认按 open_id 解释。
-  recipient_id: z.string().optional().nullable().describe('Fallback recipient ID. Prefer recipient_name first; only use recipient_id when an explicit open_id-style target is already known in configuration.'),
+  recipient_id: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      'Fallback recipient ID. Prefer recipient_name first; only use recipient_id when an explicit open_id-style target is already known in configuration.'
+    ),
   timeoutMs: z.number().int().min(100).optional().nullable().describe('Request timeout in milliseconds')
 })
 
@@ -94,7 +111,60 @@ const sendRichNotificationSchema = z.object({
   recipient_names: z.array(z.string()).optional().nullable().describe(RECIPIENT_NAMES_FIELD_DESCRIPTION),
   // 兜底 ID：当中间件没有配置 recipient_id 时使用。
   // 当前 recipient_id 默认按 open_id 解释。
-  recipient_id: z.string().optional().nullable().describe('Fallback recipient ID. Prefer recipient_name first; only use recipient_id when an explicit open_id-style target is already known in configuration.'),
+  recipient_id: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      'Fallback recipient ID. Prefer recipient_name first; only use recipient_id when an explicit open_id-style target is already known in configuration.'
+    ),
+  timeoutMs: z.number().int().min(100).optional().nullable().describe('Request timeout in milliseconds')
+})
+
+const sendFileReferenceSchema = z
+  .object({
+    source: z.literal(WORKSPACE_FILES_SOURCE).optional(),
+    filePath: z.string().optional().describe('Workspace-relative file path.'),
+    workspacePath: z.string().optional().describe('Workspace-relative file path or sandbox /workspace path alias.')
+  })
+
+const sendFileDescriptorSchema = z
+  .object({
+    path: z.string().optional().describe('Sandbox /workspace path or workspace-relative path.'),
+    filePath: z.string().optional().describe('Workspace-relative file path alias.'),
+    workspacePath: z.string().optional().describe('Workspace-relative file path or sandbox /workspace path alias.'),
+    fileRef: sendFileReferenceSchema
+      .optional()
+      .describe('Xpert workspace file reference returned by a file or history tool.'),
+    originalName: z.string().optional().describe('Filename to show in Lark.'),
+    name: z.string().optional().describe('Alias for originalName.'),
+    mimeType: z.string().optional().describe('Optional MIME type.'),
+    mimetype: z.string().optional().describe('Alias for mimeType.'),
+    extension: z.string().optional().describe('Optional file extension without a leading dot.'),
+    size: z.number().int().positive().optional().describe('Optional expected file size in bytes.')
+  })
+
+const sendFileSchema = z.object({
+  file: sendFileDescriptorSchema
+    .optional()
+    .describe('File descriptor returned by Xpert file tools or local Lark history search.'),
+  path: z.string().optional().describe('Sandbox /workspace path or workspace-relative path.'),
+  filePath: z.string().optional().describe('Workspace-relative file path alias.'),
+  workspacePath: z.string().optional().describe('Workspace-relative file path or sandbox /workspace path alias.'),
+  fileRef: sendFileReferenceSchema.optional(),
+  originalName: z.string().optional().describe('Filename to show in Lark.'),
+  original_name: z.string().optional().describe('Alias for originalName.'),
+  fileName: z.string().optional().describe('Alias for originalName.'),
+  file_name: z.string().optional().describe('Alias for originalName.'),
+  filename: z.string().optional().describe('Alias for originalName.'),
+  name: z.string().optional().describe('Alias for originalName.'),
+  mimeType: z.string().optional().describe('Optional MIME type.'),
+  mime_type: z.string().optional().describe('Alias for mimeType.'),
+  mimetype: z.string().optional().describe('Alias for mimeType.'),
+  contentType: z.string().optional().describe('Alias for mimeType.'),
+  content_type: z.string().optional().describe('Alias for mimeType.'),
+  extension: z.string().optional().describe('Optional file extension without a leading dot.'),
+  size: z.number().int().positive().optional().describe('Optional expected file size in bytes.'),
   timeoutMs: z.number().int().min(100).optional().nullable().describe('Request timeout in milliseconds')
 })
 
@@ -142,7 +212,15 @@ export type LarkNotifyResult = {
   data?: Record<string, unknown>
 }
 
-type LarkRecipient = {type: z.infer<typeof RecipientTypeSchema>; id: string}
+type LarkCommandResult = {
+  failureCount: number
+  results: Array<{
+    success: boolean
+    messageId?: string | null
+  }>
+}
+
+type LarkRecipient = { type: z.infer<typeof RecipientTypeSchema>; id: string }
 type LarkNotifyState = z.infer<typeof larkNotifyStateSchema>
 type LarkNotifyMiddlewareConfig = InferInteropZodInput<typeof middlewareConfigSchema>
 type LarkRecipientNameResolution =
@@ -256,6 +334,172 @@ function normalizeString(value: unknown): string | null {
   return trimmed ? trimmed : null
 }
 
+type LarkFileRuntimeContext = {
+  integrationId: string | null
+  chatId: string | null
+  chatType: string | null
+  senderOpenId: string | null
+}
+
+function buildLarkSendFileDescriptor(input: Record<string, unknown>): LarkSendFileDescriptor {
+  const nestedFile = isPlainObject(input.file) ? input.file : {}
+  const fileRef = readFirstRecord([nestedFile, input], ['fileRef', 'file_ref'])
+  const metadataRecords = [nestedFile, input, fileRef]
+  return {
+    path: readFirstString(metadataRecords, ['path']),
+    filePath: readFirstString(metadataRecords, ['filePath', 'file_path']),
+    workspacePath: readFirstString(metadataRecords, ['workspacePath', 'workspace_path']),
+    ...(fileRef
+      ? {
+          fileRef: {
+            source: readFirstString([fileRef], ['source']),
+            filePath: readFirstString([fileRef], ['filePath', 'file_path']),
+            workspacePath: readFirstString([fileRef], ['workspacePath', 'workspace_path']),
+            originalName: readFirstString([fileRef], ['originalName', 'original_name']),
+            name: readFirstString([fileRef], ['name']),
+            mimeType: readFirstString([fileRef], ['mimeType', 'mime_type', 'mimetype']),
+            size: readFirstNumber([fileRef], ['size'])
+          }
+        }
+      : {}),
+    originalName: readFirstString(metadataRecords, [
+      'originalName',
+      'original_name',
+      'fileName',
+      'file_name',
+      'filename'
+    ]),
+    name: readFirstString(metadataRecords, ['name']),
+    mimeType: readFirstString(metadataRecords, ['mimeType', 'mime_type', 'contentType', 'content_type']),
+    mimetype: readFirstString(metadataRecords, ['mimetype']),
+    extension: readFirstString(metadataRecords, ['extension', 'ext']),
+    size: readFirstNumber(metadataRecords, ['size'])
+  }
+}
+
+function resolveLarkFileRuntimeContext(
+  config: unknown,
+  state: Record<string, unknown>,
+  trustedTriggerOnly = false
+): LarkFileRuntimeContext {
+  const trusted = resolveLarkTrustedRuntimeContext(config)
+  if (trustedTriggerOnly) {
+    return {
+      integrationId: trusted.integrationId ?? null,
+      chatId: trusted.chatId ?? null,
+      chatType: trusted.chatType ?? null,
+      senderOpenId: trusted.senderOpenId ?? null
+    }
+  }
+  const configRecord = isPlainObject(config) ? config : {}
+  const configurable = isPlainObject(configRecord.configurable) ? configRecord.configurable : {}
+  const configurableContext = isPlainObject(configurable.context) ? configurable.context : undefined
+  const runtimePrincipal = isPlainObject(configurable.runtimePrincipal) ? configurable.runtimePrincipal : undefined
+  const metadata = isPlainObject(configRecord.metadata) ? configRecord.metadata : {}
+  const metadataContext = isPlainObject(metadata.context) ? metadata.context : undefined
+  const stateRecords = findCurrentLarkStateRecords(state)
+  const records = [configurableContext, metadataContext, runtimePrincipal, ...stateRecords]
+
+  return {
+    integrationId: readFirstString(records, ['sourceIntegrationId', 'integrationId']),
+    chatId:
+      readFirstString(records, ['chatId', 'openChatId', 'open_chat_id']) ||
+      readFirstString(stateRecords, ['lark_conversation_context_current_chat_id']),
+    chatType:
+      readFirstString(records, ['chatType', 'chat_type']) ||
+      readFirstString(stateRecords, ['lark_conversation_context_current_chat_type']),
+    senderOpenId:
+      readFirstString(records, ['senderOpenId', 'channelUserId', 'sender_open_id']) ||
+      readFirstString(stateRecords, ['lark_conversation_context_current_sender_open_id'])
+  }
+}
+
+function findCurrentLarkStateRecords(
+  source: unknown,
+  maxDepth = 4,
+  visited = new WeakSet<object>()
+): Array<Record<string, unknown>> {
+  if (!source || typeof source !== 'object' || Array.isArray(source) || maxDepth < 0) {
+    return []
+  }
+  const record = source as Record<string, unknown>
+  if (visited.has(record)) {
+    return []
+  }
+  visited.add(record)
+
+  const currentContext = isPlainObject(record.lark_current_context) ? record.lark_current_context : undefined
+  if (
+    currentContext ||
+    normalizeString(record.lark_conversation_context_current_chat_id) ||
+    normalizeString(record.lark_conversation_context_current_sender_open_id)
+  ) {
+    return currentContext ? [currentContext, record] : [record]
+  }
+
+  for (const value of Object.values(record)) {
+    const found = findCurrentLarkStateRecords(value, maxDepth - 1, visited)
+    if (found.length) {
+      return found
+    }
+  }
+  return []
+}
+
+function resolveRuntimeIntegrationId(state: Record<string, unknown>): string | null {
+  return readFirstString(
+    [state, ...findCurrentLarkStateRecords(state)],
+    ['sourceIntegrationId', 'integrationId', 'lark_conversation_context_current_integration_id']
+  )
+}
+
+function readFirstRecord(
+  records: Array<Record<string, unknown> | undefined>,
+  keys: string[]
+): Record<string, unknown> | undefined {
+  for (const record of records) {
+    if (!record) {
+      continue
+    }
+    for (const key of keys) {
+      if (isPlainObject(record[key])) {
+        return record[key] as Record<string, unknown>
+      }
+    }
+  }
+  return undefined
+}
+
+function readFirstString(records: Array<Record<string, unknown> | undefined>, keys: string[]): string | null {
+  for (const record of records) {
+    if (!record) {
+      continue
+    }
+    for (const key of keys) {
+      const value = normalizeString(record[key])
+      if (value) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
+function readFirstNumber(records: Array<Record<string, unknown> | undefined>, keys: string[]): number | null {
+  for (const record of records) {
+    if (!record) {
+      continue
+    }
+    for (const key of keys) {
+      const value = record[key]
+      if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+        return value
+      }
+    }
+  }
+  return null
+}
+
 function normalizeTimeout(value: unknown, fallback: number): number {
   const timeout = typeof value === 'number' ? value : Number(value)
   if (Number.isFinite(timeout) && timeout >= 100) {
@@ -323,10 +567,7 @@ function toSystemMessageText(content: unknown): string {
   return String(content)
 }
 
-function resolveFirstStringByPaths(
-  source: Record<string, unknown>,
-  paths: readonly string[]
-): string | null {
+function resolveFirstStringByPaths(source: Record<string, unknown>, paths: readonly string[]): string | null {
   for (const path of paths) {
     const value = getValueByPath(source, path)
     const normalized = normalizeString(value)
@@ -337,11 +578,7 @@ function resolveFirstStringByPaths(
   return null
 }
 
-function findRecipientDirectoryKeyDeep(
-  source: unknown,
-  maxDepth = 4,
-  visited = new WeakSet<object>()
-): string | null {
+function findRecipientDirectoryKeyDeep(source: unknown, maxDepth = 4, visited = new WeakSet<object>()): string | null {
   if (!source || typeof source !== 'object' || maxDepth < 0) {
     return null
   }
@@ -398,8 +635,7 @@ function normalizeRecipients(value: unknown, state: Record<string, unknown>): La
     const rawId = item.id
     const path = normalizeString(rawId)
     const resolvedValue = path ? getValueByPath(state, path) : undefined
-    const resolvedIds =
-      resolvedValue === undefined ? [] : normalizeRecipientIdValues(resolvedValue)
+    const resolvedIds = resolvedValue === undefined ? [] : normalizeRecipientIdValues(resolvedValue)
     const ids = resolvedIds.length ? resolvedIds : normalizeRecipientIdValues(rawId)
 
     ids.forEach((id) => {
@@ -428,15 +664,12 @@ function resolveStateBackedString(value: unknown, state: Record<string, unknown>
   return resolvedValues[0] ?? normalized
 }
 
-function collectMessageIds(result: LarkNotifyResult): string[] {
-  return result.results
-    .filter((item) => item.success && !!item.messageId)
-    .map((item) => item.messageId as string)
+function collectMessageIds(result: LarkCommandResult): string[] {
+  return result.results.filter((item) => item.success && !!item.messageId).map((item) => item.messageId as string)
 }
 
-function toToolMessageContent(result: LarkNotifyResult) {
-  const payload = result.data ? { ...result, data: result.data } : result
-  return JSON.stringify(payload)
+function toToolMessageContent(result: LarkCommandResult) {
+  return JSON.stringify(result)
 }
 
 function formatError(error: unknown): string {
@@ -503,15 +736,17 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
 
     const summaryNames = names.slice(0, MAX_KNOWN_RECIPIENT_SUMMARY_NAMES)
     const remainingCount = names.length - summaryNames.length
-    const suffix =
-      remainingCount > 0
-        ? ` plus ${remainingCount} more recent recipients.`
-        : '.'
+    const suffix = remainingCount > 0 ? ` plus ${remainingCount} more recent recipients.` : '.'
 
-    return `Known Lark recipients in this chat (use these exact names with recipient_name): ${summaryNames.join(', ')}${suffix}`
+    return `Known Lark recipients in this chat (use these exact names with recipient_name): ${summaryNames.join(
+      ', '
+    )}${suffix}`
   }
 
-  private formatAgentGuidance(summary: string, directory: Awaited<ReturnType<LarkRecipientDirectoryService['get']>>): string {
+  private formatAgentGuidance(
+    summary: string,
+    directory: Awaited<ReturnType<LarkRecipientDirectoryService['get']>>
+  ): string {
     const entries = directory?.entries ?? []
     const duplicateNames = new Set<string>()
     const seenNames = new Set<string>()
@@ -530,17 +765,20 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
 
     const lines = [
       'Lark notify operating rules:',
-      '- Default to lark_send_text_notification or lark_send_rich_notification.',
+      '- Default to lark_send_text_notification or lark_send_rich_notification for message notifications.',
+      '- Use lark_send_file for generated or edited workspace files. Never paste a local or workspace path into the user-facing reply.',
       '- Prefer recipient_name and real display names from the current group context.',
       `- ${summary}`,
       '- Do not ask the user for open_id and do not expose open_id in normal conversation.',
       '- Do not call lark_list_users as the default discovery step.',
-      '- If the target person is not known in this chat yet, ask the user to @mention that person first.',
+      '- If the target person is not known in this chat yet, ask the user to @mention that person first.'
     ]
 
     if (duplicateNames.size > 0) {
       lines.push(
-        `- These names are currently ambiguous in this chat: ${Array.from(duplicateNames).join(', ')}. If the user refers to one of them, ask the user to @mention the target person again.`
+        `- These names are currently ambiguous in this chat: ${Array.from(duplicateNames).join(
+          ', '
+        )}. If the user refers to one of them, ask the user to @mention the target person again.`
       )
     } else {
       lines.push('- If multiple people might match the same name, ask the user to @mention the target person again.')
@@ -626,13 +864,16 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       )
     } catch (error) {
       this.logger.warn(
-        `[${LARK_NOTIFY_MIDDLEWARE_NAME}] Failed to bind recipient ${recipient.type}:${recipient.id} to conversation "${conversationId}": ${formatError(error)}`
+        `[${LARK_NOTIFY_MIDDLEWARE_NAME}] Failed to bind recipient ${recipient.type}:${
+          recipient.id
+        } to conversation "${conversationId}": ${formatError(error)}`
       )
     }
   }
 
   meta: TAgentMiddlewareMeta = {
     name: LARK_NOTIFY_MIDDLEWARE_NAME,
+    builtin: true,
     icon: {
       type: 'image',
       value: iconImage
@@ -643,9 +884,9 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
     },
     description: {
       en_US:
-        'Provides Lark notification tools. Prefer sending by recipient_name from the current chat context instead of exposing open_id. If the target user has not appeared in this group context yet, ask the user to @mention that person first.',
+        'Provides Lark notification and workspace file sending tools. File sends use the trusted current conversation or configured scheduled recipient. Prefer sending message notifications by recipient_name instead of exposing open_id.',
       zh_Hans:
-        '提供飞书通知工具。优先基于当前对话中的真实姓名发送，而不是直接暴露 open_id；如果目标用户还没出现在当前群上下文中，请先让用户 @ 对方。'
+        '提供飞书通知和 workspace 文件发送工具。文件只发送到可信的当前会话或定时任务预配置接收人；消息通知优先基于当前对话中的真实姓名发送，而不是直接暴露 open_id。'
     },
     configSchema: {
       type: 'object',
@@ -664,7 +905,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
             component: 'remoteSelect',
             selectUrl: '/api/integration/select-options?provider=lark',
             variable: true,
-            span: 2,
+            span: 2
           }
         },
         // TODO: 当前 UI 先只支持 open_id。
@@ -681,12 +922,13 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
           description: {
             en_US: 'Currently only open_id is supported in UI. Backend supports other types via configuration.',
             zh_Hans: '当前 UI 仅支持 open_id。后端仍可通过配置使用其他类型。'
-          },
+          }
         },
         recipient_id: {
           type: 'string',
           description: {
-            en_US: 'Optional fallback recipient ID. For normal conversations, prefer recipient_name so the model can work with real names instead of open_id.',
+            en_US:
+              'Optional fallback recipient ID. For normal conversations, prefer recipient_name so the model can work with real names instead of open_id.',
             zh_Hans:
               '可选的兜底接收方 ID。普通对话中优先使用 recipient_name，让模型基于真实姓名工作，而不是直接依赖 open_id。'
           },
@@ -697,7 +939,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
             depends: [
               {
                 name: 'integrationId',
-                alias: 'integration',
+                alias: 'integration'
               }
             ]
           }
@@ -763,16 +1005,16 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
                 zh_Hans: '启用查询工具'
               },
               description: {
-                en_US: 'Expose list users/chats tools for admin or debugging only. Keep disabled for normal name-based chat flows.',
-                zh_Hans:
-                  '仅为管理或调试场景暴露用户/群组列表工具。普通基于姓名的对话流程建议保持关闭。'
+                en_US:
+                  'Expose list users/chats tools for admin or debugging only. Keep disabled for normal name-based chat flows.',
+                zh_Hans: '仅为管理或调试场景暴露用户/群组列表工具。普通基于姓名的对话流程建议保持关闭。'
               }
             }
           },
           'x-ui': {
             span: 2
           }
-        },
+        }
       }
     } as TAgentMiddlewareMeta['configSchema']
   }
@@ -799,12 +1041,17 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
      * 2. tool call 的 recipient_id 当前默认按 open_id 处理。
      * 3. 如果后续需要更多类型，再扩展 recipient_type override。
      */
-    const resolveInput = <T extends Record<string, unknown>>(value: T) => {
+    const resolveInput = <T extends Record<string, unknown>>(value: T, config?: unknown) => {
       const state = getCurrentStateSafe()
+      const trustedRuntimeContext = resolveLarkFileRuntimeContext(config, state, true)
       const renderedInput = renderTemplateValue(value, state, templateOptions)
       const renderedDefaults = renderTemplateValue(parsed.defaults, state, templateOptions)
       const renderedIntegration = renderTemplateValue(parsed.integrationId, state, templateOptions)
-      const integrationId = resolveStateBackedString(renderedIntegration, state)
+      const integrationId =
+        trustedRuntimeContext.integrationId ??
+        (parsed.trustedTriggerOnly
+          ? null
+          : resolveRuntimeIntegrationId(state) ?? resolveStateBackedString(renderedIntegration, state))
       const recipientDirectoryKey = this.resolveRecipientDirectoryKey(state)
       const timeoutMs = normalizeTimeout(
         (renderedInput as Record<string, unknown>)?.timeoutMs,
@@ -816,7 +1063,11 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       let renderedRecipients: unknown = null
       if (parsed.recipient_id) {
         const recipientType = parsed.recipient_type || 'open_id'
-        renderedRecipients = renderTemplateValue([{type: recipientType, id: parsed.recipient_id}], state, templateOptions)
+        renderedRecipients = renderTemplateValue(
+          [{ type: recipientType, id: parsed.recipient_id }],
+          state,
+          templateOptions
+        )
       }
 
       return {
@@ -825,6 +1076,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         renderedRecipients,
         renderedDefaults,
         integrationId,
+        trustedRuntimeContext,
         recipientDirectoryKey,
         timeoutMs
       }
@@ -851,16 +1103,14 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       if (unresolved.length > 0) {
         const [first] = unresolved
         if (first.status === 'ambiguous') {
-          throw new Error(
-            `无法唯一定位接收人 ${first.name}。请让用户在当前会话里通过 @ 明确指向该成员。`
-          )
+          throw new Error(`无法唯一定位接收人 ${first.name}。请让用户在当前会话里通过 @ 明确指向该成员。`)
         }
-        throw new Error(
-          `找不到接收人 ${first.name}。请先让用户在当前会话中 @ ${first.name}。`
-        )
+        throw new Error(`找不到接收人 ${first.name}。请先让用户在当前会话中 @ ${first.name}。`)
       }
       const nameRecipients = nameResolutions
-        .filter((item): item is Extract<LarkRecipientNameResolution, { status: 'resolved' }> => item.status === 'resolved')
+        .filter(
+          (item): item is Extract<LarkRecipientNameResolution, { status: 'resolved' }> => item.status === 'resolved'
+        )
         .map((item) => item.recipient)
       if (nameRecipients.length > 0) {
         return nameRecipients
@@ -877,12 +1127,13 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       if (toolRecipientIdStr) {
         // 允许 recipient_id 指向一个 Mustache 渲染后的状态变量。
         const resolvedValue = getValueByPath(state, toolRecipientIdStr)
-        const resolvedIds = resolvedValue !== undefined 
-          ? normalizeRecipientIdValues(resolvedValue) 
-          : normalizeRecipientIdValues(toolRecipientIdStr)
-        
+        const resolvedIds =
+          resolvedValue !== undefined
+            ? normalizeRecipientIdValues(resolvedValue)
+            : normalizeRecipientIdValues(toolRecipientIdStr)
+
         if (resolvedIds.length > 0) {
-          return resolvedIds.map(id => ({
+          return resolvedIds.map((id) => ({
             type: 'open_id' as const,
             id
           }))
@@ -890,6 +1141,49 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       }
 
       return []
+    }
+
+    const resolveFileTarget = (
+      runtimeContext: LarkFileRuntimeContext,
+      configuredIntegrationId: string | null,
+      renderedRecipients: unknown,
+      state: Record<string, unknown>
+    ): {
+      source: 'runtime' | 'configured'
+      integrationId: string | null
+      recipients: LarkRecipient[]
+    } => {
+      if (runtimeContext.chatId) {
+        return {
+          source: 'runtime',
+          integrationId: runtimeContext.integrationId,
+          recipients: [{ type: 'chat_id', id: runtimeContext.chatId }]
+        }
+      }
+
+      const chatType = runtimeContext.chatType?.toLowerCase()
+      if (runtimeContext.senderOpenId && (chatType === 'p2p' || chatType === 'private' || chatType === 'single')) {
+        return {
+          source: 'runtime',
+          integrationId: runtimeContext.integrationId,
+          recipients: [{ type: 'open_id', id: runtimeContext.senderOpenId }]
+        }
+      }
+
+      return {
+        source: 'configured',
+        integrationId: configuredIntegrationId,
+        recipients: normalizeRecipients(renderedRecipients, state)
+      }
+    }
+
+    const requireFileRecipients = (recipients: LarkRecipient[]) => {
+      if (!recipients.length) {
+        throw new Error(
+          `[${LARK_SEND_FILE_TOOL_NAME}] No trusted Lark file recipient was found. Run this tool from a Lark conversation, or configure a middleware recipient for a scheduled/proactive run.`
+        )
+      }
+      return recipients
     }
 
     const requireIntegrationId = (integrationId: string | null, toolName: string) => {
@@ -923,7 +1217,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       }
     }
 
-    const buildCommand = (toolName: string, toolCallId: string, result: LarkNotifyResult) => {
+    const buildCommand = <T extends LarkCommandResult>(toolName: string, toolCallId: string, result: T) => {
       return new Command({
         update: {
           lark_notify_last_result: result,
@@ -964,7 +1258,9 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
                 await params.onSuccess(recipient, result)
               } catch (error) {
                 this.logger.warn(
-                  `[${params.toolName}] post-send hook failed for ${recipient.type}:${recipient.id}: ${formatError(error)}`
+                  `[${params.toolName}] post-send hook failed for ${recipient.type}:${recipient.id}: ${formatError(
+                    error
+                  )}`
                 )
               }
             }
@@ -1012,7 +1308,8 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         async (parameters, config) => {
           const toolName = 'lark_send_text_notification'
           const toolCallId = getToolCallIdFromConfig(config)
-          const { state, renderedInput, renderedRecipients, integrationId, recipientDirectoryKey, timeoutMs } = resolveInput(parameters)
+          const { state, renderedInput, renderedRecipients, integrationId, recipientDirectoryKey, timeoutMs } =
+            resolveInput(parameters, config)
           const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
           // 接收人优先级：当前会话姓名 > middleware 默认配置 > tool call recipient_id
           const recipients = requireRecipients(
@@ -1081,10 +1378,129 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
     tools.push(
       tool(
         async (parameters, config) => {
+          const toolName = LARK_SEND_FILE_TOOL_NAME
+          const toolCallId = getToolCallIdFromConfig(config)
+          const { state, renderedInput, renderedRecipients, integrationId, trustedRuntimeContext, timeoutMs } =
+            resolveInput(parameters, config)
+          const runtimeContext = parsed.trustedTriggerOnly
+            ? trustedRuntimeContext
+            : resolveLarkFileRuntimeContext(config, state)
+          const fileTarget = resolveFileTarget(runtimeContext, integrationId, renderedRecipients, state)
+          if (fileTarget.source === 'runtime' && !fileTarget.integrationId) {
+            throw new Error(`[${toolName}] The current Lark conversation is missing its trusted runtime integrationId.`)
+          }
+          const resolvedIntegrationId = requireIntegrationId(fileTarget.integrationId, toolName)
+          const recipients = requireFileRecipients(fileTarget.recipients)
+          const workspaceFiles = context.runtime?.capabilities?.get(WorkspaceFilesRuntimeCapability)
+          if (!workspaceFiles?.readRuntimeBuffer) {
+            throw new Error(
+              `[${toolName}] platform.workspace.files runtime capability is required to read workspace files.`
+            )
+          }
+
+          const file = await resolveLarkSendFileFromWorkspace(
+            buildLarkSendFileDescriptor(renderedInput as Record<string, unknown>),
+            { workspaceFiles }
+          )
+          const client = await getClient(resolvedIntegrationId, timeoutMs, toolName)
+
+          let uploadResponse: unknown
+          try {
+            uploadResponse = await withTimeout(
+              client.im.file.create({
+                data: {
+                  file_type: file.fileType,
+                  file_name: file.fileName,
+                  file: file.buffer
+                }
+              }),
+              timeoutMs,
+              `[${toolName}] upload '${file.fileName}'`
+            )
+          } catch (error) {
+            throw new Error(`[${toolName}] Failed to upload '${file.fileName}': ${formatError(error)}`)
+          }
+
+          const fileKey = readLarkUploadedFileKey(uploadResponse)
+          if (!fileKey) {
+            throw new Error(`[${toolName}] Lark file upload did not return file_key.`)
+          }
+
+          const batchResult = await runSendTaskBatch({
+            integrationId: resolvedIntegrationId,
+            toolName,
+            recipients,
+            timeoutMs,
+            onSuccess: async (recipient) => {
+              await this.tryBindConversationForRecipient({
+                integrationId: resolvedIntegrationId,
+                recipient,
+                context
+              })
+            },
+            task: async (recipient) => {
+              const uuid = buildLarkFileSendUuid({
+                toolCallId,
+                integrationId: resolvedIntegrationId,
+                recipientType: recipient.type,
+                recipientId: recipient.id,
+                sha256: file.sha256
+              })
+              const response = await client.im.message.create({
+                params: {
+                  receive_id_type: recipient.type
+                },
+                data: {
+                  receive_id: recipient.id,
+                  msg_type: file.messageType,
+                  content: JSON.stringify({ file_key: fileKey }),
+                  ...(uuid ? { uuid } : {})
+                }
+              })
+
+              return {
+                messageId: response?.data?.message_id ?? null
+              }
+            }
+          })
+          const result = {
+            file: toLarkSendFileMetadata(file),
+            successCount: batchResult.successCount,
+            failureCount: batchResult.failureCount,
+            results: batchResult.results.map((item, index) => ({
+              index: index + 1,
+              success: item.success,
+              ...(item.messageId ? { messageId: item.messageId } : {}),
+              ...(item.error ? { error: item.error } : {})
+            }))
+          }
+
+          return buildCommand(toolName, toolCallId, result)
+        },
+        {
+          name: LARK_SEND_FILE_TOOL_NAME,
+          description:
+            'Send a generated, edited, or previously found Xpert workspace file to the trusted current Lark conversation. Scheduled/proactive runs use only the middleware-configured recipient. The tool cannot choose another integration, chat, or user.',
+          schema: sendFileSchema,
+          verboseParsingErrors: true
+        }
+      )
+    )
+
+    tools.push(
+      tool(
+        async (parameters, config) => {
           const toolName = 'lark_send_rich_notification'
           const toolCallId = getToolCallIdFromConfig(config)
-          const { state, renderedInput, renderedRecipients, renderedDefaults, integrationId, recipientDirectoryKey, timeoutMs } =
-            resolveInput(parameters)
+          const {
+            state,
+            renderedInput,
+            renderedRecipients,
+            renderedDefaults,
+            integrationId,
+            recipientDirectoryKey,
+            timeoutMs
+          } = resolveInput(parameters, config)
           const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
           // 接收人优先级：当前会话姓名 > middleware 默认配置 > tool call recipient_id
           const recipients = requireRecipients(
@@ -1102,9 +1518,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
           )
           const mode = renderedInput.mode as 'post' | 'interactive'
           const localeCandidate =
-            normalizeString(renderedInput.locale) ||
-            normalizeString(renderedDefaults.postLocale) ||
-            DEFAULT_POST_LOCALE
+            normalizeString(renderedInput.locale) || normalizeString(renderedDefaults.postLocale) || DEFAULT_POST_LOCALE
 
           if (!PostLocaleSchema.options.includes(localeCandidate as any)) {
             throw new Error(`[${toolName}] locale must be one of: ${PostLocaleSchema.options.join(', ')}`)
@@ -1197,7 +1611,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         async (parameters, config) => {
           const toolName = 'lark_update_message'
           const toolCallId = getToolCallIdFromConfig(config)
-          const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters)
+          const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters, config)
           const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
           const messageId = normalizeString(renderedInput.messageId)
           const mode = renderedInput.mode as 'text' | 'interactive'
@@ -1281,7 +1695,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         async (parameters, config) => {
           const toolName = 'lark_recall_message'
           const toolCallId = getToolCallIdFromConfig(config)
-          const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters)
+          const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters, config)
           const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
           const messageId = normalizeString(renderedInput.messageId)
 
@@ -1337,14 +1751,14 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
           async (parameters, config) => {
             const toolName = 'lark_list_users'
             const toolCallId = getToolCallIdFromConfig(config)
-            const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters)
+            const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters, config)
             const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
             const keyword = normalizeString(renderedInput.keyword)?.toLowerCase()
             const pageSize = normalizeIntInRange(renderedInput.pageSize, 20, 1, 100)
             const pageToken = normalizeString(renderedInput.pageToken)
 
             const client = await getClient(resolvedIntegrationId, timeoutMs, toolName)
-            let response: Awaited<ReturnType<typeof client.contact.v3.user.findByDepartment>>;
+            let response: Awaited<ReturnType<typeof client.contact.v3.user.findByDepartment>>
             try {
               response = await withTimeout(
                 client.contact.v3.user.findByDepartment({
@@ -1354,7 +1768,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
                     department_id: '0',
                     page_size: pageSize,
                     page_token: pageToken || undefined
-                  },
+                  }
                 }),
                 timeoutMs,
                 `[${toolName}] list users`
@@ -1375,7 +1789,11 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
                   return true
                 }
                 const values = [item.name, item.email, item.mobile]
-                return values.some((value) => String(value || '').toLowerCase().includes(keyword))
+                return values.some((value) =>
+                  String(value || '')
+                    .toLowerCase()
+                    .includes(keyword)
+                )
               })
 
             const result: LarkNotifyResult = {
@@ -1410,14 +1828,14 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
           async (parameters, config) => {
             const toolName = 'lark_list_chats'
             const toolCallId = getToolCallIdFromConfig(config)
-            const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters)
+            const { renderedInput, integrationId, timeoutMs } = resolveInput(parameters, config)
             const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
             const keyword = normalizeString(renderedInput.keyword)?.toLowerCase()
             const pageSize = normalizeIntInRange(renderedInput.pageSize, 20, 1, 100)
             const pageToken = normalizeString(renderedInput.pageToken)
 
             const client = await getClient(resolvedIntegrationId, timeoutMs, toolName)
-            let response: Awaited<ReturnType<typeof client.im.chat.list>>;
+            let response: Awaited<ReturnType<typeof client.im.chat.list>>
             try {
               response = await withTimeout(
                 client.im.chat.list({
@@ -1439,14 +1857,18 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
                 chat_id: item?.chat_id ?? null,
                 name: item?.name ?? null,
                 avatar: item?.avatar ?? null,
-                description: item?.description ?? null,
+                description: item?.description ?? null
               }))
               .filter((item) => {
                 if (!keyword) {
                   return true
                 }
                 const values = [item.name, item.chat_id, item.description]
-                return values.some((value) => String(value || '').toLowerCase().includes(keyword))
+                return values.some((value) =>
+                  String(value || '')
+                    .toLowerCase()
+                    .includes(keyword)
+                )
               })
 
             const result: LarkNotifyResult = {
@@ -1468,7 +1890,8 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
           },
           {
             name: 'lark_list_chats',
-            description: 'List chats available for Lark notifications. This tool is mainly intended for admin or debugging flows.',
+            description:
+              'List chats available for Lark notifications. This tool is mainly intended for admin or debugging flows.',
             schema: listChatsSchema,
             verboseParsingErrors: true
           }
@@ -1481,10 +1904,10 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       stateSchema: larkNotifyStateSchema,
       beforeAgent: async (state, runtime) => {
         const rootState =
-          ((runtime as Record<string, unknown> | undefined)?.state as Record<string, unknown> | undefined) ??
-          {}
+          ((runtime as Record<string, unknown> | undefined)?.state as Record<string, unknown> | undefined) ?? {}
         const recipientDirectoryKey =
-          this.resolveRecipientDirectoryKey(rootState) || this.resolveRecipientDirectoryKey((state ?? {}) as Record<string, unknown>)
+          this.resolveRecipientDirectoryKey(rootState) ||
+          this.resolveRecipientDirectoryKey((state ?? {}) as Record<string, unknown>)
         const directory = await this.recipientDirectoryService.get(recipientDirectoryKey)
         const summary = this.formatKnownRecipientsSummary(directory)
         const guidance = this.formatAgentGuidance(summary, directory)
@@ -1502,12 +1925,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         }
 
         const baseSystemContent = toSystemMessageText(request.systemMessage?.content).trim()
-        const mergedSystemContent = [
-          baseSystemContent,
-          '<lark_notify_guidance>',
-          guidance,
-          '</lark_notify_guidance>'
-        ]
+        const mergedSystemContent = [baseSystemContent, '<lark_notify_guidance>', guidance, '</lark_notify_guidance>']
           .filter(Boolean)
           .join('\n\n')
 

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-runtime.middleware.spec.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-runtime.middleware.spec.ts
@@ -1,0 +1,142 @@
+jest.mock('@xpert-ai/plugin-sdk', () => {
+  const { createLarkPluginSdkMock } = require('../../../../../test-utils/larkPluginSdkMock.cjs')
+  return createLarkPluginSdkMock(jest, {
+    AgentMiddlewareStrategy: () => (target: unknown) => target,
+    WORKSPACE_FILES_SOURCE: 'workspace_files',
+    WorkspaceFilesRuntimeCapability: Symbol('WorkspaceFilesRuntimeCapability')
+  })
+})
+
+import { LarkRuntimeMiddleware } from './lark-runtime.middleware.js'
+
+describe('LarkRuntimeMiddleware', () => {
+  it('combines the three Lark capabilities into one exact tool surface', async () => {
+    const callOrder: string[] = []
+    const localHistoryMiddleware = {
+      meta: { configSchema: { type: 'object', properties: {} } },
+      createMiddleware: jest.fn().mockReturnValue({
+        name: 'local',
+        tools: [{ name: 'lark_search_chat_history' }]
+      })
+    }
+    const notifyMiddleware = {
+      meta: {
+        configSchema: {
+          type: 'object',
+          properties: {
+            integrationId: { type: 'string' },
+            recipient_type: { type: 'string' },
+            recipient_id: { type: 'string' },
+            template: { type: 'object' },
+            lookupTools: { type: 'object' },
+            defaults: {
+              type: 'object',
+              properties: { postLocale: { type: 'string' }, timeoutMs: { type: 'number' } }
+            }
+          }
+        }
+      },
+      createMiddleware: jest.fn().mockReturnValue({
+        name: 'notify',
+        beforeAgent: async () => ({ notifyReady: true }),
+        wrapModelCall: async (request: unknown, handler: (value: unknown) => unknown) => {
+          callOrder.push('notify')
+          return handler(request)
+        },
+        tools: [
+          { name: 'lark_send_text_notification' },
+          { name: 'lark_send_rich_notification' },
+          { name: 'lark_send_file' },
+          { name: 'lark_update_message' },
+          { name: 'lark_recall_message' },
+          { name: 'lark_list_users' },
+          { name: 'lark_list_chats' }
+        ]
+      })
+    }
+    const conversationContextMiddleware = {
+      meta: {
+        configSchema: {
+          type: 'object',
+          properties: {
+            integrationId: { type: 'string' },
+            defaults: {
+              type: 'object',
+              properties: {
+                pageSize: { type: 'number' },
+                resourceContentMode: { type: 'string' }
+              }
+            }
+          }
+        }
+      },
+      createMiddleware: jest.fn().mockReturnValue({
+        name: 'remote',
+        beforeAgent: async () => ({ remoteReady: true }),
+        wrapModelCall: async (request: unknown, handler: (value: unknown) => unknown) => {
+          callOrder.push('remote')
+          return handler(request)
+        },
+        tools: [{ name: 'lark_list_messages' }, { name: 'lark_get_message' }, { name: 'lark_get_message_resource' }]
+      })
+    }
+    const strategy = new LarkRuntimeMiddleware(
+      localHistoryMiddleware as never,
+      notifyMiddleware as never,
+      conversationContextMiddleware as never
+    )
+
+    const middleware = await strategy.createMiddleware(
+      { integrationId: 'integration-must-not-override-trigger' },
+      {} as never
+    )
+
+    expect(strategy.meta.label.zh_Hans).toBe('飞书运行时')
+    expect(strategy.meta.configSchema?.properties).not.toHaveProperty('integrationId')
+    expect(strategy.meta.configSchema?.properties).not.toHaveProperty('lookupTools')
+    expect(strategy.meta.configSchema?.properties).not.toHaveProperty('recipient_type')
+    expect(strategy.meta.configSchema?.properties).not.toHaveProperty('recipient_id')
+    expect(strategy.meta.configSchema?.properties?.defaults).toEqual(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          postLocale: expect.anything(),
+          timeoutMs: expect.anything(),
+          pageSize: expect.anything(),
+          resourceContentMode: expect.anything()
+        })
+      })
+    )
+    expect(middleware.tools?.map((item) => item.name)).toEqual([
+      'lark_search_chat_history',
+      'lark_send_text_notification',
+      'lark_send_rich_notification',
+      'lark_send_file',
+      'lark_update_message',
+      'lark_recall_message',
+      'lark_list_messages',
+      'lark_get_message',
+      'lark_get_message_resource'
+    ])
+    expect(notifyMiddleware.createMiddleware).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationId: undefined,
+        trustedTriggerOnly: true,
+        lookupTools: { enabled: false }
+      }),
+      expect.anything()
+    )
+    expect(conversationContextMiddleware.createMiddleware).toHaveBeenCalledWith(
+      expect.objectContaining({ integrationId: undefined, trustedTriggerOnly: true, currentChatOnly: true }),
+      expect.anything()
+    )
+
+    const beforeAgent = middleware.beforeAgent as (state: unknown, runtime: unknown) => Promise<unknown>
+    await expect(beforeAgent({}, {})).resolves.toEqual({ remoteReady: true, notifyReady: true })
+    const wrapModelCall = middleware.wrapModelCall!
+    await wrapModelCall({} as never, async () => {
+      callOrder.push('handler')
+      return {} as never
+    })
+    expect(callOrder).toEqual(['remote', 'notify', 'handler'])
+  })
+})

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-runtime.middleware.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-runtime.middleware.ts
@@ -1,0 +1,160 @@
+import type { TAgentMiddlewareMeta } from '@xpert-ai/contracts'
+import { Injectable } from '@nestjs/common'
+import {
+  AgentMiddleware,
+  AgentMiddlewareStrategy,
+  IAgentMiddlewareContext,
+  IAgentMiddlewareStrategy
+} from '@xpert-ai/plugin-sdk'
+import { LARK_RUNTIME_MIDDLEWARE_NAME } from '../constants.js'
+import { iconImage } from '../types.js'
+import {
+  LarkConversationContextMiddleware,
+  larkConversationContextStateSchema
+} from './lark-conversation-context.middleware.js'
+import { LarkLocalHistoryMiddleware } from './lark-local-history.middleware.js'
+import { LarkNotifyMiddleware, larkNotifyStateSchema } from './lark-notify.middleware.js'
+
+const LOCAL_HISTORY_TOOLS = new Set(['lark_search_chat_history'])
+const MESSAGE_TOOLS = new Set([
+  'lark_send_text_notification',
+  'lark_send_rich_notification',
+  'lark_send_file',
+  'lark_update_message',
+  'lark_recall_message'
+])
+const REMOTE_MESSAGE_TOOLS = new Set(['lark_list_messages', 'lark_get_message', 'lark_get_message_resource'])
+
+const larkRuntimeStateSchema = larkConversationContextStateSchema.merge(larkNotifyStateSchema)
+
+export type LarkRuntimeMiddlewareConfig = Record<string, unknown>
+
+@Injectable()
+@AgentMiddlewareStrategy(LARK_RUNTIME_MIDDLEWARE_NAME)
+export class LarkRuntimeMiddleware implements IAgentMiddlewareStrategy<LarkRuntimeMiddlewareConfig> {
+  meta: TAgentMiddlewareMeta
+
+  constructor(
+    private readonly localHistoryMiddleware: LarkLocalHistoryMiddleware,
+    private readonly notifyMiddleware: LarkNotifyMiddleware,
+    private readonly conversationContextMiddleware: LarkConversationContextMiddleware
+  ) {
+    this.meta = {
+      name: LARK_RUNTIME_MIDDLEWARE_NAME,
+      icon: { type: 'image', value: iconImage },
+      label: {
+        en_US: 'Lark Runtime',
+        zh_Hans: '飞书运行时'
+      },
+      description: {
+        en_US: 'One Lark runtime for local history, message and workspace file sending, and remote message access.',
+        zh_Hans: '统一提供飞书本地历史、消息与工作区文件发送，以及远程消息读取能力。'
+      },
+      configSchema: buildRuntimeConfigSchema(
+        this.notifyMiddleware.meta.configSchema,
+        this.conversationContextMiddleware.meta.configSchema
+      )
+    }
+  }
+
+  async createMiddleware(
+    options: LarkRuntimeMiddlewareConfig,
+    context: IAgentMiddlewareContext
+  ): Promise<AgentMiddleware> {
+    const normalizedOptions = isRecord(options) ? options : {}
+    const runtimeOptions = {
+      ...normalizedOptions,
+      // The unified runtime is bound to the current Lark trigger; stored node options cannot override it.
+      integrationId: undefined,
+      trustedTriggerOnly: true as const,
+      // Remote message tools may only read the Lark chat injected by the current trigger runtime.
+      currentChatOnly: true as const
+    }
+    const [localHistory, notify, remoteMessages] = await Promise.all([
+      Promise.resolve(this.localHistoryMiddleware.createMiddleware({}, context)),
+      Promise.resolve(
+        this.notifyMiddleware.createMiddleware(
+          {
+            ...runtimeOptions,
+            // The unified runtime intentionally exposes only the five message operations.
+            lookupTools: { enabled: false }
+          },
+          context
+        )
+      ),
+      Promise.resolve(this.conversationContextMiddleware.createMiddleware(runtimeOptions, context))
+    ])
+
+    return {
+      name: LARK_RUNTIME_MIDDLEWARE_NAME,
+      stateSchema: larkRuntimeStateSchema,
+      beforeAgent: async (state, runtime) => {
+        const remoteState = await invokeBeforeAgent(remoteMessages, state, runtime)
+        const notifyState = await invokeBeforeAgent(
+          notify,
+          { ...(state as Record<string, unknown>), ...remoteState },
+          runtime
+        )
+        return { ...remoteState, ...notifyState }
+      },
+      wrapModelCall: async (request, handler) => {
+        const notifyHandler = notify.wrapModelCall
+          ? (nextRequest: typeof request) => notify.wrapModelCall!(nextRequest, handler)
+          : handler
+        return remoteMessages.wrapModelCall
+          ? remoteMessages.wrapModelCall(request, notifyHandler)
+          : notifyHandler(request)
+      },
+      tools: [
+        ...(localHistory.tools ?? []).filter((item) => LOCAL_HISTORY_TOOLS.has(item.name)),
+        ...(notify.tools ?? []).filter((item) => MESSAGE_TOOLS.has(item.name)),
+        ...(remoteMessages.tools ?? []).filter((item) => REMOTE_MESSAGE_TOOLS.has(item.name))
+      ]
+    }
+  }
+}
+
+async function invokeBeforeAgent(
+  middleware: AgentMiddleware,
+  state: unknown,
+  runtime: unknown
+): Promise<Record<string, unknown>> {
+  const hook = middleware.beforeAgent
+  if (!hook) {
+    return {}
+  }
+  const handler = typeof hook === 'function' ? hook : hook.hook
+  const result = await handler(state as never, runtime as never)
+  return isRecord(result) ? result : {}
+}
+
+function buildRuntimeConfigSchema(notifySchema: unknown, remoteSchema: unknown): TAgentMiddlewareMeta['configSchema'] {
+  const notifyProperties = getSchemaProperties(notifySchema)
+  const remoteProperties = getSchemaProperties(remoteSchema)
+  const notifyDefaults = isRecord(notifyProperties.defaults) ? notifyProperties.defaults : {}
+  const remoteDefaults = isRecord(remoteProperties.defaults) ? remoteProperties.defaults : {}
+  const notifyDefaultProperties = getSchemaProperties(notifyDefaults)
+  const remoteDefaultProperties = getSchemaProperties(remoteDefaults)
+
+  return {
+    type: 'object',
+    properties: {
+      template: notifyProperties.template,
+      defaults: {
+        ...notifyDefaults,
+        properties: {
+          ...notifyDefaultProperties,
+          ...remoteDefaultProperties
+        }
+      }
+    }
+  } as TAgentMiddlewareMeta['configSchema']
+}
+
+function getSchemaProperties(value: unknown): Record<string, unknown> {
+  return isRecord(value) && isRecord(value.properties) ? value.properties : {}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-trusted-runtime-context.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-trusted-runtime-context.ts
@@ -1,0 +1,78 @@
+export type LarkTrustedRuntimeContext = {
+  integrationId?: string
+  scopeKey?: string
+  xpertId?: string
+  tenantId?: string
+  organizationId?: string
+  chatId?: string
+  chatType?: string
+  senderOpenId?: string
+  senderName?: string
+  sourceMessageLogIds: string[]
+}
+
+/**
+ * Reads only trigger-owned runtime namespaces. Generic state fields named
+ * integrationId/chatId are deliberately ignored so model/workflow state cannot
+ * redirect Lark tools to another integration or chat.
+ */
+export function resolveLarkTrustedRuntimeContext(config: unknown): LarkTrustedRuntimeContext {
+  const root = asRecord(config)
+  const configurable = asRecord(root?.configurable)
+  const runtimePrincipal = asRecord(configurable?.runtimePrincipal)
+  const configurableContext = asRecord(configurable?.context)
+  const metadataContext = asRecord(asRecord(root?.metadata)?.context)
+  const records = [runtimePrincipal, configurableContext, metadataContext]
+
+  return {
+    integrationId: readString(records, ['sourceIntegrationId']),
+    scopeKey: readString([configurableContext, metadataContext], ['scopeKey']),
+    xpertId: readString([configurableContext, metadataContext], ['xpertId']),
+    tenantId: readString(records, ['tenantId']),
+    organizationId: readString(records, ['organizationId']),
+    chatId: readString([configurableContext, metadataContext], ['chatId', 'openChatId', 'open_chat_id']),
+    chatType: readString([configurableContext, metadataContext], ['chatType', 'chat_type']),
+    senderOpenId: readString(
+      [configurableContext, metadataContext],
+      ['senderOpenId', 'channelUserId', 'sender_open_id']
+    ),
+    senderName: readString([configurableContext, metadataContext], ['senderName']),
+    sourceMessageLogIds: readStringList(
+      [configurableContext, metadataContext],
+      ['sourceMessageLogIds', 'currentInboundLogIds']
+    )
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
+}
+
+function normalizeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function readString(records: Array<Record<string, unknown> | undefined>, keys: string[]): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = normalizeString(record?.[key])
+      if (value) {
+        return value
+      }
+    }
+  }
+  return undefined
+}
+
+function readStringList(records: Array<Record<string, unknown> | undefined>, keys: string[]): string[] {
+  const values: string[] = []
+  for (const record of records) {
+    for (const key of keys) {
+      const candidate = record?.[key]
+      if (Array.isArray(candidate)) {
+        values.push(...candidate.map(normalizeString).filter((value): value is string => Boolean(value)))
+      }
+    }
+  }
+  return Array.from(new Set(values))
+}

--- a/xpertai/integrations/lark/src/lib/types.ts
+++ b/xpertai/integrations/lark/src/lib/types.ts
@@ -480,6 +480,7 @@ export const LARK_TYPING_REACTION_EMOJI_TYPE = 'Typing'
 
 export type ChatLarkContext<T = any> = {
 	tenant: ITenant
+	tenantId?: string
 	organizationId: string
 	integrationId: string
 	connectionMode?: TLarkConnectionMode
@@ -508,6 +509,13 @@ export type ChatLarkContext<T = any> = {
 	message?: T
 	input?: string
 	files?: LarkInboundFile[]
+	/** Log rows represented by this inbound dispatch (one row normally, multiple rows for windows). */
+	currentInboundLogIds?: string[]
+	/** Timestamp used as the exclusive upper bound for automatic history lookup. */
+	historyBefore?: string
+	/** First history snapshot carried through group/summary aggregation and composed at final dispatch. */
+	historyContext?: string
+	historyFiles?: LarkInboundFile[]
 	replyToMessageId?: string
 	semanticMessage?: LarkSemanticMessage
 	recipientDirectoryKey?: string
@@ -518,10 +526,21 @@ export type ChatLarkContext<T = any> = {
 }
 
 export type LarkInboundFile = {
-	fileUrl: string
+	id?: string
+	fileUrl?: string
+	url?: string
 	mimeType?: string
+	mimetype?: string
 	originalName?: string
+	name?: string
 	fileKey?: string
+	fileId?: string
+	fileAssetId?: string
+	storageFileId?: string
+	filePath?: string
+	workspacePath?: string
+	size?: number
+	extension?: string
 }
 
 export type TLarkEventMention = {
@@ -563,8 +582,8 @@ export type TLarkEvent = {
 		}
 		create_time: string
 		message_id: string
-		message_type?: 'text' | 'post' | 'image' | 'file' | 'audio'
-		msg_type?: 'text' | 'post' | 'image' | 'file' | 'audio'
+		message_type?: 'text' | 'post' | 'image' | 'file' | 'audio' | 'media'
+		msg_type?: 'text' | 'post' | 'image' | 'file' | 'audio' | 'media'
 		update_time: string
 		mentions?: TLarkEventMention[]
 	}
@@ -649,6 +668,8 @@ export type LarkGroupWindowParticipant = {
 
 export type LarkGroupWindowItem = {
 	messageId: string
+	messageLogId?: string
+	messageLogCreatedAt?: string
 	senderOpenId: string
 	userId?: string
 	senderName?: string
@@ -715,7 +736,8 @@ export type LarkRenderElement =
 export enum LarkCardActionEnum {
 	Confirm = 'lark-confirm',
 	Reject = 'lark-reject',
-	EndConversation = 'lark-end-conversation'
+	EndConversation = 'lark-end-conversation',
+	DismissPermissionGuide = 'lark-dismiss-permission-guide'
 }
 
 export type LarkCardActionPayload = {
@@ -727,6 +749,7 @@ export type LarkCardActionValue = string | LarkCardActionPayload
 export const LARK_END_CONVERSATION = LarkCardActionEnum.EndConversation
 export const LARK_CONFIRM = LarkCardActionEnum.Confirm
 export const LARK_REJECT = LarkCardActionEnum.Reject
+export const LARK_DISMISS_PERMISSION_GUIDE = LarkCardActionEnum.DismissPermissionGuide
 
 export type TLarkConversationStatus = TChatConversationStatus | 'end'
 

--- a/xpertai/integrations/lark/src/lib/views/lark-integration-view.provider.spec.ts
+++ b/xpertai/integrations/lark/src/lib/views/lark-integration-view.provider.spec.ts
@@ -22,6 +22,7 @@ import { LarkConversationService } from '../conversation.service.js'
 import { LarkRecipientDirectoryService } from '../lark-recipient-directory.service.js'
 import { LarkChannelStrategy } from '../lark-channel.strategy.js'
 import { LarkLongConnectionService } from '../lark-long-connection.service.js'
+import { LarkMessageHistoryService } from '../lark-message-history.service.js'
 import { TIntegrationLarkOptions } from '../types.js'
 import { LarkIntegrationViewProvider } from './lark-integration-view.provider.js'
 
@@ -153,17 +154,52 @@ describe('LarkIntegrationViewProvider', () => {
         total: 1
       })
     }
+    const messageHistoryService = {
+      listMessageLogs: jest.fn().mockResolvedValue({
+        items: [
+          {
+            id: 'message-log-1',
+            createdAt: new Date('2026-04-03T00:00:00.000Z'),
+            messageCreatedAt: new Date('2026-04-03T00:00:00.000Z'),
+            sentAt: null,
+            direction: 'inbound',
+            status: 'history_only',
+            chatId: 'chat-1',
+            scopeKey: 'group:chat-1',
+            senderName: 'Alice',
+            senderOpenId: 'ou_user_1',
+            messageType: 'file',
+            content: 'quarterly report',
+            botMentioned: false,
+            xpertId: 'xpert-1',
+            error: null
+          }
+        ],
+        total: 1,
+        page: 1,
+        pageSize: 10
+      }),
+      listMessageFiles: jest.fn().mockResolvedValue([
+        {
+          id: 'message-file-1',
+          messageLogId: 'message-log-1',
+          status: 'ready'
+        }
+      ])
+    }
 
     return {
       longConnectionService,
       larkChannel,
       recipientDirectoryService,
       conversationService,
+      messageHistoryService,
       provider: new LarkIntegrationViewProvider(
         longConnectionService as unknown as LarkLongConnectionService,
         larkChannel as unknown as LarkChannelStrategy,
         recipientDirectoryService as unknown as LarkRecipientDirectoryService,
-        conversationService as unknown as LarkConversationService
+        conversationService as unknown as LarkConversationService,
+        messageHistoryService as unknown as LarkMessageHistoryService
       )
     }
   }
@@ -179,13 +215,50 @@ describe('LarkIntegrationViewProvider', () => {
     expect(provider.supports(createContext('slack'))).toBe(false)
   })
 
-  it('declares status, connections, users, and conversations tabs for integration detail main tabs', () => {
+  it('declares status, connections, users, conversations, and messages tabs for integration detail main tabs', () => {
     const { provider } = createFixture()
 
-    expect(
-      provider.getViewManifests(createContext(), 'detail.main_tabs').map((manifest) => manifest.key)
-    ).toEqual(['status', 'connections', 'users', 'conversations'])
+    const manifests = provider.getViewManifests(createContext(), 'detail.main_tabs')
+    expect(manifests.map((manifest) => manifest.key)).toEqual([
+      'status',
+      'connections',
+      'users',
+      'conversations',
+      'messages'
+    ])
+    expect(manifests.find((manifest) => manifest.key === 'messages')).toEqual(
+      expect.objectContaining({
+        refreshable: true,
+        view: expect.objectContaining({
+          type: 'remote_component',
+          component: expect.objectContaining({ isolation: 'iframe', entry: 'lark-message-history' })
+        }),
+        dataSource: expect.objectContaining({
+          querySchema: expect.objectContaining({
+            supportsPagination: true,
+            supportsSearch: true,
+            supportsSort: true
+          }),
+          cache: { enabled: false }
+        })
+      })
+    )
     expect(provider.getViewManifests(createContext(), 'detail.sidebar')).toEqual([])
+  })
+
+  it('serves the plugin-owned scrollable message history component', () => {
+    const { provider } = createFixture()
+
+    const result = provider.getRemoteComponentEntry(createContext(), 'messages', {
+      isolation: 'iframe',
+      entry: 'lark-message-history'
+    })
+
+    expect(result.contentType).toBe('text/html; charset=utf-8')
+    expect(result.html).toContain('id="search"')
+    expect(result.html).toContain('id="refresh"')
+    expect(result.html).toContain("overflow: auto")
+    expect(result.html).toContain("post('requestData'")
   })
 
   it('loads status data from runtime status and bot info', async () => {
@@ -283,10 +356,66 @@ describe('LarkIntegrationViewProvider', () => {
     })
   })
 
+  it('loads paginated local message history without calling Lark APIs', async () => {
+    const { provider, messageHistoryService } = createFixture()
+
+    await expect(
+      provider.getViewData(createContext(), 'messages', {
+        page: 1,
+        pageSize: 10,
+        search: 'report',
+        sortBy: 'createdAt',
+        sortDirection: 'desc'
+      })
+    ).resolves.toEqual({
+      items: [
+        {
+          id: 'message-log-1',
+          createdAt: '2026-04-03T00:00:00.000Z',
+          direction: 'inbound',
+          status: 'history_only',
+          conversation: 'chat-1',
+          sender: 'Alice',
+          messageType: 'file',
+          content: 'quarterly report',
+          attachmentStatus: 'ready (1)',
+          botMentioned: false,
+          xpertId: 'xpert-1',
+          error: null
+        }
+      ],
+      total: 1
+    })
+
+    expect(messageHistoryService.listMessageLogs).toHaveBeenCalledWith({
+      integrationId: 'integration-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      cursor: undefined,
+      page: 1,
+      pageSize: 10,
+      search: 'report',
+      sortBy: 'createdAt',
+      sortDirection: 'desc'
+    })
+    expect(messageHistoryService.listMessageFiles).toHaveBeenCalledWith({
+      integrationId: 'integration-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      messageLogIds: ['message-log-1']
+    })
+  })
+
   it('refreshes and invokes reconnect or disconnect for long connection integrations', async () => {
     const { provider, longConnectionService } = createFixture('long_connection')
 
     await expect(provider.executeViewAction(createContext(), 'status', 'refresh', {})).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        refresh: true
+      })
+    )
+    await expect(provider.executeViewAction(createContext(), 'messages', 'refresh', {})).resolves.toEqual(
       expect.objectContaining({
         success: true,
         refresh: true

--- a/xpertai/integrations/lark/src/lib/views/lark-integration-view.provider.ts
+++ b/xpertai/integrations/lark/src/lib/views/lark-integration-view.provider.ts
@@ -1,6 +1,8 @@
 import type {
   I18nObject,
   XpertExtensionViewManifest,
+  XpertRemoteComponentEntry,
+  XpertRemoteComponentViewSchema,
   XpertResolvedViewHostContext,
   XpertViewActionRequest,
   XpertViewActionResult,
@@ -23,6 +25,12 @@ import {
   LarkManagedConnectionInfo
 } from '../lark-long-connection.service.js'
 import { LARK_PLUGIN_NAME, LARK_VIEW_PROVIDER_KEY } from '../constants.js'
+import { LarkMessageHistoryService } from '../lark-message-history.service.js'
+import type { LarkMessageFileEntity, LarkMessageLogEntity } from '../entities/index.js'
+import {
+  LARK_MESSAGE_HISTORY_REMOTE_ENTRY,
+  renderLarkMessageHistoryRemoteHtml
+} from './lark-message-history.remote.js'
 
 const DEFAULT_PAGE_SIZE = 10
 
@@ -73,6 +81,21 @@ type LarkConversationViewRow = {
   updatedAt: string | null
 }
 
+type LarkMessageViewRow = {
+  id: string
+  createdAt: string | null
+  direction: string
+  status: string
+  conversation: string
+  sender: string | null
+  messageType: string | null
+  content: string | null
+  attachmentStatus: string | null
+  botMentioned: boolean
+  xpertId: string
+  error: string | null
+}
+
 @Injectable()
 @ViewExtensionProvider(LARK_VIEW_PROVIDER_KEY)
 export class LarkIntegrationViewProvider implements IXpertViewExtensionProvider {
@@ -80,7 +103,8 @@ export class LarkIntegrationViewProvider implements IXpertViewExtensionProvider 
     private readonly longConnectionService: LarkLongConnectionService,
     private readonly larkChannel: LarkChannelStrategy,
     private readonly recipientDirectoryService: LarkRecipientDirectoryService,
-    private readonly conversationService: LarkConversationService
+    private readonly conversationService: LarkConversationService,
+    private readonly messageHistoryService: LarkMessageHistoryService
   ) {}
 
   supports(context: XpertResolvedViewHostContext) {
@@ -320,8 +344,62 @@ export class LarkIntegrationViewProvider implements IXpertViewExtensionProvider 
             ttlMs: 30 * 1000
           }
         }
+      },
+      {
+        key: 'messages',
+        title: text('Messages', '消息'),
+        hostType: context.hostType,
+        slot,
+        order: 50,
+        refreshable: true,
+        source: {
+          provider: LARK_VIEW_PROVIDER_KEY,
+          plugin: LARK_PLUGIN_NAME
+        },
+        view: {
+          type: 'remote_component',
+          runtime: 'react',
+          protocolVersion: 1,
+          component: {
+            isolation: 'iframe',
+            entry: LARK_MESSAGE_HISTORY_REMOTE_ENTRY
+          },
+          dataSource: {
+            mode: 'platform'
+          }
+        },
+        dataSource: {
+          mode: 'platform',
+          querySchema: {
+            supportsPagination: true,
+            supportsSearch: true,
+            supportsSort: true,
+            defaultPageSize: DEFAULT_PAGE_SIZE
+          },
+          cache: {
+            enabled: false
+          }
+        }
       }
     ]
+  }
+
+  getRemoteComponentEntry(
+    _context: XpertResolvedViewHostContext,
+    viewKey: string,
+    component: XpertRemoteComponentViewSchema['component']
+  ): XpertRemoteComponentEntry {
+    if (viewKey !== 'messages' || component.entry !== LARK_MESSAGE_HISTORY_REMOTE_ENTRY) {
+      return {
+        html: '<!doctype html><html><body>Unsupported Lark remote component.</body></html>',
+        contentType: 'text/html; charset=utf-8'
+      }
+    }
+
+    return {
+      html: renderLarkMessageHistoryRemoteHtml(),
+      contentType: 'text/html; charset=utf-8'
+    }
   }
 
   async getViewData(
@@ -374,6 +452,33 @@ export class LarkIntegrationViewProvider implements IXpertViewExtensionProvider 
       }
     }
 
+    if (viewKey === 'messages') {
+      const result = await this.messageHistoryService.listMessageLogs({
+        integrationId: context.hostId,
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        cursor: query.cursor,
+        page: query.page,
+        pageSize: query.pageSize,
+        search: query.search,
+        sortBy: normalizeMessageSort(query.sortBy),
+        sortDirection: query.sortDirection ?? null
+      })
+      const files = await this.messageHistoryService.listMessageFiles({
+        integrationId: context.hostId,
+        tenantId: context.tenantId,
+        organizationId: context.organizationId,
+        messageLogIds: result.items.map((item) => item.id)
+      })
+      const filesByLogId = groupMessageFiles(files)
+
+      return {
+        items: result.items.map((item) => this.mapMessageRow(item, filesByLogId.get(item.id) ?? [])),
+        total: result.total,
+        ...(result.nextCursor ? { nextCursor: result.nextCursor } : {})
+      }
+    }
+
     return {}
   }
 
@@ -383,7 +488,7 @@ export class LarkIntegrationViewProvider implements IXpertViewExtensionProvider 
     actionKey: string,
     _request: XpertViewActionRequest
   ): Promise<XpertViewActionResult> {
-    if (viewKey !== 'status' && viewKey !== 'connections') {
+    if (viewKey !== 'status' && viewKey !== 'connections' && viewKey !== 'messages') {
       return {
         success: false,
         message: text('Unsupported action', '不支持的操作')
@@ -521,6 +626,57 @@ export class LarkIntegrationViewProvider implements IXpertViewExtensionProvider 
       updatedAt: formatDateTime(item.updatedAt)
     }
   }
+
+  private mapMessageRow(item: LarkMessageLogEntity, files: LarkMessageFileEntity[]): LarkMessageViewRow {
+    return {
+      id: item.id,
+      createdAt: formatDateTime(item.createdAt),
+      direction: item.direction,
+      status: item.status,
+      conversation: item.chatId ?? item.scopeKey,
+      sender: item.senderName ?? item.senderOpenId ?? null,
+      messageType: item.messageType ?? null,
+      content: item.content ?? null,
+      attachmentStatus: summarizeAttachmentStatuses(files),
+      botMentioned: item.botMentioned,
+      xpertId: item.xpertId,
+      error: item.error ?? null
+    }
+  }
+}
+
+function normalizeMessageSort(
+  value: string | null | undefined
+): 'createdAt' | 'messageCreatedAt' | 'direction' | 'status' | 'senderName' | 'botMentioned' | null {
+  return value === 'createdAt' ||
+    value === 'messageCreatedAt' ||
+    value === 'direction' ||
+    value === 'status' ||
+    value === 'senderName' ||
+    value === 'botMentioned'
+    ? value
+    : null
+}
+
+function groupMessageFiles(files: LarkMessageFileEntity[]): Map<string, LarkMessageFileEntity[]> {
+  const result = new Map<string, LarkMessageFileEntity[]>()
+  for (const file of files) {
+    const items = result.get(file.messageLogId) ?? []
+    items.push(file)
+    result.set(file.messageLogId, items)
+  }
+  return result
+}
+
+function summarizeAttachmentStatuses(files: LarkMessageFileEntity[]): string | null {
+  if (!files.length) {
+    return null
+  }
+  const counts = new Map<string, number>()
+  for (const file of files) {
+    counts.set(file.status, (counts.get(file.status) ?? 0) + 1)
+  }
+  return [...counts.entries()].map(([status, count]) => `${status} (${count})`).join(', ')
 }
 
 function buildFallbackStatusSummary(hostSnapshot: unknown): LarkStatusSummary {

--- a/xpertai/integrations/lark/src/lib/views/lark-message-history.remote.ts
+++ b/xpertai/integrations/lark/src/lib/views/lark-message-history.remote.ts
@@ -1,0 +1,436 @@
+export const LARK_MESSAGE_HISTORY_REMOTE_ENTRY = 'lark-message-history'
+
+const REMOTE_COMPONENT_CHANNEL = 'xpertai.remote_component'
+const REMOTE_COMPONENT_PROTOCOL_VERSION = 1
+
+export function renderLarkMessageHistoryRemoteHtml(): string {
+  const script = buildRemoteScript()
+  return `<!doctype html>
+<html lang="zh-Hans">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Lark Message History</title>
+    <style>${REMOTE_STYLES}</style>
+  </head>
+  <body>
+    <main id="app" class="app-shell" aria-busy="false">
+      <form id="toolbar" class="toolbar">
+        <input id="search" class="search-input" type="search" autocomplete="off" />
+        <button id="refresh" class="button button-secondary" type="button">
+          <span aria-hidden="true">↻</span><span id="refresh-label"></span>
+        </button>
+        <button id="submit" class="button button-primary" type="submit"></button>
+      </form>
+      <div id="notice" class="notice" role="status" aria-live="polite"></div>
+      <section class="table-frame" aria-label="Lark message history">
+        <table>
+          <colgroup id="columns"></colgroup>
+          <thead><tr id="headers"></tr></thead>
+          <tbody id="rows"></tbody>
+        </table>
+        <div id="empty" class="empty" hidden></div>
+      </section>
+      <footer class="pagination">
+        <span id="total" class="total"></span>
+        <div class="page-actions">
+          <button id="previous" class="button button-secondary" type="button"></button>
+          <span id="page" class="page-number"></span>
+          <button id="next" class="button button-secondary" type="button"></button>
+        </div>
+      </footer>
+    </main>
+    <script>${escapeInlineScript(script)}</script>
+  </body>
+</html>`
+}
+
+function buildRemoteScript(): string {
+  return `(() => {
+  const CHANNEL = ${JSON.stringify(REMOTE_COMPONENT_CHANNEL)}
+  const VERSION = ${REMOTE_COMPONENT_PROTOCOL_VERSION}
+  const PAGE_SIZE = 10
+  const VIEWPORT_HEIGHT = 720
+  const pending = new Map()
+  let instanceId = null
+  let requestSequence = 0
+  let readyTimer = null
+  const state = {
+    locale: 'zh-Hans',
+    page: 1,
+    pageSize: PAGE_SIZE,
+    search: '',
+    sortBy: 'createdAt',
+    sortDirection: 'desc',
+    cursors: [null],
+    nextCursor: null,
+    total: 0,
+    items: [],
+    loading: false,
+    error: ''
+  }
+
+  const definitions = [
+    { key: 'createdAt', labels: ['Time', '时间'], width: '12rem', sortBy: 'createdAt' },
+    { key: 'direction', labels: ['Direction', '方向'], width: '7rem', sortBy: 'direction' },
+    { key: 'status', labels: ['Status', '状态'], width: '8rem', sortBy: 'status' },
+    { key: 'conversation', labels: ['Conversation', '会话'], width: '18rem' },
+    { key: 'sender', labels: ['Sender', '发送者'], width: '18rem', sortBy: 'senderName' },
+    { key: 'messageType', labels: ['Type', '类型'], width: '7rem' },
+    { key: 'content', labels: ['Content', '正文'], width: '24rem' },
+    { key: 'attachmentStatus', labels: ['Attachments', '附件状态'], width: '10rem' },
+    { key: 'botMentioned', labels: ['Mentioned', '是否 @'], width: '8rem', sortBy: 'botMentioned' },
+    { key: 'xpertId', labels: ['Xpert', 'Xpert'], width: '18rem' },
+    { key: 'error', labels: ['Error', '错误'], width: '18rem' }
+  ]
+
+  const copy = {
+    en: {
+      searchPlaceholder: 'Search messages', refresh: 'Refresh', search: 'Search', loading: 'Loading…',
+      empty: 'No messages', failed: 'Unable to load messages', previous: 'Previous', next: 'Next',
+      page: (page, pages) => 'Page ' + page + ' / ' + pages,
+      total: (total) => total + ' message' + (total === 1 ? '' : 's')
+    },
+    zh: {
+      searchPlaceholder: '搜索消息', refresh: '刷新', search: '搜索', loading: '正在加载…',
+      empty: '暂无消息', failed: '消息加载失败', previous: '上一页', next: '下一页',
+      page: (page, pages) => '第 ' + page + ' / ' + pages + ' 页',
+      total: (total) => '共 ' + total + ' 条消息'
+    }
+  }
+
+  const elements = {
+    app: document.getElementById('app'), toolbar: document.getElementById('toolbar'),
+    search: document.getElementById('search'), refresh: document.getElementById('refresh'),
+    refreshLabel: document.getElementById('refresh-label'), submit: document.getElementById('submit'),
+    notice: document.getElementById('notice'), columns: document.getElementById('columns'),
+    headers: document.getElementById('headers'), rows: document.getElementById('rows'),
+    empty: document.getElementById('empty'), total: document.getElementById('total'),
+    previous: document.getElementById('previous'), next: document.getElementById('next'),
+    page: document.getElementById('page')
+  }
+
+  function language() {
+    return String(state.locale || '').toLowerCase().startsWith('en') ? copy.en : copy.zh
+  }
+
+  function label(pair) {
+    return language() === copy.en ? pair[0] : pair[1]
+  }
+
+  function post(type, body) {
+    if (!instanceId && type !== 'ready') return false
+    parent.postMessage(Object.assign({ channel: CHANNEL, protocolVersion: VERSION, instanceId, type }, body || {}), '*')
+    return true
+  }
+
+  function announceReady() {
+    post('ready')
+    if (readyTimer !== null) return
+    readyTimer = window.setInterval(() => {
+      if (instanceId) {
+        window.clearInterval(readyTimer)
+        readyTimer = null
+      } else {
+        post('ready')
+      }
+    }, 500)
+    window.setTimeout(() => {
+      if (readyTimer !== null) window.clearInterval(readyTimer)
+      readyTimer = null
+    }, 10000)
+  }
+
+  function requestData(query) {
+    const requestId = String(++requestSequence)
+    return new Promise((resolve, reject) => {
+      pending.set(requestId, { resolve, reject })
+      if (!post('requestData', { requestId, query })) {
+        pending.delete(requestId)
+        reject(new Error('Remote bridge is not initialized'))
+        return
+      }
+      window.setTimeout(() => {
+        if (!pending.has(requestId)) return
+        pending.delete(requestId)
+        reject(new Error('Request timed out'))
+      }, 30000)
+    })
+  }
+
+  function responsePayload(response) {
+    if (!response || typeof response !== 'object') return response || null
+    if (response.payload !== undefined) return response.payload
+    if (response.data !== undefined) return response.data
+    if (response.result !== undefined) return response.result
+    return response
+  }
+
+  function normalizePayload(response) {
+    let payload = responsePayload(response)
+    if (payload && typeof payload === 'object' && payload.data && !Array.isArray(payload.items)) payload = payload.data
+    if (payload && typeof payload === 'object' && payload.table && !Array.isArray(payload.items)) payload = payload.table
+    return payload && typeof payload === 'object' ? payload : {}
+  }
+
+  function applyTheme(theme) {
+    if (!theme || typeof theme !== 'object') return
+    const root = document.documentElement
+    const values = theme.variables && typeof theme.variables === 'object' ? theme.variables : theme
+    for (const [key, value] of Object.entries(values)) {
+      if (typeof value !== 'string' && typeof value !== 'number') continue
+      const cssKey = String(key).startsWith('--') ? String(key) : '--xpert-' + String(key).replace(/[A-Z]/g, (part) => '-' + part.toLowerCase())
+      root.style.setProperty(cssKey, String(value))
+    }
+  }
+
+  function reportResize() {
+    post('resize', { height: VIEWPORT_HEIGHT, viewportBound: true })
+  }
+
+  function formatDate(value) {
+    if (!value) return '–'
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return String(value)
+    try {
+      return new Intl.DateTimeFormat(state.locale || undefined, { dateStyle: 'medium', timeStyle: 'medium' }).format(date)
+    } catch {
+      return date.toISOString()
+    }
+  }
+
+  function cellText(item, key) {
+    const value = item ? item[key] : null
+    if (key === 'createdAt') return formatDate(value)
+    if (key === 'botMentioned') return value === true ? 'true' : value === false ? 'false' : '–'
+    if (value === null || value === undefined || value === '') return '–'
+    return typeof value === 'string' ? value : JSON.stringify(value)
+  }
+
+  function renderHeaders() {
+    elements.columns.replaceChildren()
+    elements.headers.replaceChildren()
+    for (const definition of definitions) {
+      const column = document.createElement('col')
+      column.style.width = definition.width
+      elements.columns.appendChild(column)
+      const header = document.createElement('th')
+      header.scope = 'col'
+      if (definition.sortBy) {
+        const button = document.createElement('button')
+        button.type = 'button'
+        button.className = 'sort-button'
+        const active = state.sortBy === definition.sortBy
+        button.textContent = label(definition.labels) + (active ? (state.sortDirection === 'asc' ? ' ↑' : ' ↓') : '')
+        button.addEventListener('click', () => {
+          if (state.sortBy === definition.sortBy) state.sortDirection = state.sortDirection === 'asc' ? 'desc' : 'asc'
+          else {
+            state.sortBy = definition.sortBy
+            state.sortDirection = definition.sortBy === 'senderName' ? 'asc' : 'desc'
+          }
+          state.page = 1
+          state.cursors = [null]
+          state.nextCursor = null
+          void load()
+        })
+        header.appendChild(button)
+      } else {
+        header.textContent = label(definition.labels)
+      }
+      elements.headers.appendChild(header)
+    }
+  }
+
+  function renderRows() {
+    elements.rows.replaceChildren()
+    for (const item of state.items) {
+      const row = document.createElement('tr')
+      for (const definition of definitions) {
+        const cell = document.createElement('td')
+        const value = cellText(item, definition.key)
+        cell.textContent = value
+        cell.title = value === '–' ? '' : value
+        row.appendChild(cell)
+      }
+      elements.rows.appendChild(row)
+    }
+  }
+
+  function render() {
+    const t = language()
+    const pages = Math.max(1, Math.ceil(state.total / state.pageSize))
+    elements.app.setAttribute('aria-busy', String(state.loading))
+    elements.search.placeholder = t.searchPlaceholder
+    elements.search.setAttribute('aria-label', t.searchPlaceholder)
+    elements.refreshLabel.textContent = t.refresh
+    elements.refresh.setAttribute('aria-label', t.refresh)
+    elements.submit.textContent = t.search
+    elements.previous.textContent = t.previous
+    elements.next.textContent = t.next
+    elements.total.textContent = t.total(state.total)
+    elements.page.textContent = t.page(state.page, pages)
+    elements.notice.textContent = state.error ? t.failed + ': ' + state.error : state.loading ? t.loading : ''
+    elements.notice.classList.toggle('notice-error', Boolean(state.error))
+    elements.empty.textContent = state.error ? t.failed : t.empty
+    elements.empty.hidden = state.loading || state.items.length > 0
+    elements.refresh.disabled = state.loading
+    elements.submit.disabled = state.loading
+    elements.previous.disabled = state.loading || state.page <= 1
+    elements.next.disabled = state.loading || !state.nextCursor
+    renderHeaders()
+    renderRows()
+  }
+
+  async function load() {
+    if (!instanceId || state.loading) return
+    state.loading = true
+    state.error = ''
+    render()
+    try {
+      const response = await requestData({
+        page: state.page,
+        pageSize: state.pageSize,
+        search: state.search || undefined,
+        cursor: state.cursors[state.page - 1] || undefined,
+        sortBy: state.sortBy,
+        sortDirection: state.sortDirection
+      })
+      const payload = normalizePayload(response)
+      state.items = Array.isArray(payload.items) ? payload.items : []
+      state.total = Number.isFinite(Number(payload.total)) ? Math.max(0, Number(payload.total)) : state.items.length
+      state.nextCursor = typeof payload.nextCursor === 'string' && payload.nextCursor ? payload.nextCursor : null
+      const pages = Math.max(1, Math.ceil(state.total / state.pageSize))
+      if (state.page > pages) {
+        state.page = 1
+        state.cursors = [null]
+        state.nextCursor = null
+        state.loading = false
+        return void load()
+      }
+    } catch (error) {
+      state.items = []
+      state.total = 0
+      state.error = error instanceof Error ? error.message : String(error || 'Unknown error')
+    } finally {
+      state.loading = false
+      render()
+      reportResize()
+    }
+  }
+
+  elements.toolbar.addEventListener('submit', (event) => {
+    event.preventDefault()
+    state.search = elements.search.value.trim()
+    state.page = 1
+    state.cursors = [null]
+    state.nextCursor = null
+    void load()
+  })
+  elements.refresh.addEventListener('click', () => {
+    state.page = 1
+    state.cursors = [null]
+    state.nextCursor = null
+    void load()
+  })
+  elements.previous.addEventListener('click', () => {
+    if (state.page <= 1) return
+    state.page -= 1
+    void load()
+  })
+  elements.next.addEventListener('click', () => {
+    if (!state.nextCursor) return
+    state.cursors[state.page] = state.nextCursor
+    state.page += 1
+    void load()
+  })
+
+  window.addEventListener('message', (event) => {
+    const message = event.data
+    if (!message || typeof message !== 'object' || message.channel !== CHANNEL || message.protocolVersion !== VERSION) return
+    if (message.type === 'init') {
+      instanceId = typeof message.instanceId === 'string' ? message.instanceId : null
+      state.locale = typeof message.locale === 'string' ? message.locale : state.locale
+      const initialQuery = message.initialQuery && typeof message.initialQuery === 'object' ? message.initialQuery : {}
+      state.page = 1
+      state.cursors = [typeof initialQuery.cursor === 'string' && initialQuery.cursor ? initialQuery.cursor : null]
+      state.search = typeof initialQuery.search === 'string' ? initialQuery.search.trim() : ''
+      state.sortBy = definitions.some((definition) => definition.sortBy === initialQuery.sortBy)
+        ? initialQuery.sortBy
+        : state.sortBy
+      state.sortDirection = initialQuery.sortDirection === 'asc' ? 'asc' : 'desc'
+      elements.search.value = state.search
+      applyTheme(message.theme)
+      if (readyTimer !== null) window.clearInterval(readyTimer)
+      readyTimer = null
+      render()
+      reportResize()
+      void load()
+      return
+    }
+    if (message.instanceId !== instanceId) return
+    if (message.type === 'theme' || message.type === 'themeChanged' || message.type === 'theme-change') {
+      applyTheme(message.theme || (message.payload && message.payload.theme) || message.payload)
+      return
+    }
+    if (message.requestId !== undefined) {
+      const key = String(message.requestId)
+      const item = pending.get(key)
+      if (!item) return
+      pending.delete(key)
+      if (message.type === 'error') item.reject(new Error(String(message.message || 'Remote request failed')))
+      else item.resolve(message)
+    }
+  })
+
+  render()
+  announceReady()
+})()`
+}
+
+function escapeInlineScript(value: string): string {
+  return value.replace(/<\/script/gi, '<\\/script')
+}
+
+const REMOTE_STYLES = `
+:root {
+  color-scheme: light dark;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --surface: var(--xpert-background, #ffffff);
+  --surface-muted: var(--xpert-muted, #f7f7f8);
+  --text: var(--xpert-foreground, #18181b);
+  --text-muted: var(--xpert-muted-foreground, #71717a);
+  --border: var(--xpert-border, #e4e4e7);
+  --primary: var(--xpert-primary, #18181b);
+  --primary-text: var(--xpert-primary-foreground, #ffffff);
+}
+* { box-sizing: border-box; }
+html, body { width: 100%; height: 100%; min-height: 0; margin: 0; overflow: hidden; background: var(--surface); color: var(--text); }
+button, input { font: inherit; }
+.app-shell { display: flex; height: min(720px, 100vh); min-height: 0; flex-direction: column; gap: 12px; padding: 16px; overflow: hidden; }
+.toolbar { display: flex; flex: 0 0 auto; align-items: center; gap: 8px; }
+.search-input { min-width: 0; height: 36px; flex: 1 1 auto; border: 1px solid var(--border); border-radius: 8px; background: var(--surface); color: var(--text); padding: 0 12px; outline: none; }
+.search-input:focus { border-color: var(--primary); box-shadow: 0 0 0 2px color-mix(in srgb, var(--primary) 18%, transparent); }
+.button { display: inline-flex; height: 36px; flex: 0 0 auto; align-items: center; justify-content: center; gap: 6px; border-radius: 8px; padding: 0 13px; cursor: pointer; white-space: nowrap; }
+.button:disabled { cursor: default; opacity: .5; }
+.button-primary { border: 1px solid var(--primary); background: var(--primary); color: var(--primary-text); }
+.button-secondary { border: 1px solid var(--border); background: var(--surface); color: var(--text); }
+.button:not(:disabled):hover { filter: brightness(.97); }
+.notice { min-height: 18px; flex: 0 0 auto; color: var(--text-muted); font-size: 12px; }
+.notice:empty { display: none; }
+.notice-error { color: #dc2626; }
+.table-frame { position: relative; min-height: 0; flex: 1 1 auto; overflow: auto; border: 1px solid var(--border); border-radius: 9px; background: var(--surface); overscroll-behavior: contain; }
+table { min-width: 158rem; width: max-content; border-collapse: separate; border-spacing: 0; table-layout: fixed; font-size: 13px; }
+thead { position: sticky; top: 0; z-index: 2; }
+th { height: 42px; border-bottom: 1px solid var(--border); background: var(--surface-muted); color: var(--text-muted); padding: 0 12px; text-align: left; font-weight: 600; }
+td { height: 52px; max-height: 92px; border-bottom: 1px solid var(--border); padding: 10px 12px; overflow: hidden; color: var(--text); text-overflow: ellipsis; vertical-align: top; white-space: normal; word-break: break-word; }
+tbody tr:last-child td { border-bottom: 0; }
+tbody tr:hover td { background: color-mix(in srgb, var(--surface-muted) 65%, transparent); }
+.sort-button { width: 100%; border: 0; background: transparent; color: inherit; padding: 0; cursor: pointer; text-align: left; font-weight: inherit; }
+.empty { position: absolute; inset: 42px 0 0; padding: 48px 16px; color: var(--text-muted); text-align: center; }
+.pagination { display: flex; min-height: 36px; flex: 0 0 auto; align-items: center; justify-content: space-between; gap: 12px; }
+.total, .page-number { color: var(--text-muted); font-size: 13px; }
+.page-actions { display: flex; align-items: center; gap: 8px; }
+@media (prefers-color-scheme: dark) {
+  :root { --surface: var(--xpert-background, #18181b); --surface-muted: var(--xpert-muted, #27272a); --text: var(--xpert-foreground, #fafafa); --text-muted: var(--xpert-muted-foreground, #a1a1aa); --border: var(--xpert-border, #3f3f46); --primary: var(--xpert-primary, #fafafa); --primary-text: var(--xpert-primary-foreground, #18181b); }
+}
+`

--- a/xpertai/integrations/lark/src/lib/workflow/lark-trigger-aggregation.types.ts
+++ b/xpertai/integrations/lark/src/lib/workflow/lark-trigger-aggregation.types.ts
@@ -39,6 +39,10 @@ export interface LarkTriggerAggregationState {
 	version: number
 	inputParts: string[]
 	files?: LarkInboundFile[]
+	historyContext?: string
+	historyFiles?: LarkInboundFile[]
+	currentInboundLogIds?: string[]
+	historyBefore?: string
 	lastMessageAt: number
 	tenantId?: string
 	organizationId?: string

--- a/xpertai/integrations/lark/src/lib/workflow/lark-trigger.strategy.spec.ts
+++ b/xpertai/integrations/lark/src/lib/workflow/lark-trigger.strategy.spec.ts
@@ -29,7 +29,12 @@ const DEFAULT_TRIGGER_CONFIG = {
 	groupUserOpenIds: [],
 	groupReplyStrategy: 'mention_only',
 	sessionTimeoutSeconds: 3600,
-	summaryWindowSeconds: 0
+	summaryWindowSeconds: 0,
+	captureUnmentionedGroupMessages: false,
+	historyContextLimit: 20,
+	historyContextWindowSeconds: 3600,
+	historyRetentionDays: 30,
+	historyAttachmentMaxSizeMb: 10
 } as const
 
 type PersistedBinding = {
@@ -37,6 +42,9 @@ type PersistedBinding = {
 	xpertId: string
 	config?: Record<string, unknown>
 	ownerOpenId?: string | null
+	tenantId?: string | null
+	organizationId?: string | null
+	createdById?: string | null
 }
 
 describe('LarkTriggerStrategy', () => {
@@ -150,12 +158,20 @@ describe('LarkTriggerStrategy', () => {
 				throw new Error(`Unexpected token: ${String(token)}`)
 			})
 		}
+		const messageHistoryService = {
+			updateInboundStatus: jest.fn().mockResolvedValue(undefined)
+		}
+		const messageHistoryQueue = {
+			scheduleCleanup: jest.fn().mockResolvedValue(undefined)
+		}
 
 		const strategy = new (LarkTriggerStrategy as any)(
 			dispatchService as any,
 			aggregationService as any,
 			larkChannel as any,
 			bindingRepository as any,
+			messageHistoryService as any,
+			messageHistoryQueue as any,
 			pluginContext as any
 		)
 		return {
@@ -164,6 +180,8 @@ describe('LarkTriggerStrategy', () => {
 			aggregationService,
 			handoffPermissionService,
 			bindingRepository,
+			messageHistoryService,
+			messageHistoryQueue,
 			persistedBindings
 		}
 	}
@@ -177,11 +195,14 @@ describe('LarkTriggerStrategy', () => {
 				...DEFAULT_TRIGGER_CONFIG
 			},
 			ownerOpenId: 'ou_owner_1',
+			tenantId: 'tenant-1',
+			organizationId: 'org-1',
+			createdById: 'user-1',
 			...overrides
 		}
 	}
 
-	it('exposes session timeout and summary window defaults in trigger schema', () => {
+	it('exposes session, summary, and stored-history defaults in trigger schema', () => {
 		const { strategy } = createStrategy()
 		const properties = strategy.meta.configSchema.properties as Record<string, any>
 
@@ -195,6 +216,63 @@ describe('LarkTriggerStrategy', () => {
 			en_US: 'Summary Window (seconds)',
 			zh_Hans: '汇总时间（秒）'
 		})
+		expect(properties.captureUnmentionedGroupMessages.default).toBe(false)
+		expect(properties.historyContextLimit).toEqual(
+			expect.objectContaining({ default: 20, minimum: 0, maximum: 100 })
+		)
+		expect(properties.historyContextWindowSeconds).toEqual(
+			expect.objectContaining({ default: 3600, minimum: 0 })
+		)
+		expect(properties.historyRetentionDays).toEqual(
+			expect.objectContaining({ default: 30, minimum: 0 })
+		)
+		expect(properties.historyRetentionDays.description.zh_Hans).toContain('0 表示永久保留')
+		expect(properties.historyAttachmentMaxSizeMb).toEqual(
+			expect.objectContaining({ default: 10, minimum: 1, maximum: 25 })
+		)
+	})
+
+	it('keeps legacy persisted bindings opted out when history fields are missing', () => {
+		const { strategy } = createStrategy()
+
+		expect(
+			strategy.normalizeConfig({
+				enabled: true,
+				integrationId: 'integration-1'
+			})
+		).toEqual(
+			expect.objectContaining({
+				captureUnmentionedGroupMessages: false,
+				historyContextLimit: 0,
+				historyContextWindowSeconds: 3600,
+				historyRetentionDays: 30,
+				historyAttachmentMaxSizeMb: 10
+			})
+		)
+	})
+
+	it('normalizes explicitly configured message-history fields', () => {
+		const { strategy } = createStrategy()
+
+		expect(
+			strategy.normalizeConfig({
+				enabled: true,
+				integrationId: 'integration-1',
+				captureUnmentionedGroupMessages: true,
+				historyContextLimit: 999,
+				historyContextWindowSeconds: 0,
+				historyRetentionDays: 0,
+				historyAttachmentMaxSizeMb: 999
+			})
+		).toEqual(
+			expect.objectContaining({
+				captureUnmentionedGroupMessages: true,
+				historyContextLimit: 100,
+				historyContextWindowSeconds: 0,
+				historyRetentionDays: 0,
+				historyAttachmentMaxSizeMb: 25
+			})
+		)
 	})
 
 	it('reports validation error when integration is missing', async () => {
@@ -458,6 +536,69 @@ describe('LarkTriggerStrategy', () => {
 		).toBe(true)
 	})
 
+	it('matches inbound scope without applying the group mention requirement', () => {
+		const { strategy } = createStrategy()
+		const binding = createBinding({
+			config: {
+				integrationId: 'integration-1',
+				...DEFAULT_TRIGGER_CONFIG,
+				allowedGroupScope: 'selected_chats',
+				allowedGroupChatIds: ['chat-1'],
+				groupReplyStrategy: 'mention_only'
+			}
+		})
+
+		expect(
+			strategy.matchesInboundScope({
+				binding: binding as any,
+				integrationId: 'integration-1',
+				chatType: 'group',
+				chatId: 'chat-1',
+				senderOpenId: 'ou_sender_1',
+				botMentioned: false
+			})
+		).toBe(true)
+		expect(
+			strategy.matchesInboundScope({
+				binding: binding as any,
+				integrationId: 'integration-1',
+				chatType: 'group',
+				chatId: 'chat-2',
+				senderOpenId: 'ou_sender_1',
+				botMentioned: true
+			})
+		).toBe(false)
+		expect(
+			strategy.matchesInboundScope({
+				binding: binding as any,
+				integrationId: 'integration-2',
+				chatType: 'group',
+				chatId: 'chat-1',
+				senderOpenId: 'ou_sender_1',
+				botMentioned: true
+			})
+		).toBe(false)
+	})
+
+	it('checks inbound scope before applying group reply strategy', () => {
+		const { strategy } = createStrategy()
+		const scopeSpy = jest.spyOn(strategy, 'matchesInboundScope').mockReturnValue(false)
+
+		expect(
+			strategy.matchesInboundMessage({
+				config: {
+					integrationId: 'integration-1',
+					...DEFAULT_TRIGGER_CONFIG,
+					groupReplyStrategy: 'all_messages'
+				},
+				integrationId: 'integration-1',
+				chatType: 'group',
+				botMentioned: true
+			})
+		).toBe(false)
+		expect(scopeSpy).toHaveBeenCalledTimes(1)
+	})
+
 	it('publishes normalized config without owner open id for supported scopes', async () => {
 		const { strategy, bindingRepository, persistedBindings } = createStrategy()
 
@@ -490,6 +631,31 @@ describe('LarkTriggerStrategy', () => {
 				})
 			})
 		)
+	})
+
+	it('does not block trigger publication when cleanup scheduling fails', async () => {
+		const { strategy, bindingRepository, messageHistoryQueue } = createStrategy()
+		const callback = jest.fn()
+		messageHistoryQueue.scheduleCleanup.mockRejectedValueOnce(new Error('cleanup queue unavailable'))
+
+		await expect(
+			strategy.publish(
+				{
+					xpertId: 'xpert-1',
+					config: {
+						integrationId: 'integration-1',
+						enabled: true,
+						captureUnmentionedGroupMessages: true,
+						historyRetentionDays: 30
+					}
+				} as any,
+				callback
+			)
+		).resolves.toBeUndefined()
+
+		expect(bindingRepository.upsert).toHaveBeenCalledTimes(1)
+		expect(messageHistoryQueue.scheduleCleanup).toHaveBeenCalledTimes(1)
+		expect((strategy as any).callbacks.get('integration-1')).toBe(callback)
 	})
 
 	it('persists zero summary window without changing session timeout fallback behavior', async () => {
@@ -650,6 +816,10 @@ describe('LarkTriggerStrategy', () => {
 				integrationId: 'integration-1',
 				input: '第一条消息',
 				files: [{ fileUrl: 'data:image/png;base64,YWJj', mimeType: 'image/png' }],
+				historyContext: '[历史上下文]\n用户: 更早消息',
+				historyFiles: [{ fileAssetId: 'history-asset-1' }],
+				currentInboundLogIds: ['log-1'],
+				historyBefore: '2026-07-15T08:00:00.000Z',
 				larkMessage: {
 					integrationId: 'integration-1',
 					chatId: 'chat-1',
@@ -678,6 +848,13 @@ describe('LarkTriggerStrategy', () => {
 				version: 1,
 				inputParts: ['第一条消息'],
 				files: [{ fileUrl: 'data:image/png;base64,YWJj', mimeType: 'image/png' }],
+				historyContext: '[历史上下文]\n用户: 更早消息',
+				historyFiles: [{ fileAssetId: 'history-asset-1' }],
+				currentInboundLogIds: ['log-1'],
+				historyBefore: '2026-07-15T08:00:00.000Z',
+				tenantId: 'tenant-1',
+				organizationId: 'org-1',
+				executorUserId: 'user-1',
 				endUserId: 'mapped-user-1',
 				latestMessage: expect.objectContaining({
 					chatId: 'chat-1',
@@ -689,6 +866,11 @@ describe('LarkTriggerStrategy', () => {
 		)
 		expect(handoffPermissionService.enqueue).toHaveBeenCalledWith(
 			expect.objectContaining({
+				tenantId: 'tenant-1',
+				headers: expect.objectContaining({
+					organizationId: 'org-1',
+					userId: 'user-1'
+				}),
 				payload: {
 					aggregateKey: 'lark:v2:scope:integration-1:group:chat-1',
 					version: 1
@@ -702,7 +884,7 @@ describe('LarkTriggerStrategy', () => {
 	})
 
 	it('flushes the current aggregate into a single dispatch payload', async () => {
-		const { strategy, aggregationService, dispatchService } = createStrategy()
+		const { strategy, aggregationService, dispatchService, messageHistoryService } = createStrategy()
 		aggregationService.get.mockResolvedValue({
 			aggregateKey: 'lark:v2:scope:integration-1:group:chat-1',
 			integrationId: 'integration-1',
@@ -710,6 +892,9 @@ describe('LarkTriggerStrategy', () => {
 			version: 2,
 			inputParts: ['第一条消息', '第二条消息'],
 			files: [{ fileUrl: 'data:image/png;base64,YWJj', mimeType: 'image/png' }],
+			historyContext: '[历史上下文]\n用户: 更早消息',
+			historyFiles: [{ fileAssetId: 'history-asset-1' }],
+			currentInboundLogIds: ['log-1', 'log-2'],
 			lastMessageAt: Date.now(),
 			tenantId: 'tenant-1',
 			organizationId: 'org-1',
@@ -740,14 +925,26 @@ describe('LarkTriggerStrategy', () => {
 		expect(dispatchService.enqueueDispatch).toHaveBeenCalledWith(
 			expect.objectContaining({
 				xpertId: 'xpert-1',
+				executionContext: {
+					tenantId: 'tenant-1',
+					organizationId: 'org-1',
+					createdById: 'user-1'
+				},
 				input: '第一条消息\n第二条消息',
 				files: [{ fileUrl: 'data:image/png;base64,YWJj', mimeType: 'image/png' }],
+				historyContext: '[历史上下文]\n用户: 更早消息',
+				historyFiles: [{ fileAssetId: 'history-asset-1' }],
+				currentInboundLogIds: ['log-1', 'log-2'],
 				options: expect.objectContaining({
 					fromEndUserId: 'mapped-user-1'
 				})
 			})
 		)
 		expect(dispatchService.enqueueDispatch.mock.calls[0][0].larkMessage.chatId).toBe('chat-1')
+		expect(messageHistoryService.updateInboundStatus).toHaveBeenCalledWith(
+			['log-1', 'log-2'],
+			'dispatched'
+		)
 		expect(aggregationService.clear).toHaveBeenCalledWith('lark:v2:scope:integration-1:group:chat-1')
 	})
 })

--- a/xpertai/integrations/lark/src/lib/workflow/lark-trigger.strategy.ts
+++ b/xpertai/integrations/lark/src/lib/workflow/lark-trigger.strategy.ts
@@ -17,6 +17,8 @@ import { randomUUID } from 'crypto'
 import { Repository } from 'typeorm'
 import { LarkChannelStrategy } from '../lark-channel.strategy.js'
 import { LarkChatDispatchService } from '../handoff/lark-chat-dispatch.service.js'
+import { LarkMessageHistoryQueueService } from '../lark-message-history-queue.service.js'
+import { LarkMessageHistoryService } from '../lark-message-history.service.js'
 import { ChatLarkMessage } from '../message.js'
 import { LARK_PLUGIN_CONTEXT } from '../tokens.js'
 import type { LarkGroupWindow, LarkInboundFile, TIntegrationLarkOptions } from '../types.js'
@@ -40,6 +42,13 @@ import {
 
 const DEFAULT_SESSION_TIMEOUT_SECONDS = 3600
 const DEFAULT_SUMMARY_WINDOW_SECONDS = 0
+const DEFAULT_HISTORY_CONTEXT_LIMIT = 20
+const MAX_HISTORY_CONTEXT_LIMIT = 100
+const DEFAULT_HISTORY_CONTEXT_WINDOW_SECONDS = 3600
+const DEFAULT_HISTORY_RETENTION_DAYS = 30
+const DEFAULT_HISTORY_ATTACHMENT_MAX_SIZE_MB = 10
+const MIN_HISTORY_ATTACHMENT_MAX_SIZE_MB = 1
+const MAX_HISTORY_ATTACHMENT_MAX_SIZE_MB = 25
 
 type TLarkInboundDispatchOptions = {
 	confirm?: boolean
@@ -130,6 +139,60 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 						zh_Hans: '连续消息会在该窗口内汇总后再发送给数字专家。'
 					},
 					default: DEFAULT_SUMMARY_WINDOW_SECONDS
+				},
+				historyContextLimit: {
+					type: 'number',
+					title: {
+						en_US: 'History Context Limit',
+						zh_Hans: '历史上下文条数'
+					},
+					description: {
+						en_US: 'Recent stored messages to prepend as context. Set to 0 to disable.',
+						zh_Hans: '作为上下文附加的最近已存消息条数。设为 0 表示关闭。'
+					},
+					default: DEFAULT_HISTORY_CONTEXT_LIMIT,
+					minimum: 0,
+					maximum: MAX_HISTORY_CONTEXT_LIMIT
+				},
+				historyContextWindowSeconds: {
+					type: 'number',
+					title: {
+						en_US: 'History Context Window (seconds)',
+						zh_Hans: '历史上下文时间窗口（秒）'
+					},
+					description: {
+						en_US: 'Only messages newer than this window are included. Set to 0 for no time limit.',
+						zh_Hans: '只附加该时间窗口内的消息。设为 0 表示不限制时间。'
+					},
+					default: DEFAULT_HISTORY_CONTEXT_WINDOW_SECONDS,
+					minimum: 0
+				},
+				historyRetentionDays: {
+					type: 'number',
+					title: {
+						en_US: 'History Retention (days)',
+						zh_Hans: '历史消息保留天数'
+					},
+					description: {
+						en_US: 'Stored message history is deleted after this many days. Set to 0 to retain forever.',
+						zh_Hans: '已存消息超过该天数后删除。设为 0 表示永久保留。'
+					},
+					default: DEFAULT_HISTORY_RETENTION_DAYS,
+					minimum: 0
+				},
+				historyAttachmentMaxSizeMb: {
+					type: 'number',
+					title: {
+						en_US: 'History Attachment Max Size (MiB)',
+						zh_Hans: '历史附件最大大小（MiB）'
+					},
+					description: {
+						en_US: 'Attachments larger than this value are not retained for history context.',
+						zh_Hans: '超过该大小的附件不会保留用于历史上下文。'
+					},
+					default: DEFAULT_HISTORY_ATTACHMENT_MAX_SIZE_MB,
+					minimum: MIN_HISTORY_ATTACHMENT_MAX_SIZE_MB,
+					maximum: MAX_HISTORY_ATTACHMENT_MAX_SIZE_MB
 				},
 				singleChatScope: {
 					type: 'string',
@@ -304,6 +367,18 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 							}
 						}
 					} as any
+				},
+				captureUnmentionedGroupMessages: {
+					type: 'boolean',
+					title: {
+						en_US: 'Capture Unmentioned Group Messages',
+						zh_Hans: '记录群聊中未 @ 机器人的消息'
+					},
+					description: {
+						en_US: 'Store in-scope group messages even when the bot is not mentioned, so they can be used as later history context.',
+						zh_Hans: '记录范围内未 @ 机器人的群消息，供后续触发时作为历史上下文。'
+					},
+					default: false
 				}
 			},
 			required: ['enabled', 'integrationId'],
@@ -324,6 +399,8 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		private readonly larkChannel: LarkChannelStrategy,
 		@InjectRepository(LarkTriggerBindingEntity)
 		private readonly bindingRepository: Repository<LarkTriggerBindingEntity>,
+		private readonly messageHistoryService: LarkMessageHistoryService,
+		private readonly messageHistoryQueue: LarkMessageHistoryQueueService,
 		@Inject(LARK_PLUGIN_CONTEXT)
 		private readonly pluginContext: PluginContext
 	) {}
@@ -358,6 +435,24 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			singleChatUserOpenIds: this.normalizeStringArray(config?.singleChatUserOpenIds),
 			allowedGroupChatIds: this.normalizeStringArray(config?.allowedGroupChatIds),
 			groupUserOpenIds: this.normalizeStringArray(config?.groupUserOpenIds),
+			// Missing fields identify bindings persisted before message history was introduced.
+			// Keep those bindings opt-in instead of silently enabling capture or history context.
+			captureUnmentionedGroupMessages: config?.captureUnmentionedGroupMessages === true,
+			historyContextLimit:
+				config?.historyContextLimit === undefined
+					? 0
+					: this.normalizeHistoryContextLimit(config.historyContextLimit),
+			historyContextWindowSeconds: this.normalizeNonNegativeSeconds(
+				merged.historyContextWindowSeconds,
+				DEFAULT_HISTORY_CONTEXT_WINDOW_SECONDS
+			),
+			historyRetentionDays: this.normalizeNonNegativeSeconds(
+				merged.historyRetentionDays,
+				DEFAULT_HISTORY_RETENTION_DAYS
+			),
+			historyAttachmentMaxSizeMb: this.normalizeHistoryAttachmentMaxSizeMb(
+				merged.historyAttachmentMaxSizeMb
+			),
 			sessionTimeoutSeconds: this.normalizePositiveSeconds(
 				merged.sessionTimeoutSeconds,
 				DEFAULT_SESSION_TIMEOUT_SECONDS
@@ -369,12 +464,16 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		}
 	}
 
-	matchesInboundMessage(params: TLarkInboundMatchParams): boolean {
+	matchesInboundScope(params: TLarkInboundMatchParams): boolean {
 		const config = this.normalizeConfig(
 			params.binding?.config ?? params.config,
 			params.integrationId
 		)
 		if (!config.enabled || !config.integrationId) {
+			return false
+		}
+		const inboundIntegrationId = this.normalizeString(params.integrationId)
+		if (inboundIntegrationId && inboundIntegrationId !== config.integrationId) {
 			return false
 		}
 
@@ -404,11 +503,22 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			return false
 		}
 
-		if (config.groupReplyStrategy === 'mention_only' && !params.botMentioned) {
+		return true
+	}
+
+	matchesInboundMessage(params: TLarkInboundMatchParams): boolean {
+		if (!this.matchesInboundScope(params)) {
 			return false
 		}
+		if (params.chatType !== 'group') {
+			return true
+		}
 
-		return true
+		const config = this.normalizeConfig(
+			params.binding?.config ?? params.config,
+			params.integrationId
+		)
+		return config.groupReplyStrategy === 'all_messages' || Boolean(params.botMentioned)
 	}
 
 	async validate(payload: TWorkflowTriggerParams<TLarkTriggerConfig>) {
@@ -600,6 +710,22 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			},
 			['integrationId']
 		)
+		if (normalizedConfig.captureUnmentionedGroupMessages || normalizedConfig.historyContextLimit > 0) {
+			try {
+				await this.messageHistoryQueue.scheduleCleanup({
+					integrationId,
+					tenantId: context.tenantId ?? undefined,
+					organizationId: context.organizationId ?? undefined,
+					retentionDays: normalizedConfig.historyRetentionDays
+				})
+			} catch (error) {
+				this.logger.warn(
+					`Failed to schedule Lark history cleanup while publishing integration ${integrationId}: ${
+						error instanceof Error ? error.message : String(error)
+					}`
+				)
+			}
+		}
 
 		// Keep only runtime callback in memory; integration/xpert binding source of truth is DB.
 		this.callbacks.set(integrationId, callback)
@@ -652,6 +778,10 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		integrationId: string
 		input?: string
 		files?: LarkInboundFile[]
+		historyContext?: string
+		historyFiles?: LarkInboundFile[]
+		currentInboundLogIds?: string[]
+		historyBefore?: string
 		larkMessage: ChatLarkMessage
 		options?: TLarkInboundDispatchOptions
 	}): Promise<boolean> {
@@ -682,6 +812,11 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		)
 
 		const dispatchOptions = this.resolveDispatchOptions(binding, params.options)
+		const bindingExecutionContext = {
+			tenantId: this.normalizeString(binding.tenantId),
+			organizationId: this.normalizeString(binding.organizationId),
+			createdById: this.normalizeString(binding.createdById)
+		}
 		const normalizedConfig = this.normalizeConfig(binding.config, params.integrationId)
 		const summaryWindowSeconds = this.normalizeNonNegativeSeconds(
 			normalizedConfig.summaryWindowSeconds,
@@ -694,8 +829,12 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 				dispatchMode: 'immediate',
 				dispatchPayload: {
 					xpertId: binding.xpertId,
+					executionContext: bindingExecutionContext,
 					input: params.input,
 					files: params.files,
+					historyContext: params.historyContext,
+					historyFiles: params.historyFiles,
+					currentInboundLogIds: params.currentInboundLogIds,
 					larkMessage: params.larkMessage,
 					options: dispatchOptions
 				}
@@ -715,6 +854,21 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		const sameRoutingTarget =
 			currentState?.integrationId === params.integrationId && currentState?.xpertId === binding.xpertId
 		const nextVersion = (currentState?.version ?? 0) + 1
+		const tenantId =
+			bindingExecutionContext.tenantId ??
+			(sameRoutingTarget ? currentState?.tenantId : undefined) ??
+			RequestContext.currentTenantId() ??
+			undefined
+		const organizationId =
+			bindingExecutionContext.organizationId ??
+			(sameRoutingTarget ? currentState?.organizationId : undefined) ??
+			RequestContext.getOrganizationId() ??
+			undefined
+		const executorUserId =
+			bindingExecutionContext.createdById ??
+			(sameRoutingTarget ? currentState?.executorUserId : undefined) ??
+			RequestContext.currentUserId() ??
+			undefined
 		const aggregateState: LarkTriggerAggregationState = {
 			aggregateKey,
 			integrationId: params.integrationId,
@@ -725,10 +879,23 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 				...(sameRoutingTarget ? currentState?.files ?? [] : []),
 				...(params.files ?? [])
 			],
+			historyContext: sameRoutingTarget
+				? currentState?.historyContext ?? params.historyContext
+				: params.historyContext,
+			historyFiles: sameRoutingTarget
+				? currentState?.historyFiles ?? params.historyFiles
+				: params.historyFiles,
+			currentInboundLogIds: this.uniqueIds([
+				...(sameRoutingTarget ? currentState?.currentInboundLogIds ?? [] : []),
+				...(params.currentInboundLogIds ?? [])
+			]),
+			historyBefore: sameRoutingTarget
+				? currentState?.historyBefore ?? params.historyBefore
+				: params.historyBefore,
 			lastMessageAt: Date.now(),
-			tenantId: RequestContext.currentTenantId() ?? undefined,
-			organizationId: RequestContext.getOrganizationId() ?? undefined,
-			executorUserId: RequestContext.currentUserId() ?? undefined,
+			tenantId,
+			organizationId,
+			executorUserId,
 			endUserId: dispatchOptions?.fromEndUserId,
 			options: {
 				...(dispatchOptions?.fromEndUserId ? { fromEndUserId: dispatchOptions.fromEndUserId } : {}),
@@ -740,7 +907,7 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			},
 			latestMessage: {
 				integrationId: params.larkMessage.integrationId,
-				organizationId: RequestContext.getOrganizationId() ?? undefined,
+				organizationId,
 				connectionMode: params.larkMessage.connectionMode,
 				chatId: params.larkMessage.chatId,
 				chatType: params.larkMessage.chatType,
@@ -790,8 +957,16 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			dispatchMode: `buffered version=${state.version}`,
 			dispatchPayload: {
 				xpertId: state.xpertId,
+				executionContext: {
+					tenantId: state.tenantId,
+					organizationId: state.organizationId,
+					createdById: state.executorUserId
+				},
 				input,
 				files: state.files,
+				historyContext: state.historyContext,
+				historyFiles: state.historyFiles,
+				currentInboundLogIds: state.currentInboundLogIds,
 				larkMessage: new ChatLarkMessage(
 					{
 						tenant: null as any,
@@ -820,6 +995,10 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 				options: state.options ?? (state.endUserId ? { fromEndUserId: state.endUserId } : undefined)
 			}
 		})
+		await this.messageHistoryService.updateInboundStatus(
+			state.currentInboundLogIds ?? [],
+			'dispatched'
+		)
 
 		await this.aggregationService.clear(aggregateKey)
 		return true
@@ -860,6 +1039,17 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 		return normalized || undefined
 	}
 
+	private uniqueIds(ids: Array<string | undefined | null>): string[] | undefined {
+		const values = Array.from(
+			new Set(
+				ids
+					.map((id) => (typeof id === 'string' ? id.trim() : ''))
+					.filter((id): id is string => Boolean(id))
+			)
+		)
+		return values.length ? values : undefined
+	}
+
 	private normalizePositiveSeconds(value: unknown, defaultValue: number): number {
 		if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
 			return Math.floor(value)
@@ -872,6 +1062,24 @@ export class LarkTriggerStrategy implements IWorkflowTriggerStrategy<TLarkTrigge
 			return Math.floor(value)
 		}
 		return defaultValue
+	}
+
+	private normalizeHistoryContextLimit(value: unknown): number {
+		if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+			return Math.min(Math.floor(value), MAX_HISTORY_CONTEXT_LIMIT)
+		}
+		return DEFAULT_HISTORY_CONTEXT_LIMIT
+	}
+
+	private normalizeHistoryAttachmentMaxSizeMb(value: unknown): number {
+		if (
+			typeof value !== 'number' ||
+			!Number.isFinite(value) ||
+			value < MIN_HISTORY_ATTACHMENT_MAX_SIZE_MB
+		) {
+			return DEFAULT_HISTORY_ATTACHMENT_MAX_SIZE_MB
+		}
+		return Math.min(Math.floor(value), MAX_HISTORY_ATTACHMENT_MAX_SIZE_MB)
 	}
 
 	private async dispatchInboundMessage(params: {

--- a/xpertai/integrations/lark/src/lib/workflow/lark-trigger.types.ts
+++ b/xpertai/integrations/lark/src/lib/workflow/lark-trigger.types.ts
@@ -24,6 +24,11 @@ export type TLarkTriggerConfig = {
 	groupReplyStrategy: TLarkGroupReplyStrategy
 	sessionTimeoutSeconds: number
 	summaryWindowSeconds: number
+	captureUnmentionedGroupMessages: boolean
+	historyContextLimit: number
+	historyContextWindowSeconds: number
+	historyRetentionDays: number
+	historyAttachmentMaxSizeMb: number
 }
 
 export const DEFAULT_LARK_TRIGGER_CONFIG: Omit<TLarkTriggerConfig, 'integrationId'> = {
@@ -38,5 +43,10 @@ export const DEFAULT_LARK_TRIGGER_CONFIG: Omit<TLarkTriggerConfig, 'integrationI
 	groupUserOpenIds: [],
 	groupReplyStrategy: 'mention_only',
 	sessionTimeoutSeconds: 3600,
-	summaryWindowSeconds: 0
+	summaryWindowSeconds: 0,
+	captureUnmentionedGroupMessages: false,
+	historyContextLimit: 20,
+	historyContextWindowSeconds: 3600,
+	historyRetentionDays: 30,
+	historyAttachmentMaxSizeMb: 10
 }

--- a/xpertai/integrations/lark/src/xpert-lark-admin-assistant.yaml
+++ b/xpertai/integrations/lark/src/xpert-lark-admin-assistant.yaml
@@ -86,26 +86,4 @@ nodes:
       toolsetIds: []
       knowledgebaseIds: []
     hash: lark-admin-agent-v1
-  - type: workflow
-    key: Middleware_LarkConversationContext
-    position:
-      x: 1140
-      y: 260
-    entity:
-      type: middleware
-      key: Middleware_LarkConversationContext
-      title: Lark Conversation Context
-      provider: LarkConversationContextMiddleware
-      required: false
-      options:
-        integrationId: ""
-        defaults:
-          timeoutMs: 10000
-          pageSize: 20
-          resourceContentMode: metadata
-    hash: lark-admin-context-middleware-v1
-connections:
-  - type: workflow
-    key: Agent_LarkAdmin/Middleware_LarkConversationContext
-    from: Agent_LarkAdmin
-    to: Middleware_LarkConversationContext
+connections: []

--- a/xpertai/integrations/lark/src/xpert-lark-conversation-assistant.yaml
+++ b/xpertai/integrations/lark/src/xpert-lark-conversation-assistant.yaml
@@ -73,10 +73,19 @@ nodes:
         configured trigger policy. Do not broaden the conversation beyond the current user request unless
         the user asks.
 
-        Use Lark conversation context tools when the user asks about previous messages, group context,
-        shared files, message resources, or when you need to verify what was said earlier. Treat open_id,
+        Files attached to the current user message are already available in the request files; read them
+        directly. Use lark_search_chat_history with includeFiles=true for older shared files or when the
+        user asks about previous messages and group context. This tool searches only the locally stored
+        history for the current conversation. Use lark_list_messages, lark_get_message, and
+        lark_get_message_resource only when the user explicitly needs remote Feishu message data that is
+        not present in local history. Never ask for or invent another chat id. Treat open_id,
         chat_id, message_id, and file keys as internal identifiers; do not present them as people names or
         user-facing explanations unless the administrator explicitly asks for diagnostics.
+
+        When the user asks you to generate, edit, or return a file, finish writing it into the Xpert
+        workspace and call lark_send_file. Never paste a local path or workspace path into the user-facing
+        reply. lark_send_file automatically uses the trusted current Lark conversation and cannot be used
+        to choose another chat or user.
 
         Use Lark notification tools only when the user clearly asks you to send, update, or recall a Lark
         message. Prefer recipient_name or recipient_names from the current chat context instead of exposing
@@ -89,7 +98,7 @@ nodes:
       collaboratorNames: []
       toolsetIds: []
       knowledgebaseIds: []
-    hash: lark-conversation-agent-v1
+    hash: lark-conversation-agent-v3
   - type: workflow
     key: Trigger_Lark
     position:
@@ -112,59 +121,39 @@ nodes:
         groupUserScope: all_users
         groupUserOpenIds: []
         groupReplyStrategy: mention_only
-    hash: lark-conversation-trigger-v1
+        captureUnmentionedGroupMessages: true
+        historyContextLimit: 20
+        historyContextWindowSeconds: 3600
+        historyRetentionDays: 30
+        historyAttachmentMaxSizeMb: 10
+    hash: lark-conversation-trigger-v2
   - type: workflow
-    key: Middleware_LarkConversationContext
+    key: Middleware_LarkRuntime
     position:
       x: 1160
       y: 250
     entity:
       type: middleware
-      key: Middleware_LarkConversationContext
-      title: Lark Conversation Context
-      provider: LarkConversationContextMiddleware
-      required: true
-      options:
-        integrationId: ""
-        defaults:
-          timeoutMs: 10000
-          pageSize: 20
-          resourceContentMode: metadata
-    hash: lark-conversation-context-middleware-v1
-  - type: workflow
-    key: Middleware_LarkNotify
-    position:
-      x: 1160
-      y: 460
-    entity:
-      type: middleware
-      key: Middleware_LarkNotify
-      title: Lark Notify Tools
-      provider: LarkNotifyMiddleware
+      key: Middleware_LarkRuntime
+      title: 飞书运行时
+      provider: LarkRuntimeMiddleware
       required: false
       options:
-        integrationId: ""
-        recipient_type: open_id
-        recipient_id: ""
         template:
           enabled: true
           strict: false
         defaults:
           postLocale: zh_cn
           timeoutMs: 10000
-        lookupTools:
-          enabled: true
-    hash: lark-notify-middleware-v1
+          pageSize: 20
+          resourceContentMode: metadata
+    hash: lark-runtime-middleware-v2
 connections:
   - type: workflow
     key: Trigger_Lark/Agent_LarkConversation
     from: Trigger_Lark
     to: Agent_LarkConversation
   - type: workflow
-    key: Agent_LarkConversation/Middleware_LarkConversationContext
+    key: Agent_LarkConversation/Middleware_LarkRuntime
     from: Agent_LarkConversation
-    to: Middleware_LarkConversationContext
-  - type: workflow
-    key: Agent_LarkConversation/Middleware_LarkNotify
-    from: Agent_LarkConversation
-    to: Middleware_LarkNotify
+    to: Middleware_LarkRuntime


### PR DESCRIPTION
# Plugin Submission Form

## 1. Metadata

- **Plugin Author**: Xpert AI
- **Plugin Name**: `@xpert-ai/plugin-lark`
- **Repository URL**: https://github.com/xpert-ai/xpert-plugins

## 2. Submission Type

- [ ] New plugin submission
- [x] Version update for existing plugin

## 3. Description

This update adds a scoped Lark message-history runtime and attachment pipeline.

- Persist inbound and outbound message history with tenant, organization, integration, Xpert, and chat scope.
- Materialize attachment references into scoped workspace storage while keeping current vision inputs model-readable.
- Inject recent local context and expose trigger-bound runtime tools for local history, current-chat-only remote history, message sending, and workspace-file sending.
- Add retry-safe queue identifiers, cleanup scheduling, card-action deduplication, and safer steer follow-up handling.
- Add administrator permission guidance and a cursor-paginated message-history view.
- Add a minor changeset for `@xpert-ai/plugin-lark`.

### Model image-input boundary

Workspace preview URLs remain persistence references. Current inbound images are read as bytes and dispatched as Data URLs so remote vision models never receive host-local `localhost` URLs. Temporary workspace failures can fall back to the original Lark resource path, while permanent file-size limits remain enforced.

## 4. Validation

- Focused changed specs: **22 suites / 270 tests passed**. Jest reported open handles after the final result, so the locally started test process was terminated after the pass summary.
- `NX_DAEMON=false pnpm -C xpertai exec nx build @xpert-ai/plugin-lark --skip-nx-cache --skip-sync`
- `pnpm -C plugin-dev-harness build`
- Node 20 `plugin-dev-harness` lifecycle: register, start, bootstrap, destroy, and stop passed.
- `git diff --check` passed.

The repository-wide Lark Jest command is not green on current `main`: 11 existing suites fail because some tests require live Feishu credentials, several unchanged cache/error-classification assertions fail, and other suites hit the existing Jest `lodash-es` parsing issue. Those unrelated failures are not changed in this PR.

Not performed: real Feishu bot end-to-end image/history validation and installation into a running local Xpert instance.

## 5. Checklist

- [ ] I have read and followed the Publish to Xpert Marketplace guidelines
- [ ] I have read and comply with the Plugin Developer Agreement
- [ ] I confirm my plugin works properly on both Xpert Community Edition and Cloud Version
- [ ] I confirm my plugin has been thoroughly tested for completeness and functionality
- [x] My plugin brings new value to Xpert

## 6. Documentation Checklist

- [ ] Step-by-step setup instructions
- [ ] Detailed usage instructions
- [ ] All required APIs and credentials are clearly listed
- [ ] Connection requirements and configuration details
- [x] Link to the repository for the plugin source code

## 7. Privacy Protection Information

### Data Collection

This update stores Lark message content, sender open IDs and display names, chat/message identifiers, attachment metadata and scoped workspace copies, plus conversation/execution metadata inside the configured Xpert tenant. History defaults to 30-day retention and can be cleaned through the plugin-owned cleanup flow. It does not introduce a new third-party data destination beyond Lark and the model provider configured by the Xpert deployment.

### Privacy Policy

- [ ] I confirm that I have prepared and included a privacy policy in my plugin package based on the Plugin Privacy Protection Guidelines