### PR TITLE
[codex] fix Lark permission guide cards

### DIFF
--- a/xpertai/.changeset/tidy-larks-guide.md
+++ b/xpertai/.changeset/tidy-larks-guide.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-lark": patch
+---
+
+Send administrator permission guide cards when Lark message and file tools report structured missing application permissions.

--- a/xpertai/integrations/lark/src/lib/lark-context-tool.service.spec.ts
+++ b/xpertai/integrations/lark/src/lib/lark-context-tool.service.spec.ts
@@ -4,7 +4,7 @@ jest.mock('@xpert-ai/plugin-sdk', () => ({
 }))
 
 import { Readable } from 'node:stream'
-import { LarkContextToolService } from './lark-context-tool.service.js'
+import { LarkApplicationPermissionError, LarkContextToolService } from './lark-context-tool.service.js'
 
 async function createFixture() {
   const messageList = jest.fn().mockResolvedValue({
@@ -166,10 +166,10 @@ describe('LarkContextToolService', () => {
     ])
   })
 
-  it('preserves structured application permission failures for the runtime middleware', async () => {
+  it('preserves structured application permission failures without relying on a known error code', async () => {
     const { service, messageList } = await createFixture()
     messageList.mockRejectedValue({
-      code: 99991679,
+      code: 12345678,
       msg: 'Access denied',
       error: {
         message: 'missing permission',
@@ -188,7 +188,7 @@ describe('LarkContextToolService', () => {
     ).rejects.toEqual(
       expect.objectContaining({
         name: 'LarkApplicationPermissionError',
-        code: 99991679,
+        code: 12345678,
         scopes: ['im:message.group_msg']
       })
     )
@@ -222,32 +222,29 @@ describe('LarkContextToolService', () => {
     )
   })
 
-  it('extracts required scopes from a trusted application permission error message', async () => {
+  it('does not infer application permissions from an error code or free-form message', async () => {
     const { service, messageList } = await createFixture()
     messageList.mockResolvedValue({
-      code: 99991679,
+      code: 99991672,
       msg: 'Access denied. Required scope: im:message.group_msg',
       error: {
         message: 'The app does not have im:message.group_msg permission'
       }
     })
 
-    await expect(
-      service.listMessages({
+    const error = await service
+      .listMessages({
         integrationId: 'integration-1',
         containerIdType: 'chat',
         containerId: 'oc_chat_1'
       })
-    ).rejects.toEqual(
-      expect.objectContaining({
-        name: 'LarkApplicationPermissionError',
-        code: 99991679,
-        scopes: ['im:message.group_msg']
-      })
-    )
+      .catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(LarkApplicationPermissionError)
   })
 
-  it('handles the missing-scope code returned by the Lark message list API', async () => {
+  it('does not treat a generic message operation error as missing application permission', async () => {
     const { service, messageList } = await createFixture()
     messageList.mockResolvedValue({
       code: 230027,
@@ -257,19 +254,16 @@ describe('LarkContextToolService', () => {
       }
     })
 
-    await expect(
-      service.listMessages({
+    const error = await service
+      .listMessages({
         integrationId: 'integration-1',
         containerIdType: 'chat',
         containerId: 'oc_chat_1'
       })
-    ).rejects.toEqual(
-      expect.objectContaining({
-        name: 'LarkApplicationPermissionError',
-        code: 230027,
-        scopes: ['im:message.group_msg']
-      })
-    )
+      .catch((caught) => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect(error).not.toBeInstanceOf(LarkApplicationPermissionError)
   })
 
   it('sends a deterministic administrator permission guide card to the trusted chat', async () => {

--- a/xpertai/integrations/lark/src/lib/lark-context-tool.service.ts
+++ b/xpertai/integrations/lark/src/lib/lark-context-tool.service.ts
@@ -18,7 +18,6 @@ import { toLarkApiErrorMessage, toNonEmptyString } from './utils.js'
 
 const DEFAULT_TIMEOUT_MS = 10000
 const RESOURCE_INLINE_CONTENT_MODE = 'base64'
-const LARK_MISSING_PERMISSION_CODES = new Set([99991679, 230027])
 
 export class LarkApplicationPermissionError extends Error {
   constructor(
@@ -29,6 +28,21 @@ export class LarkApplicationPermissionError extends Error {
     super(message)
     this.name = 'LarkApplicationPermissionError'
   }
+}
+
+export function toLarkApplicationPermissionError(
+  error: unknown,
+  toolName: string,
+  operation: string
+): LarkApplicationPermissionError | null {
+  const parsed = parseLarkClientError(error)
+  const scopes = extractStructuredApplicationPermissionScopes(parsed)
+  if (!scopes.length) {
+    return null
+  }
+
+  const message = toLarkApiErrorMessage(error) || getErrorMessage(error) || 'Unknown error'
+  return new LarkApplicationPermissionError(parsed.code, scopes, `[${toolName}] ${operation}: ${message}`)
 }
 
 type LarkMessageItem = {
@@ -566,16 +580,10 @@ export class LarkContextToolService {
   }
 
   private toContextToolError(error: unknown, toolName: string, operation: string): Error {
-    const parsed = parseLarkClientError(error)
-    const scopes = extractApplicationPermissionScopes(parsed)
-    if (LARK_MISSING_PERMISSION_CODES.has(parsed.code) && scopes.length) {
-      return new LarkApplicationPermissionError(
-        parsed.code,
-        scopes,
-        `[${toolName}] ${operation}: ${this.formatError(error)}`
-      )
-    }
-    return new Error(`[${toolName}] ${operation}: ${this.formatError(error)}`)
+    return (
+      toLarkApplicationPermissionError(error, toolName, operation) ??
+      new Error(`[${toolName}] ${operation}: ${this.formatError(error)}`)
+    )
   }
 
   private assertLarkApiSuccess(response: unknown, toolName: string, operation: string): void {
@@ -586,23 +594,17 @@ export class LarkContextToolService {
   }
 }
 
-function extractApplicationPermissionScopes(parsed: ReturnType<typeof parseLarkClientError>): string[] {
-  const structuredScopes = (parsed.error.permission_violations ?? [])
-    .filter((violation) => violation.type === 'action_privilege_required')
-    .map((violation) => violation.subject.trim())
-    .filter(Boolean)
-
-  if (structuredScopes.length) {
-    return Array.from(new Set(structuredScopes))
-  }
-
-  if (!LARK_MISSING_PERMISSION_CODES.has(parsed.code)) {
-    return []
-  }
-
-  const message = `${parsed.msg}\n${parsed.error.message}`
-  const textScopes = message.match(/\b[a-z][a-z0-9_]*(?::[a-z0-9_.-]+)+\b/gi) ?? []
-  return Array.from(new Set(textScopes.map((scope) => scope.trim()).filter((scope) => scope.length <= 128)))
+function extractStructuredApplicationPermissionScopes(
+  parsed: ReturnType<typeof parseLarkClientError>
+): string[] {
+  return Array.from(
+    new Set(
+      (parsed.error.permission_violations ?? [])
+        .filter((violation) => violation.type === 'action_privilege_required')
+        .map((violation) => violation.subject.trim())
+        .filter(Boolean)
+    )
+  )
 }
 
 function describeApplicationScope(scope: string): string {

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-notify.conversation-binding.spec.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-notify.conversation-binding.spec.ts
@@ -94,11 +94,15 @@ async function createFixture(options: {
   const recipientDirectoryService = {
     resolveByName: jest.fn().mockResolvedValue({ status: 'not_found' })
   }
+  const contextToolService = {
+    sendApplicationPermissionGuideCard: jest.fn().mockResolvedValue({})
+  }
 
   const strategy = new LarkNotifyMiddleware(
     larkChannel as any,
     conversationService as any,
-    recipientDirectoryService as any
+    recipientDirectoryService as any,
+    contextToolService as any
   )
   const middleware = await Promise.resolve(
     strategy.createMiddleware(mergeConfig(options.config), createContext(options.context))

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.spec.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.spec.ts
@@ -141,11 +141,18 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>, conte
     get: jest.fn().mockResolvedValue(null),
     resolveByName: jest.fn().mockResolvedValue({ status: 'not_found' })
   }
+  const contextToolService = {
+    sendApplicationPermissionGuideCard: jest.fn().mockResolvedValue({
+      messageId: 'permission-card-1',
+      consoleUrl: 'https://open.feishu.cn/app/cli_test/auth'
+    })
+  }
 
   const strategy = new LarkNotifyMiddleware(
     larkChannel as any,
     conversationService as any,
-    recipientDirectoryService as any
+    recipientDirectoryService as any,
+    contextToolService as any
   )
   const middleware = await Promise.resolve(strategy.createMiddleware(mergeConfig(config), context as any))
 
@@ -159,7 +166,8 @@ async function createFixture(config?: Partial<LarkNotifyMiddlewareConfig>, conte
     listUsers,
     listChats,
     conversationService,
-    recipientDirectoryService
+    recipientDirectoryService,
+    contextToolService
   }
 }
 
@@ -169,6 +177,17 @@ function getTool(middleware: any, name: string) {
     throw new Error(`Tool ${name} not found`)
   }
   return tool
+}
+
+function createApplicationPermissionError(scopes: string[]) {
+  return {
+    code: 99991672,
+    msg: 'Access denied',
+    error: {
+      message: 'missing permission',
+      permission_violations: scopes.map((subject) => ({ type: 'action_privilege_required', subject }))
+    }
+  }
 }
 
 function createWorkspaceFiles(
@@ -366,6 +385,147 @@ describe('LarkNotifyMiddleware', () => {
     expect(serializedResult).not.toContain(workspace.buffer.toString('base64'))
     expect(serializedResult).not.toContain('integration-runtime')
     expect(serializedResult).not.toContain('chat-runtime')
+  })
+
+  it('sends an administrator permission card when Lark rejects a file upload scope', async () => {
+    const workspace = createWorkspaceFiles({ name: 'report.pdf', mimeType: 'application/pdf' })
+    const { middleware, fileCreate, messageCreate, contextToolService } = await createFixture(
+      undefined,
+      createWorkspaceContext(workspace.api)
+    )
+    fileCreate.mockRejectedValue(createApplicationPermissionError(['im:resource:upload', 'im:resource']))
+
+    const result = await getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+      { path: '/workspace/files/report.pdf' },
+      {
+        configurable: {
+          context: {
+            from: 'lark',
+            channelType: 'lark',
+            sourceIntegrationId: 'integration-runtime',
+            chatId: 'chat-runtime',
+            chatType: 'group'
+          }
+        },
+        metadata: {
+          tool_call_id: 'tool-file-permission'
+        }
+      }
+    )
+
+    expect(contextToolService.sendApplicationPermissionGuideCard).toHaveBeenCalledWith({
+      integrationId: 'integration-runtime',
+      chatId: 'chat-runtime',
+      scopes: ['im:resource:upload', 'im:resource'],
+      toolCallId: 'tool-file-permission'
+    })
+    expect(messageCreate).not.toHaveBeenCalled()
+    expect(result.update.lark_notify_last_result).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: 'lark_application_permission_required',
+        requiredScopes: ['im:resource:upload', 'im:resource'],
+        permissionGuideSent: true
+      })
+    )
+    expect((result as any).goto).toEqual(['end'])
+  })
+
+  it('sends an administrator permission card when Lark rejects the file message send scope', async () => {
+    const workspace = createWorkspaceFiles({ name: 'report.pdf', mimeType: 'application/pdf' })
+    const { middleware, fileCreate, messageCreate, contextToolService } = await createFixture(
+      undefined,
+      createWorkspaceContext(workspace.api)
+    )
+    messageCreate.mockRejectedValue(createApplicationPermissionError(['im:message']))
+
+    const result = await getTool(middleware, LARK_SEND_FILE_TOOL_NAME).invoke(
+      { path: '/workspace/files/report.pdf' },
+      {
+        configurable: {
+          context: {
+            from: 'lark',
+            channelType: 'lark',
+            sourceIntegrationId: 'integration-runtime',
+            chatId: 'chat-runtime',
+            chatType: 'group'
+          }
+        },
+        metadata: {
+          tool_call_id: 'tool-file-send-permission'
+        }
+      }
+    )
+
+    expect(fileCreate).toHaveBeenCalledTimes(1)
+    expect(messageCreate).toHaveBeenCalledTimes(1)
+    expect(contextToolService.sendApplicationPermissionGuideCard).toHaveBeenCalledWith({
+      integrationId: 'integration-runtime',
+      chatId: 'chat-runtime',
+      scopes: ['im:message'],
+      toolCallId: 'tool-file-send-permission'
+    })
+    expect(result.update.lark_notify_last_result).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: 'lark_application_permission_required',
+        requiredScopes: ['im:message'],
+        permissionGuideSent: true
+      })
+    )
+    expect((result as any).goto).toEqual(['end'])
+  })
+
+  it.each([
+    {
+      toolName: 'lark_send_text_notification',
+      input: { content: 'hello' },
+      toolCallId: 'tool-text-send-permission'
+    },
+    {
+      toolName: 'lark_send_rich_notification',
+      input: { mode: 'post', locale: 'zh_cn', markdown: '## hello' },
+      toolCallId: 'tool-rich-send-permission'
+    }
+  ])('sends an administrator permission card when $toolName lacks a send scope', async ({
+    toolName,
+    input,
+    toolCallId
+  }) => {
+    const { middleware, messageCreate, contextToolService } = await createFixture()
+    messageCreate.mockRejectedValue(createApplicationPermissionError(['im:message']))
+
+    const result = await getTool(middleware, toolName).invoke(input, {
+      configurable: {
+        context: {
+          from: 'lark',
+          channelType: 'lark',
+          sourceIntegrationId: 'integration-runtime',
+          chatId: 'chat-runtime',
+          chatType: 'group'
+        }
+      },
+      metadata: {
+        tool_call_id: toolCallId
+      }
+    })
+
+    expect(messageCreate).toHaveBeenCalledTimes(1)
+    expect(contextToolService.sendApplicationPermissionGuideCard).toHaveBeenCalledWith({
+      integrationId: 'integration-runtime',
+      chatId: 'chat-runtime',
+      scopes: ['im:message'],
+      toolCallId
+    })
+    expect(result.update.lark_notify_last_result).toEqual(
+      expect.objectContaining({
+        success: false,
+        error: 'lark_application_permission_required',
+        requiredScopes: ['im:message'],
+        permissionGuideSent: true
+      })
+    )
+    expect((result as any).goto).toEqual(['end'])
   })
 
   it('falls back to the current sender open_id only for a private Lark chat without chatId', async () => {

--- a/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.ts
+++ b/xpertai/integrations/lark/src/lib/middlewares/lark-notify.middleware.ts
@@ -20,6 +20,7 @@ import { LarkConversationService } from '../conversation.service.js'
 import { toRecipientConversationUserKey } from '../conversation-user-key.js'
 import { LARK_NOTIFY_MIDDLEWARE_NAME, LARK_SEND_FILE_TOOL_NAME } from '../constants.js'
 import { LarkChannelStrategy } from '../lark-channel.strategy.js'
+import { LarkContextToolService, toLarkApplicationPermissionError } from '../lark-context-tool.service.js'
 import { LarkRecipientDirectoryService } from '../lark-recipient-directory.service.js'
 import {
   buildLarkFileSendUuid,
@@ -703,7 +704,8 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
   constructor(
     private readonly larkChannel: LarkChannelStrategy,
     private readonly conversationService: LarkConversationService,
-    private readonly recipientDirectoryService: LarkRecipientDirectoryService
+    private readonly recipientDirectoryService: LarkRecipientDirectoryService,
+    private readonly contextToolService: LarkContextToolService
   ) {}
 
   private resolveTargetXpertId(context: IAgentMiddlewareContext): string | null {
@@ -1234,15 +1236,78 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
       })
     }
 
+    const buildApplicationPermissionCommand = async (params: {
+      error: unknown
+      toolName: string
+      toolCallId: string
+      integrationId: string
+      chatId: string | null
+      operation: string
+    }): Promise<Command | null> => {
+      const permissionError = toLarkApplicationPermissionError(params.error, params.toolName, params.operation)
+      if (!permissionError) {
+        return null
+      }
+
+      let permissionGuideSent = false
+      let permissionGuideError: string | undefined
+      if (params.chatId) {
+        try {
+          await this.contextToolService.sendApplicationPermissionGuideCard({
+            integrationId: params.integrationId,
+            chatId: params.chatId,
+            scopes: permissionError.scopes,
+            toolCallId: params.toolCallId
+          })
+          permissionGuideSent = true
+        } catch (error) {
+          permissionGuideError = formatError(error)
+        }
+      } else {
+        permissionGuideError = 'No trusted current Lark chat was available for the permission guide.'
+      }
+
+      const result = {
+        tool: params.toolName,
+        success: false,
+        error: 'lark_application_permission_required',
+        requiredScopes: permissionError.scopes,
+        permissionGuideSent,
+        ...(permissionGuideError ? { permissionGuideError } : {}),
+        message: permissionGuideSent
+          ? 'An administrator permission guide card was sent to the current Lark chat. Do not retry this tool until an administrator enables the permissions and publishes the app.'
+          : 'The Lark application is missing required permissions. Ask an administrator to enable the listed scopes and publish the app before retrying.'
+      }
+
+      return new Command({
+        update: {
+          lark_notify_last_result: result,
+          messages: [
+            new ToolMessage({
+              content: JSON.stringify(result),
+              name: params.toolName,
+              tool_call_id: params.toolCallId,
+              status: 'success'
+            })
+          ]
+        },
+        ...(permissionGuideSent ? { goto: 'end' } : {})
+      })
+    }
+
     const runSendTaskBatch = async (params: {
       integrationId: string
       toolName: string
+      toolCallId: string
+      permissionGuideChatId: string | null
+      operation: string
       recipients: LarkRecipient[]
       timeoutMs: number
       task: (recipient: LarkRecipient) => Promise<{ messageId?: string | null }>
       onSuccess?: (recipient: LarkRecipient, result: { messageId?: string | null }) => Promise<void>
-    }): Promise<LarkNotifyResult> => {
+    }) => {
       const results: LarkNotifyResultItem[] = []
+      let applicationPermissionCause: unknown
 
       for (let i = 0; i < params.recipients.length; i += MAX_BATCH_CONCURRENCY) {
         const group = params.recipients.slice(i, i + MAX_BATCH_CONCURRENCY)
@@ -1277,6 +1342,12 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
           if (item.status === 'fulfilled') {
             results.push(item.value)
           } else {
+            if (
+              applicationPermissionCause === undefined &&
+              toLarkApplicationPermissionError(item.reason, params.toolName, params.operation)
+            ) {
+              applicationPermissionCause = item.reason
+            }
             results.push({
               target: `${recipient.type}:${recipient.id}`,
               success: false,
@@ -1284,6 +1355,10 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
             })
           }
         })
+
+        if (applicationPermissionCause !== undefined) {
+          break
+        }
       }
 
       const successCount = results.filter((item) => item.success).length
@@ -1293,13 +1368,26 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         `[${params.toolName}] integrationId=${params.integrationId}, recipientCount=${params.recipients.length}, successCount=${successCount}, failureCount=${failureCount}`
       )
 
-      return {
+      const result: LarkNotifyResult = {
         tool: params.toolName,
         integrationId: params.integrationId,
         successCount,
         failureCount,
         results
       }
+      const permissionCommand =
+        applicationPermissionCause === undefined
+          ? null
+          : await buildApplicationPermissionCommand({
+              error: applicationPermissionCause,
+              toolName: params.toolName,
+              toolCallId: params.toolCallId,
+              integrationId: params.integrationId,
+              chatId: params.permissionGuideChatId,
+              operation: params.operation
+            })
+
+      return { result, permissionCommand }
     }
 
     const tools = []
@@ -1308,8 +1396,15 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
         async (parameters, config) => {
           const toolName = 'lark_send_text_notification'
           const toolCallId = getToolCallIdFromConfig(config)
-          const { state, renderedInput, renderedRecipients, integrationId, recipientDirectoryKey, timeoutMs } =
-            resolveInput(parameters, config)
+          const {
+            state,
+            renderedInput,
+            renderedRecipients,
+            integrationId,
+            recipientDirectoryKey,
+            trustedRuntimeContext,
+            timeoutMs
+          } = resolveInput(parameters, config)
           const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
           // 接收人优先级：当前会话姓名 > middleware 默认配置 > tool call recipient_id
           const recipients = requireRecipients(
@@ -1333,9 +1428,14 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
 
           const client = await getClient(resolvedIntegrationId, timeoutMs, toolName)
 
-          const result = await runSendTaskBatch({
+          const batch = await runSendTaskBatch({
             integrationId: resolvedIntegrationId,
             toolName,
+            toolCallId,
+            permissionGuideChatId: parsed.trustedTriggerOnly
+              ? trustedRuntimeContext.chatId
+              : resolveLarkFileRuntimeContext(config, state).chatId,
+            operation: 'Failed to send text notification',
             recipients,
             timeoutMs,
             onSuccess: async (recipient) => {
@@ -1362,8 +1462,11 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
               }
             }
           })
+          if (batch.permissionCommand) {
+            return batch.permissionCommand
+          }
 
-          return buildCommand(toolName, toolCallId, result)
+          return buildCommand(toolName, toolCallId, batch.result)
         },
         {
           name: 'lark_send_text_notification',
@@ -1418,6 +1521,17 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
               `[${toolName}] upload '${file.fileName}'`
             )
           } catch (error) {
+            const permissionCommand = await buildApplicationPermissionCommand({
+              error,
+              toolName,
+              toolCallId,
+              integrationId: resolvedIntegrationId,
+              chatId: runtimeContext.chatId,
+              operation: `Failed to upload '${file.fileName}'`
+            })
+            if (permissionCommand) {
+              return permissionCommand
+            }
             throw new Error(`[${toolName}] Failed to upload '${file.fileName}': ${formatError(error)}`)
           }
 
@@ -1426,9 +1540,12 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
             throw new Error(`[${toolName}] Lark file upload did not return file_key.`)
           }
 
-          const batchResult = await runSendTaskBatch({
+          const batch = await runSendTaskBatch({
             integrationId: resolvedIntegrationId,
             toolName,
+            toolCallId,
+            permissionGuideChatId: runtimeContext.chatId,
+            operation: `Failed to send '${file.fileName}'`,
             recipients,
             timeoutMs,
             onSuccess: async (recipient) => {
@@ -1463,6 +1580,10 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
               }
             }
           })
+          if (batch.permissionCommand) {
+            return batch.permissionCommand
+          }
+          const batchResult = batch.result
           const result = {
             file: toLarkSendFileMetadata(file),
             successCount: batchResult.successCount,
@@ -1499,6 +1620,7 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
             renderedDefaults,
             integrationId,
             recipientDirectoryKey,
+            trustedRuntimeContext,
             timeoutMs
           } = resolveInput(parameters, config)
           const resolvedIntegrationId = requireIntegrationId(integrationId, toolName)
@@ -1546,9 +1668,14 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
 
           const client = await getClient(resolvedIntegrationId, timeoutMs, toolName)
 
-          const result = await runSendTaskBatch({
+          const batch = await runSendTaskBatch({
             integrationId: resolvedIntegrationId,
             toolName,
+            toolCallId,
+            permissionGuideChatId: parsed.trustedTriggerOnly
+              ? trustedRuntimeContext.chatId
+              : resolveLarkFileRuntimeContext(config, state).chatId,
+            operation: 'Failed to send rich notification',
             recipients,
             timeoutMs,
             onSuccess: async (recipient) => {
@@ -1593,8 +1720,11 @@ export class LarkNotifyMiddleware implements IAgentMiddlewareStrategy {
               }
             }
           })
+          if (batch.permissionCommand) {
+            return batch.permissionCommand
+          }
 
-          return buildCommand(toolName, toolCallId, result)
+          return buildCommand(toolName, toolCallId, batch.result)
         },
         {
           name: 'lark_send_rich_notification',


### PR DESCRIPTION
## Problem

When a Lark message or file tool failed because the application lacked required scopes, the tool only returned an error to the agent. Administrators did not receive an actionable permission card in the current chat, and code-based or text-parsing fallbacks could classify unrelated errors as permission failures.

## Root cause

Application permission handling was concentrated in the remote message context service and depended partly on selected error codes and scope-like text. The notification middleware did not handle structured `action_privilege_required` violations from text, rich-message, file-upload, or file-send operations.

## Fix

- Recognize application permission failures only from structured Lark `permission_violations` entries with type `action_privilege_required`.
- Share the structured permission conversion between remote-message and notification tools.
- Send an administrator permission guide card to the trusted current Lark chat for text, rich-message, file-upload, and file-send failures.
- End the current tool path only when the guide card was sent successfully; otherwise return the original actionable permission result without redirecting to an unrelated chat.
- Add focused regression coverage and a patch changeset for `@xpert-ai/plugin-lark`.

## Validation

- Focused Lark permission and notification suites passed earlier in this implementation run: 47 tests passed.
- `git diff --cached --check` passed.
- A final focused rerun was blocked before Jest execution because pnpm dependency verification hit the local certificate error `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`; no test assertion failed.
