### PR TITLE
fix: make design font vendoring idempotent

### DIFF
--- a/xpertai/apps/canvas/.xpertai-plugin/plugin.json
+++ b/xpertai/apps/canvas/.xpertai-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpert-ai/plugin-canvas",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Canvas app plugin for agent-managed tldraw infinite canvases, image holders, annotation workflows, reviewable versions, and an editable workbench.",
   "author": "XpertAI",
   "homepage": "https://github.com/xpert-ai/xpert-plugins/tree/main/xpertai/apps/canvas",

--- a/xpertai/scripts/vendor-design-fonts.mjs
+++ b/xpertai/scripts/vendor-design-fonts.mjs
@@ -12,7 +12,7 @@ const vendorDist = join(pluginDist, 'vendor', 'design-fonts')
 await mkdir(vendorDist, { recursive: true })
 await cp(sourceDist, vendorDist, { recursive: true })
 
-let replacementCount = 0
+let vendoredImportCount = 0
 for (const file of await listFiles(pluginDist)) {
   if (!/\.(?:js|d\.ts)$/.test(file) || file.startsWith(vendorDist)) {
     continue
@@ -20,17 +20,18 @@ for (const file of await listFiles(pluginDist)) {
   const source = await readFile(file, 'utf8')
   const vendorEntry = relative(dirname(file), join(vendorDist, 'index.js')).split(sep).join('/')
   const specifier = vendorEntry.startsWith('.') ? vendorEntry : `./${vendorEntry}`
-  const rewritten = source.replace(/(['"])@xpert-ai\/design-fonts\1/g, (_match, quote) => {
-    replacementCount += 1
-    return `${quote}${specifier}${quote}`
-  })
+  const rewritten = source.replace(/(['"])@xpert-ai\/design-fonts\1/g, (_match, quote) => `${quote}${specifier}${quote}`)
+  const escapedSpecifier = specifier.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  if (new RegExp(`(['"])${escapedSpecifier}\\1`).test(rewritten)) {
+    vendoredImportCount += 1
+  }
   if (rewritten !== source) {
     await writeFile(file, rewritten)
   }
 }
 
-if (!replacementCount) {
-  throw new Error(`No @xpert-ai/design-fonts imports were found in ${pluginDist}.`)
+if (!vendoredImportCount) {
+  throw new Error(`No @xpert-ai/design-fonts or vendored design font imports were found in ${pluginDist}.`)
 }
 
 async function listFiles(directory) {


### PR DESCRIPTION
## Summary

- allow the shared design font vendor step to recognize already-rewritten dist imports
- preserve the guard when neither workspace nor vendored font imports exist
- synchronize the Canvas plugin manifest with the pending 0.4.3 release

This fixes the second prepack failure in Release Plugins run 29883754461. No new changeset is included because Canvas 0.4.3 and Excalidraw 0.12.3 are already versioned and remain unpublished.

## Validation

- Canvas prepack passed twice consecutively
- Excalidraw prepack passed twice consecutively
- raw import rewrite fixture passed
- second-run idempotency fixture passed
- missing-import guard fixture passed
- Canvas Sandbox Action smoke test passed twice
- plugin-dev-harness lifecycle completed for Canvas and Excalidraw