### PR TITLE
fix: validate vendored design fonts in app packages

### DIFF
--- a/xpertai/.changeset/verify-vendored-design-fonts.md
+++ b/xpertai/.changeset/verify-vendored-design-fonts.md
@@ -1,0 +1,6 @@
+---
+'@xpert-ai/plugin-canvas': patch
+'@xpert-ai/plugin-excalidraw': patch
+---
+
+Verify that published Canvas and Excalidraw packages vendor design font metadata without depending on the private workspace package.

--- a/xpertai/apps/canvas/.xpertai-plugin/plugin.json
+++ b/xpertai/apps/canvas/.xpertai-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpert-ai/plugin-canvas",
-  "version": "0.3.0",
+  "version": "0.4.2",
   "description": "Canvas app plugin for agent-managed tldraw infinite canvases, image holders, annotation workflows, reviewable versions, and an editable workbench.",
   "author": "XpertAI",
   "homepage": "https://github.com/xpert-ai/xpert-plugins/tree/main/xpertai/apps/canvas",

--- a/xpertai/apps/canvas/scripts/verify-package-output.mjs
+++ b/xpertai/apps/canvas/scripts/verify-package-output.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -8,6 +8,8 @@ const requiredFiles = [
   'dist/index.d.ts',
   'dist/xpert-canvas-assistant.yaml',
   'dist/lib/remote-components/canvas-workbench/app.js',
+  'dist/vendor/design-fonts/index.js',
+  'dist/vendor/design-fonts/index.d.ts',
   'dist/sandbox-actions/canvas-export/action.json',
   'dist/sandbox-actions/canvas-export/bundle/runner.mjs',
   'dist/sandbox-actions/canvas-export/bundle/renderer.js',
@@ -28,6 +30,14 @@ if (missing.length) {
 const packageJson = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'))
 const pluginManifest = JSON.parse(readFileSync(join(packageRoot, '.xpertai-plugin/plugin.json'), 'utf8'))
 const actionManifest = JSON.parse(readFileSync(join(packageRoot, 'dist/sandbox-actions/canvas-export/action.json'), 'utf8'))
+if (packageJson.dependencies?.['@xpert-ai/design-fonts']) {
+  throw new Error('Canvas must vendor @xpert-ai/design-fonts instead of publishing it as a runtime dependency.')
+}
+const unresolvedDesignFontImports = listRuntimeFiles(join(packageRoot, 'dist'))
+  .filter((file) => readFileSync(file, 'utf8').includes('@xpert-ai/design-fonts'))
+if (unresolvedDesignFontImports.length) {
+  throw new Error(`Canvas package output still imports @xpert-ai/design-fonts: ${unresolvedDesignFontImports.join(', ')}`)
+}
 if (pluginManifest.name !== packageJson.name || pluginManifest.version !== packageJson.version) {
   throw new Error('Canvas package and plugin manifest identity/version must match.')
 }
@@ -39,4 +49,12 @@ if (pluginManifest.sandboxActions !== './dist/sandbox-actions/canvas-export/acti
 }
 if (actionManifest.name !== 'canvas.export' || actionManifest.version !== '1.0.0' || actionManifest.runtimeProfile !== 'browser/playwright-1.61/v1') {
   throw new Error('Canvas Sandbox Action identity, version, or runtime profile is invalid.')
+}
+
+function listRuntimeFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return listRuntimeFiles(path)
+    return /\.(?:js|mjs|d\.ts)$/.test(entry.name) ? [path] : []
+  })
 }

--- a/xpertai/apps/excalidraw/scripts/verify-package-output.mjs
+++ b/xpertai/apps/excalidraw/scripts/verify-package-output.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
 import { dirname, join, normalize } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -29,6 +29,8 @@ const requiredFiles = new Set([
   'dist/lib/diagram-engine/diagram-engine.module.js',
   'dist/lib/diagram-engine/diagram.middleware.js',
   'dist/lib/remote-components/excalidraw-workbench/app.js',
+  'dist/vendor/design-fonts/index.js',
+  'dist/vendor/design-fonts/index.d.ts',
   'dist/lib/artifact-viewer/app.js',
   'dist/lib/artifact-viewer/app.css',
   'dist/xpert-excalidraw-assistant.yaml',
@@ -50,4 +52,21 @@ if (missingFiles.length) {
     console.error(`- ${normalize(file)}`)
   }
   process.exit(1)
+}
+
+if (packageJson.dependencies?.['@xpert-ai/design-fonts']) {
+  throw new Error('Excalidraw must vendor @xpert-ai/design-fonts instead of publishing it as a runtime dependency.')
+}
+const unresolvedDesignFontImports = listRuntimeFiles(join(packageRoot, 'dist'))
+  .filter((file) => readFileSync(file, 'utf8').includes('@xpert-ai/design-fonts'))
+if (unresolvedDesignFontImports.length) {
+  throw new Error(`Excalidraw package output still imports @xpert-ai/design-fonts: ${unresolvedDesignFontImports.join(', ')}`)
+}
+
+function listRuntimeFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name)
+    if (entry.isDirectory()) return listRuntimeFiles(path)
+    return /\.(?:js|mjs|d\.ts)$/.test(entry.name) ? [path] : []
+  })
 }


### PR DESCRIPTION
## Summary

- require Canvas and Excalidraw package output to include vendored design font metadata
- fail packaging when the private workspace package is declared as a runtime dependency or remains imported in dist
- synchronize the Canvas plugin manifest version and add patch changesets for both plugins

## Validation

- Canvas and Excalidraw prepack passed
- generated tarballs contain dist/vendor/design-fonts and no @xpert-ai/design-fonts runtime dependency
- clean temporary npm install of both tarballs passed without @xpert-ai/design-fonts in the dependency tree
- plugin-dev-harness lifecycle passed for both plugins
- Canvas Sandbox Action smoke test passed