### PR TITLE
[codex] feat: add presentation prompt workflows

### DIFF
--- a/xpertai/.changeset/template-prompt-workflows.md
+++ b/xpertai/.changeset/template-prompt-workflows.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-presentation-studio': patch
+---
+
+Add workspace prompt workflow defaults to the Presentation Studio assistant template.

--- a/xpertai/apps/presentation-studio/src/lib/presentation-studio.templates.spec.ts
+++ b/xpertai/apps/presentation-studio/src/lib/presentation-studio.templates.spec.ts
@@ -1,4 +1,7 @@
-import { presentationStudioTemplates } from './presentation-studio.templates.js'
+import {
+  presentationStudioPromptWorkflows,
+  presentationStudioTemplates
+} from './presentation-studio.templates.js'
 
 describe('Presentation Studio assistant template', () => {
   it('instructs the agent to batch inspections and honor exact array item contracts', () => {
@@ -39,5 +42,33 @@ describe('Presentation Studio assistant template', () => {
       expect(dsl).toContain('from: Agent_PresentationStudio')
       expect(dsl).toContain(`to: ${middlewareKey}`)
     }
+  })
+
+  it('declares the workspace prompt workflows used to start presentation tasks', () => {
+    const expectedArgsHints = {
+      'presentation-create': '{"topic_or_material":"...","audience":"...","page_count":10,"goal":"..."}',
+      'presentation-refine': '{"deck_id":"...","requirements":"..."}',
+      'presentation-export': '{"deck_id":"...","formats":["html","pdf","pptx"]}',
+      'presentation-share': '{"deck_id":"..."}'
+    }
+    expect(presentationStudioPromptWorkflows.map(({ name }) => name)).toEqual([
+      'presentation-create',
+      'presentation-refine',
+      'presentation-export',
+      'presentation-share'
+    ])
+    expect(presentationStudioTemplates[0]?.promptWorkflows).toBe(presentationStudioPromptWorkflows)
+
+    for (const workflow of presentationStudioPromptWorkflows) {
+      expect(workflow.name).toMatch(/^[a-z0-9][a-z0-9_-]{0,63}$/)
+      expect(workflow.category).toBe('presentation')
+      expect(workflow.visibility).toBe('team')
+      expect(workflow.argsHint).toBe(expectedArgsHints[workflow.name])
+      expect(workflow.label).toMatch(/[\u4e00-\u9fff]/)
+      expect(workflow.description).toMatch(/[\u4e00-\u9fff]/)
+      expect(workflow.template).toContain('请使用用户输入的语言输出。')
+      expect(workflow.template.match(/\{\{\s*([^}]+?)\s*\}\}/g)).toEqual(['{{args}}'])
+    }
+    expect(presentationStudioPromptWorkflows[3]?.template).toContain('最终回复只返回工具产生的 shareUrl')
   })
 })

--- a/xpertai/apps/presentation-studio/src/lib/presentation-studio.templates.ts
+++ b/xpertai/apps/presentation-studio/src/lib/presentation-studio.templates.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { XpertTypeEnum } from '@xpert-ai/contracts'
+import { XpertTypeEnum, type TPromptWorkflow } from '@xpert-ai/contracts'
 import type { XpertTemplateContribution } from '@xpert-ai/plugin-sdk'
 import {
   PRESENTATION_AGENT_KEY,
@@ -31,6 +31,70 @@ function readDsl() {
 }
 
 const capabilities = [PRESENTATION_FEATURE, PRESENTATION_GENERATION_CAPABILITY, PRESENTATION_WORKBENCH_CAPABILITY, PRESENTATION_COLLABORATION_CAPABILITY, PRESENTATION_EXPORT_CAPABILITY]
+
+export const presentationStudioPromptWorkflows = [
+  {
+    name: 'presentation-create',
+    label: '生成演示稿',
+    description: '基于主题或结构化材料创建可编辑演示稿。',
+    category: 'presentation',
+    argsHint: '{"topic_or_material":"...","audience":"...","page_count":10,"goal":"..."}',
+    template: [
+      '基于以下输入创建一份可编辑演示稿。未指定页数时默认 10 页；先规划结构，再选择合适主题和版式，完成真实内容并保存可审阅版本。',
+      '请使用用户输入的语言输出。',
+      '',
+      '{{args}}'
+    ].join('\n'),
+    tags: ['presentation', 'workflow'],
+    visibility: 'team'
+  },
+  {
+    name: 'presentation-refine',
+    label: '优化演示稿',
+    description: '检查并优化现有演示稿，保存新的可审阅版本。',
+    category: 'presentation',
+    argsHint: '{"deck_id":"...","requirements":"..."}',
+    template: [
+      '检查并优化当前或指定演示稿。先读取最新状态，重点检查文案预算、版式契约、媒体引用和页面完整性；只修改需要改进的内容，完成后保存新版本。',
+      '请使用用户输入的语言输出。',
+      '',
+      '{{args}}'
+    ].join('\n'),
+    tags: ['presentation', 'workflow'],
+    visibility: 'team'
+  },
+  {
+    name: 'presentation-export',
+    label: '导出演示稿',
+    description: '将演示稿导出为 HTML、PDF 或 PPTX。',
+    category: 'presentation',
+    argsHint: '{"deck_id":"...","formats":["html","pdf","pptx"]}',
+    template: [
+      '将当前或指定演示稿导出为要求的格式；未指定格式时导出 HTML、PDF 和 PPTX。等待每项导出完成并返回实际可用的结果，不要声称失败或未完成的导出已经成功。',
+      '请使用用户输入的语言输出。',
+      '',
+      '{{args}}'
+    ].join('\n'),
+    tags: ['presentation', 'export'],
+    visibility: 'team'
+  },
+  {
+    name: 'presentation-share',
+    label: '分享演示稿',
+    description: '为演示稿生成 HTML 分享链接。',
+    category: 'presentation',
+    argsHint: '{"deck_id":"..."}',
+    template: [
+      '为当前或指定演示稿生成 HTML 分享链接。等待必要的导出完成，只使用工具返回的链接；最终回复只返回工具产生的 shareUrl，不添加说明或自行构造链接。',
+      '请使用用户输入的语言输出。',
+      '',
+      '{{args}}'
+    ].join('\n'),
+    tags: ['presentation', 'share'],
+    visibility: 'team'
+  }
+] satisfies TPromptWorkflow[]
+
 export const presentationStudioTemplates: XpertTemplateContribution[] = [{
   key: PRESENTATION_ASSISTANT_TEMPLATE_KEY,
   name: 'Presentation Studio Assistant',
@@ -56,6 +120,7 @@ export const presentationStudioTemplates: XpertTemplateContribution[] = [{
     '请检查当前演示稿的文案预算、版式和媒体引用后保存版本。',
     '将当前演示稿导出为 HTML、PDF 和 PPTX。'
   ],
+  promptWorkflows: presentationStudioPromptWorkflows,
   releaseNotes: 'Created the Presentation Studio Agentic App assistant.',
   xpertName: '演示文稿生成助手',
   providerKey: PRESENTATION_TEMPLATE_PROVIDER_KEY


### PR DESCRIPTION
## Summary

Add four reusable workspace prompt workflows to the Presentation Studio assistant template.

## Problem

After initializing Presentation Studio, users had no ready-made workspace commands for the most common create, refine, export, and share flows.

## Root cause

The template only supplied conversational start prompts. It did not declare persistent prompt workflows for the host to initialize in the workspace.

## Changes

- Add `/presentation-create`, `/presentation-refine`, `/presentation-export`, and `/presentation-share` workflow definitions.
- Use team visibility, the `presentation` category, Chinese labels and descriptions, and only the supported `{{args}}` placeholder.
- Keep the existing template DSL and middleware connections unchanged.
- Add focused contract tests and a patch changeset.

## Validation

- Presentation Studio focused Jest: 1 suite, 3 tests passed.
- `git diff --check` passed.

This plugin patch should be released after the corresponding host support is deployed.