### PR TITLE
fix: prevent stale WeChat aggregate flushes

### DIFF
--- a/community/.changeset/wechat-aggregate-flush-lock.md
+++ b/community/.changeset/wechat-aggregate-flush-lock.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-community-wechat": patch
+---
+
+Keep per-conversation WeChat aggregate locks renewed while inbound attachments materialize so stale flush jobs cannot dispatch old snapshots.

--- a/community/integrations/wechat/src/lib/workflow/wechat-trigger-aggregation.service.spec.ts
+++ b/community/integrations/wechat/src/lib/workflow/wechat-trigger-aggregation.service.spec.ts
@@ -155,10 +155,122 @@ describe('WechatTriggerAggregationService', () => {
     )
     expect(callback).toHaveBeenCalledTimes(1)
     expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('pexpire'"),
+      1,
+      'plugin_wechat:trigger:tenant-1:org-1:integration-1:lock:inbound:aggregate-1',
+      expect.any(String),
+      '3000'
+    )
+    expect(redis.eval).toHaveBeenCalledWith(
       expect.stringContaining("redis.call('get'"),
       1,
       'plugin_wechat:trigger:tenant-1:org-1:integration-1:lock:inbound:aggregate-1',
       expect.any(String)
+    )
+  })
+
+  it('clears aggregate state only while the lock token is still owned', async () => {
+    const { service, redis } = createService()
+    const scope = {
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      integrationId: 'integration-1'
+    }
+
+    await expect(
+      service.withAggregateLock('aggregate-1', async (lease) => {
+        await lease.clearStateIfOwned()
+      }, 3000, scope)
+    ).resolves.toBeUndefined()
+
+    expect(redis.eval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('del', KEYS[2])"),
+      2,
+      'plugin_wechat:trigger:tenant-1:org-1:integration-1:lock:inbound:aggregate-1',
+      'plugin_wechat:trigger:tenant-1:org-1:integration-1:aggregate:aggregate-1',
+      expect.any(String)
+    )
+  })
+
+  it('does not clear aggregate state after lock ownership is lost', async () => {
+    let lockToken = ''
+    let aggregateState = 'version-2'
+    const redis = createRedis({
+      set: jest.fn(async (_key: string, token: string) => {
+        lockToken = token
+        return 'OK'
+      }),
+      eval: jest.fn(async (script: string, _keyCount: number, ...args: string[]) => {
+        if (script.includes("redis.call('del', KEYS[2])")) {
+          if (lockToken !== args[2]) {
+            return -1
+          }
+          aggregateState = ''
+          return 1
+        }
+        if (script.includes("redis.call('pexpire'")) {
+          return lockToken === args[1] ? 1 : 0
+        }
+        return lockToken === args[1] ? 1 : 0
+      })
+    })
+    const { service } = createService(redis)
+
+    await expect(
+      service.withAggregateLock('aggregate-1', async (lease) => {
+        lockToken = 'new-owner-token'
+        aggregateState = 'version-3'
+        await lease.clearStateIfOwned()
+      })
+    ).rejects.toThrow('inbound_aggregate_lock_lost')
+
+    expect(aggregateState).toBe('version-3')
+  })
+
+  it('renews the per-aggregate lock while the callback is still running', async () => {
+    jest.useFakeTimers()
+    try {
+      const { service, redis } = createService()
+      let finishCallback!: () => void
+      const callbackGate = new Promise<void>((resolve) => {
+        finishCallback = resolve
+      })
+      let notifyCallbackStarted!: () => void
+      const callbackStarted = new Promise<void>((resolve) => {
+        notifyCallbackStarted = resolve
+      })
+
+      const result = service.withAggregateLock(
+        'aggregate-1',
+        async () => {
+          notifyCallbackStarted()
+          await callbackGate
+          return 'done'
+        },
+        3000
+      )
+      await callbackStarted
+      await jest.advanceTimersByTimeAsync(7000)
+
+      const evalCalls = redis.eval.mock.calls as unknown[][]
+      const renewCalls = evalCalls.filter(([script]) => String(script).includes("redis.call('pexpire'"))
+      expect(renewCalls.length).toBeGreaterThanOrEqual(2)
+
+      finishCallback()
+      await expect(result).resolves.toBe('done')
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it('rejects the callback result when aggregate lock ownership is lost', async () => {
+    const redis = createRedis({
+      eval: jest.fn(async (script: string) => script.includes("redis.call('pexpire'") ? 0 : 1)
+    })
+    const { service } = createService(redis)
+
+    await expect(service.withAggregateLock('aggregate-1', async () => 'done')).rejects.toThrow(
+      'inbound_aggregate_lock_lost'
     )
   })
 

--- a/community/integrations/wechat/src/lib/workflow/wechat-trigger-aggregation.service.ts
+++ b/community/integrations/wechat/src/lib/workflow/wechat-trigger-aggregation.service.ts
@@ -29,6 +29,11 @@ type AggregationScope = {
   organizationId?: string | null
 }
 
+export type WechatAggregateLockLease = {
+  ensureOwned(): Promise<void>
+  clearStateIfOwned(): Promise<void>
+}
+
 @Injectable()
 export class WechatTriggerAggregationService {
   private _managedQueueService?: ManagedQueueService
@@ -136,20 +141,73 @@ export class WechatTriggerAggregationService {
 
   async withAggregateLock<T>(
     aggregateKey: string,
-    callback: () => Promise<T>,
+    callback: (lease: WechatAggregateLockLease) => Promise<T>,
     ttlMs: number = DEFAULT_LOCK_TTL_MS,
     scope?: AggregationScope
   ): Promise<T> {
     const token = randomUUID()
     const key = this.buildLockKey(aggregateKey, scope)
+    const stateKey = this.buildKey(aggregateKey, scope)
     const acquired = await this.acquireLock(key, token, ttlMs)
     if (!acquired) {
       throw new Error('inbound_aggregate_lock_unavailable')
     }
 
+    let stopped = false
+    let lostError: Error | undefined
+    let renewalInFlight: Promise<void> | undefined
+    const renew = async (): Promise<void> => {
+      if (stopped || lostError) {
+        return
+      }
+      try {
+        if (!(await this.renewLock(key, token, ttlMs))) {
+          lostError = new Error('inbound_aggregate_lock_lost')
+        }
+      } catch {
+        lostError = new Error('inbound_aggregate_lock_renew_failed')
+      }
+    }
+    const ensureOwned = async (): Promise<void> => {
+      if (renewalInFlight) {
+        await renewalInFlight
+      }
+      if (lostError) {
+        throw lostError
+      }
+      await renew()
+      if (lostError) {
+        throw lostError
+      }
+    }
+    const clearStateIfOwned = async (): Promise<void> => {
+      if (renewalInFlight) {
+        await renewalInFlight
+      }
+      if (lostError) {
+        throw lostError
+      }
+      if (!(await this.deleteAggregateStateIfLockOwned(key, stateKey, token))) {
+        lostError = new Error('inbound_aggregate_lock_lost')
+        throw lostError
+      }
+    }
+    const renewTimer = setInterval(() => {
+      if (!renewalInFlight && !lostError) {
+        renewalInFlight = renew().finally(() => {
+          renewalInFlight = undefined
+        })
+      }
+    }, Math.max(1, Math.floor(ttlMs / 3)))
+
     try {
-      return await callback()
+      const result = await callback({ ensureOwned, clearStateIfOwned })
+      await ensureOwned()
+      return result
     } finally {
+      stopped = true
+      clearInterval(renewTimer)
+      await renewalInFlight?.catch(() => undefined)
       await this.releaseLock(key, token)
     }
   }
@@ -167,6 +225,17 @@ export class WechatTriggerAggregationService {
     return result === 'OK'
   }
 
+  private async renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+    const result = await (await this.getRedis()).eval(
+      "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+      1,
+      key,
+      token,
+      String(ttlMs)
+    )
+    return result === 1
+  }
+
   private async releaseLock(key: string, token: string): Promise<void> {
     await (await this.getRedis()).eval(
       "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
@@ -174,6 +243,17 @@ export class WechatTriggerAggregationService {
       key,
       token
     )
+  }
+
+  private async deleteAggregateStateIfLockOwned(lockKey: string, stateKey: string, token: string): Promise<boolean> {
+    const result = await (await this.getRedis()).eval(
+      "if redis.call('get', KEYS[1]) ~= ARGV[1] then return -1 end redis.call('del', KEYS[2]) return 1",
+      2,
+      lockKey,
+      stateKey,
+      token
+    )
+    return result === 1
   }
 
   private buildKey(aggregateKey: string, scope?: AggregationScope): string {

--- a/community/integrations/wechat/src/lib/workflow/wechat-trigger.strategy.spec.ts
+++ b/community/integrations/wechat/src/lib/workflow/wechat-trigger.strategy.spec.ts
@@ -16,6 +16,7 @@ jest.mock('@xpert-ai/plugin-sdk', () => ({
 
 import { WechatTriggerStrategy } from './wechat-trigger.strategy.js'
 import { WechatMessage } from '../message.js'
+import type { WechatAggregateLockLease } from './wechat-trigger-aggregation.service.js'
 
 describe('WechatTriggerStrategy', () => {
   it('replays published trigger bindings during server bootstrap', () => {
@@ -49,13 +50,19 @@ describe('WechatTriggerStrategy', () => {
         payload
       }))
     }
+    const aggregateLockLease = {
+      ensureOwned: jest.fn().mockResolvedValue(undefined),
+      clearStateIfOwned: jest.fn().mockResolvedValue(undefined)
+    }
     const aggregationService = {
       get: jest.fn().mockResolvedValue(null),
       save: jest.fn().mockResolvedValue(undefined),
       clear: jest.fn().mockResolvedValue(undefined),
       enqueueAggregate: jest.fn().mockResolvedValue({ id: 'aggregate-job-1' }),
       enqueueFlush: jest.fn().mockResolvedValue({ id: 'flush-job-1' }),
-      withAggregateLock: jest.fn(async (_aggregateKey: string, callback: () => Promise<unknown>) => callback())
+      withAggregateLock: jest.fn(async (_aggregateKey: string, callback: (lease: WechatAggregateLockLease) => Promise<unknown>) =>
+        callback(aggregateLockLease)
+      )
     }
     const bindingRepository = {
       upsert: jest.fn().mockResolvedValue(undefined),
@@ -191,6 +198,7 @@ describe('WechatTriggerStrategy', () => {
       strategy,
       dispatchService,
       aggregationService,
+      aggregateLockLease,
       bindingRepository,
       accountRepository,
       wechatClient,
@@ -728,6 +736,73 @@ describe('WechatTriggerStrategy', () => {
     )
   })
 
+  it('locks flush and rejects an outdated aggregate version', async () => {
+    const { strategy, dispatchService, aggregationService, aggregateLockLease } = createStrategy()
+    const aggregateKey = 'integration-1:uuid-1:wxid_friend:wxid_friend'
+    const state = {
+      aggregateKey,
+      integrationId: 'integration-1',
+      accountUuid: '*',
+      conversationUserKey: aggregateKey,
+      xpertId: 'xpert-1',
+      version: 2,
+      inputParts: ['分析这张图片', ''],
+      items: [
+        { input: '分析这张图片', messageKind: 'text', chatType: 'private' },
+        { input: '', messageKind: 'image', chatType: 'private' }
+      ],
+      files: [
+        {
+          fileUrl: 'data:image/png;base64,iVBORw0KGgo=',
+          mimeType: 'image/png',
+          originalName: 'wechat-image.png',
+          fileKey: 'image-key-1',
+          fileAssetId: 'image-asset-1'
+        }
+      ],
+      currentInboundLogIds: ['inbound-text-log-1', 'inbound-image-log-1'],
+      lastMessageAt: Date.now(),
+      tenantId: 'tenant-1',
+      organizationId: 'org-1',
+      latestMessage: {
+        integrationId: 'integration-1',
+        uuid: 'uuid-1',
+        contactId: 'wxid_friend',
+        senderId: 'wxid_friend',
+        messageId: 'image-msg-1'
+      }
+    }
+    aggregationService.get.mockResolvedValue(state)
+    const scope = {
+      integrationId: 'integration-1',
+      tenantId: 'tenant-1',
+      organizationId: 'org-1'
+    }
+
+    await expect(
+      strategy.flushBufferedConversation({ aggregateKey, version: 1, ...scope })
+    ).resolves.toBe(false)
+    expect(dispatchService.enqueueDispatch).not.toHaveBeenCalled()
+
+    await expect(
+      strategy.flushBufferedConversation({ aggregateKey, version: 2, ...scope })
+    ).resolves.toBe(true)
+    expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+    expect(dispatchService.enqueueDispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: '分析这张图片',
+        files: [expect.objectContaining({ fileAssetId: 'image-asset-1' })]
+      })
+    )
+    expect(aggregationService.withAggregateLock).toHaveBeenCalledWith(
+      aggregateKey,
+      expect.any(Function),
+      undefined,
+      expect.objectContaining(scope)
+    )
+    expect(aggregateLockLease.clearStateIfOwned).toHaveBeenCalledTimes(1)
+  })
+
   it('coalesces duplicate pending file refs and materializes the more complete attachment metadata', async () => {
     const { strategy, aggregationService, wechatClient, workspaceFiles } = createStrategy()
     const partialFileRef = {
@@ -847,7 +922,7 @@ describe('WechatTriggerStrategy', () => {
   })
 
   it('flushes one debounced batch as one fresh-session dispatch with history context', async () => {
-    const { strategy, dispatchService, aggregationService } = createStrategy()
+    const { strategy, dispatchService, aggregationService, aggregateLockLease } = createStrategy()
     aggregationService.get.mockResolvedValueOnce({
       aggregateKey: 'integration-1:uuid-1:wxid_friend:wxid_friend',
       integrationId: 'integration-1',
@@ -905,18 +980,19 @@ describe('WechatTriggerStrategy', () => {
         conversationId: expect.anything()
       })
     )
-    expect(aggregationService.clear).toHaveBeenCalledWith(
-      'integration-1:uuid-1:wxid_friend:wxid_friend',
-      expect.objectContaining({
-        integrationId: 'integration-1',
-        tenantId: 'tenant-1',
-        organizationId: 'org-1'
-      })
-    )
+    expect(aggregateLockLease.clearStateIfOwned).toHaveBeenCalledTimes(1)
   })
 
   it('materializes pending files at flush and dispatches FileAsset handles with merged text', async () => {
-    const { strategy, dispatchService, aggregationService, wechatClient, workspaceFiles, messageFileRepository } = createStrategy()
+    const {
+      strategy,
+      dispatchService,
+      aggregationService,
+      aggregateLockLease,
+      wechatClient,
+      workspaceFiles,
+      messageFileRepository
+    } = createStrategy()
     const fileRef = {
       uuid: 'uuid-1',
       contactId: 'wxid_friend',
@@ -1361,8 +1437,15 @@ describe('WechatTriggerStrategy', () => {
   })
 
   it('keeps the debounced batch and retries flush when file attachment fields are not ready', async () => {
-    const { strategy, dispatchService, aggregationService, wechatClient, messageLogRepository, messageFileRepository } =
-      createStrategy()
+    const {
+      strategy,
+      dispatchService,
+      aggregationService,
+      aggregateLockLease,
+      wechatClient,
+      messageLogRepository,
+      messageFileRepository
+    } = createStrategy()
     wechatClient.downloadFile.mockResolvedValueOnce({
       success: false,
       error: '无法从应用消息提取附件'
@@ -1440,7 +1523,7 @@ describe('WechatTriggerStrategy', () => {
         status: 'failed'
       })
     )
-    expect(aggregationService.clear).not.toHaveBeenCalled()
+    expect(aggregateLockLease.clearStateIfOwned).not.toHaveBeenCalled()
     expect(aggregationService.save).toHaveBeenCalledWith(
       expect.objectContaining({
         fileMaterializeRetryCount: 1,
@@ -1814,7 +1897,7 @@ describe('WechatTriggerStrategy', () => {
   })
 
   it('skips a debounced group batch when no item matches the trigger policy', async () => {
-    const { strategy, dispatchService, aggregationService, messageLogRepository } = createStrategy()
+    const { strategy, dispatchService, aggregationService, aggregateLockLease, messageLogRepository } = createStrategy()
     aggregationService.get.mockResolvedValueOnce({
       aggregateKey: 'integration-1:uuid-1:room@chatroom:wxid_sender',
       integrationId: 'integration-1',
@@ -1866,14 +1949,7 @@ describe('WechatTriggerStrategy', () => {
         error: 'filtered_by_trigger_policy'
       })
     )
-    expect(aggregationService.clear).toHaveBeenCalledWith(
-      'integration-1:uuid-1:room@chatroom:wxid_sender',
-      expect.objectContaining({
-        integrationId: 'integration-1',
-        tenantId: 'tenant-1',
-        organizationId: 'org-1'
-      })
-    )
+    expect(aggregateLockLease.clearStateIfOwned).toHaveBeenCalledTimes(1)
   })
 
   it('dispatches debounced group join welcomes without normal group mention or keyword policy', async () => {

--- a/community/integrations/wechat/src/lib/workflow/wechat-trigger.strategy.ts
+++ b/community/integrations/wechat/src/lib/workflow/wechat-trigger.strategy.ts
@@ -50,7 +50,10 @@ import {
   WechatTriggerAggregationState,
   WechatTriggerFlushPayload
 } from './wechat-trigger-aggregation.types.js'
-import { WechatTriggerAggregationService } from './wechat-trigger-aggregation.service.js'
+import {
+  type WechatAggregateLockLease,
+  WechatTriggerAggregationService
+} from './wechat-trigger-aggregation.service.js'
 import { TWechatTriggerConfig, WechatTrigger } from './wechat-trigger.types.js'
 
 const DEFAULT_SESSION_TIMEOUT_SECONDS = 3600
@@ -924,7 +927,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       return
     }
 
-    await this.aggregationService.withAggregateLock(aggregateKey, async () => {
+    await this.aggregationService.withAggregateLock(aggregateKey, async (lease) => {
       const currentState = await this.aggregationService.get(aggregateKey, payload)
       const sameRoutingTarget =
         currentState?.integrationId === payload.integrationId &&
@@ -1001,6 +1004,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
         this.normalizePositiveSeconds(payload.sessionTimeoutSeconds, DEFAULT_SESSION_TIMEOUT_SECONDS),
         summaryWindowSeconds * 3
       )
+      await lease.ensureOwned()
       await this.aggregationService.save(aggregateState, ttlSeconds)
       await this.aggregationService.enqueueFlush(aggregateState, summaryWindowSeconds * 1000)
     }, undefined, payload)
@@ -1012,6 +1016,19 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       return false
     }
 
+    return this.aggregationService.withAggregateLock(
+      aggregateKey,
+      (lease) => this.flushBufferedConversationUnderLock(aggregateKey, payload, lease),
+      undefined,
+      payload
+    )
+  }
+
+  private async flushBufferedConversationUnderLock(
+    aggregateKey: string,
+    payload: WechatTriggerFlushPayload,
+    lease: WechatAggregateLockLease
+  ): Promise<boolean> {
     const state = await this.aggregationService.get(aggregateKey, payload)
     if (!state || state.version !== payload.version) {
       return false
@@ -1040,6 +1057,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       pendingFiles,
       markFailures: false
     })
+    await lease.ensureOwned()
     if (materialized.success === false) {
       if (materialized.recoverable && this.canRetryPendingFileMaterialize(state)) {
         await this.schedulePendingFileMaterializeRetry(aggregateKey, state, materialized.error)
@@ -1047,7 +1065,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       }
       await this.markPendingFilesFailed(pendingFiles, state, materialized.error)
       await this.markInboundLogs(state.currentInboundLogIds, state, 'failed', materialized.error)
-      await this.aggregationService.clear(aggregateKey, state)
+      await lease.clearStateIfOwned()
       return false
     }
 
@@ -1069,7 +1087,7 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       await this.markInboundLogs(dispatchLogIds, state, 'skipped', 'filtered_by_trigger_policy')
       await this.markInboundLogs(skippedLogIds, state, 'skipped', skippedError)
       await this.markInboundLogs(duplicateLogIds, state, 'skipped', 'duplicate_file_event')
-      await this.aggregationService.clear(aggregateKey, state)
+      await lease.clearStateIfOwned()
       return false
     }
 
@@ -1078,11 +1096,12 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       await this.markInboundLogs(dispatchLogIds, state, 'skipped', 'empty_inbound_message_after_file_rules')
       await this.markInboundLogs(skippedLogIds, state, 'skipped', skippedError)
       await this.markInboundLogs(duplicateLogIds, state, 'skipped', 'duplicate_file_event')
-      await this.aggregationService.clear(aggregateKey, state)
+      await lease.clearStateIfOwned()
       return false
     }
     const dispatchInput = this.composeDispatchInput(aggregatedInput, state.historyContext)
 
+    await lease.ensureOwned()
     await this.dispatchInboundMessage({
       integrationId: state.integrationId,
       accountUuid: this.normalizeTriggerAccountUuid(state.accountUuid),
@@ -1120,10 +1139,11 @@ export class WechatTriggerStrategy implements IWorkflowTriggerStrategy<TWechatTr
       }
     })
 
+    await lease.ensureOwned()
     await this.markInboundLogs(dispatchLogIds, state, 'dispatched')
     await this.markInboundLogs(skippedLogIds, state, 'skipped', skippedError)
     await this.markInboundLogs(duplicateLogIds, state, 'skipped', 'duplicate_file_event')
-    await this.aggregationService.clear(aggregateKey, state)
+    await lease.clearStateIfOwned()
     return true
   }
 


### PR DESCRIPTION
## Summary

- serialize WeChat aggregate and flush work with the same renewable per-conversation Redis lock
- reject outdated flush payload versions before dispatch
- atomically clear aggregate state only while the current lock token is still owned
- add focused race, lock renewal, stale-version, and lock-loss regression coverage

## Root cause

Inbound image materialization can outlive the previous five-second lock. A stale flush could then read or dispatch an older aggregate snapshot, and a worker that lost its lock could unconditionally delete state written by a newer worker.

## Validation

- `pnpm exec jest --config jest.config.ts --runInBand` — 23 suites, 266 tests passed
- `pnpm exec tsc -p tsconfig.lib.json --pretty false`
- `pnpm exec tsc -p tsconfig.spec.json --noEmit --pretty false`
- Node 20 `plugin-dev-harness` lifecycle load passed
- `pnpm -C community exec changeset status` reports a patch bump
- `git diff --check` passed

Browser and live WeChat validation were not run.