### PR TITLE
fix: enable Excalidraw online fonts

### DIFF
--- a/xpertai/.changeset/fix-excalidraw-online-fonts.md
+++ b/xpertai/.changeset/fix-excalidraw-online-fonts.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-excalidraw': patch
+---
+
+Fix managed Excalidraw font IDs and allow published drawings to load the official HTTPS font assets.

--- a/xpertai/.changeset/fix-pencil-design-fonts-prepack.md
+++ b/xpertai/.changeset/fix-pencil-design-fonts-prepack.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-pencil': patch
+---
+
+Run design font vendoring during Pencil prepack so published packages do not keep runtime imports to workspace-only font helpers.

--- a/xpertai/.changeset/fix-pencil-published-fonts.md
+++ b/xpertai/.changeset/fix-pencil-published-fonts.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-pencil': patch
+---
+
+Load managed online fonts used by published Pencil SVG artifacts.

--- a/xpertai/apps/excalidraw/src/lib/diagram-engine/diagram-engine.spec.ts
+++ b/xpertai/apps/excalidraw/src/lib/diagram-engine/diagram-engine.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common'
+import { serializeTypographyPresets } from '@xpert-ai/design-fonts'
 import { normalizeExcalidrawScene } from '../excalidraw-scene.validation.js'
 import {
   ArtifactTemplateCatalogService,
@@ -86,6 +87,30 @@ describe('Excalidraw DiagramEngine reference implementation', () => {
 
     expect(textElements.length).toBeGreaterThan(0)
     expect(textElements.every((element) => element.fontFamily === 3)).toBe(true)
+  })
+
+  it('uses the Excalidraw 0.18 managed font family ids', () => {
+    const presets = serializeTypographyPresets('excalidraw')
+
+    expect(Object.fromEntries(presets.map((preset) => [preset.id, preset.fontFamilyId]))).toEqual({
+      'neutral-ui': 6,
+      'modern-tech': 9,
+      editorial: 2,
+      developer: 3,
+      expressive: 7,
+      handwritten: 5,
+      'zh-modern': 6
+    })
+  })
+
+  it('accepts registered Excalidraw font ids and rejects the unused id 4', () => {
+    const valid = structuredClone(BUILTIN_DIAGRAM_TEMPLATES[0].payload.base)
+    valid.appearance.fontFamilyId = 9
+    expect(() => parseDiagramIr(valid)).not.toThrow()
+
+    const invalid = structuredClone(BUILTIN_DIAGRAM_TEMPLATES[0].payload.base)
+    invalid.appearance.fontFamilyId = 4
+    expect(() => parseDiagramIr(invalid)).toThrow(/appearance\.fontFamilyId/)
   })
 
   it('renders SVG to PNG and writes both artifacts to workspace-scoped quality paths', async () => {

--- a/xpertai/apps/excalidraw/src/lib/diagram-engine/diagram.schema.ts
+++ b/xpertai/apps/excalidraw/src/lib/diagram-engine/diagram.schema.ts
@@ -61,7 +61,16 @@ export const diagramIrSchema = z.object({
     colorScheme: z.enum(['light', 'dark']),
     rendering: z.enum(['clean', 'sketch']),
     palette: z.enum(['neutral', 'semantic']),
-    fontFamilyId: z.number().int().min(1).max(8).optional()
+    fontFamilyId: z.union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.literal(5),
+      z.literal(6),
+      z.literal(7),
+      z.literal(8),
+      z.literal(9)
+    ]).optional()
   }).strict(),
   layout: z.object({
     strategy: z.enum(['layered', 'flow', 'sequence', 'radial', 'matrix', 'explicit']),

--- a/xpertai/apps/excalidraw/src/lib/excalidraw-artifact-viewer.service.spec.ts
+++ b/xpertai/apps/excalidraw/src/lib/excalidraw-artifact-viewer.service.spec.ts
@@ -28,6 +28,8 @@ describe('ExcalidrawArtifactViewerService', () => {
     const documentHead = html.slice(0, html.indexOf('<script>window.__XPERT_EXCALIDRAW_ARTIFACT__='))
     expect(documentHead).not.toMatch(/<script\s+src=/i)
     expect(documentHead).not.toMatch(/<link\s+[^>]*href=/i)
+    expect(documentHead).toContain('font-src data: https:')
+    expect(documentHead).toContain("connect-src 'none'")
     const payloadScript = html.split('<script>window.__XPERT_EXCALIDRAW_ARTIFACT__=')[1]?.split('</script>')[0] ?? ''
     expect(payloadScript).not.toContain('collaborators')
   })

--- a/xpertai/apps/excalidraw/src/lib/excalidraw-artifact-viewer.service.ts
+++ b/xpertai/apps/excalidraw/src/lib/excalidraw-artifact-viewer.service.ts
@@ -210,7 +210,7 @@ function renderArtifactHtml(
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="referrer" content="no-referrer">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' blob:; style-src 'unsafe-inline'; img-src data: blob:; font-src data:; worker-src blob:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' blob:; style-src 'unsafe-inline'; img-src data: blob:; font-src data: https:; worker-src blob:; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'">
   <title>${title}</title>
   <style>${css}</style>
 </head>

--- a/xpertai/apps/pencil/scripts/prepack.mjs
+++ b/xpertai/apps/pencil/scripts/prepack.mjs
@@ -65,5 +65,6 @@ runNode(
 runNode(join(packageRoot, 'scripts', 'clean-dist.mjs'))
 runNode(join(packageRoot, 'scripts', 'build-remote-components.mjs'))
 runNode(requireFromPencil.resolve('typescript/bin/tsc'), ['-p', 'tsconfig.lib.json'])
+runNode(join(workspaceRoot, 'scripts', 'vendor-design-fonts.mjs'))
 runNode(join(packageRoot, 'scripts', 'copy-assets.mjs'))
 runNode(join(packageRoot, 'scripts', 'verify-package-output.mjs'))

--- a/xpertai/apps/pencil/scripts/prepack.mjs
+++ b/xpertai/apps/pencil/scripts/prepack.mjs
@@ -65,6 +65,6 @@ runNode(
 runNode(join(packageRoot, 'scripts', 'clean-dist.mjs'))
 runNode(join(packageRoot, 'scripts', 'build-remote-components.mjs'))
 runNode(requireFromPencil.resolve('typescript/bin/tsc'), ['-p', 'tsconfig.lib.json'])
-runNode(join(workspaceRoot, 'scripts', 'vendor-design-fonts.mjs'))
+runNode(join(packageRoot, '..', '..', 'scripts', 'vendor-design-fonts.mjs'))
 runNode(join(packageRoot, 'scripts', 'copy-assets.mjs'))
 runNode(join(packageRoot, 'scripts', 'verify-package-output.mjs'))

--- a/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.service.ts
+++ b/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
+import { buildOnlineFontFaceCss } from '@xpert-ai/design-fonts'
 import { createHash } from 'node:crypto'
 import { graphFromSnapshot } from './pencil-graph.js'
 import type { PencilGraphSnapshot } from './types.js'
@@ -45,6 +46,7 @@ export class PencilArtifactViewerService {
       title: normalizeText(input.title, 'Untitled Pencil design'),
       description: normalizeOptionalText(input.description),
       revision: normalizeRevision(input.revision),
+      fontCss: buildOnlineFontFaceCss(collectPublishedFontFamilies(pages)),
       pages
     })
     const buffer = Buffer.from(html, 'utf8')
@@ -104,6 +106,7 @@ function renderViewerHtml(input: {
   title: string
   description?: string
   revision: number
+  fontCss: string
   pages: Array<{ id: string; name: string; svg: string }>
 }) {
   const navigation = input.pages
@@ -115,10 +118,23 @@ function renderViewerHtml(input: {
   const empty = input.pages.length ? '' : '<div class="empty">This design has no pages.</div>'
   return `<!doctype html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>${escapeHtml(input.title)}</title><style>${VIEWER_CSS}</style></head>
+<title>${escapeHtml(input.title)}</title><style>${input.fontCss}${input.fontCss ? '\n' : ''}${VIEWER_CSS}</style></head>
 <body><header><div><h1>${escapeHtml(input.title)}</h1>${input.description ? `<p>${escapeHtml(input.description)}</p>` : ''}</div><span>Revision ${input.revision}</span></header>
 <main><aside aria-label="Pages">${navigation}</aside><div class="viewer"><div class="viewport">${pages}${empty}</div><div class="controls" aria-label="View controls"><button type="button" data-action="out" aria-label="Zoom out">−</button><button type="button" data-action="reset" aria-label="Reset zoom">100%</button><button type="button" data-action="fit" aria-label="Fit page">Fit</button><button type="button" data-action="in" aria-label="Zoom in">+</button><button type="button" data-action="fullscreen" aria-label="Enter fullscreen" title="Enter fullscreen">⛶</button></div></div></main>
 <script>${VIEWER_SCRIPT}</script></body></html>`
+}
+
+function collectPublishedFontFamilies(pages: Array<{ svg: string }>) {
+  const families = new Set<string>()
+  for (const page of pages) {
+    for (const match of page.svg.matchAll(/\bfont-family\s*=\s*["']([^"']+)["']/gi)) {
+      const family = match[1]?.trim()
+      if (family) {
+        families.add(family)
+      }
+    }
+  }
+  return [...families]
 }
 
 const VIEWER_CSS = `

--- a/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.spec.ts
+++ b/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common'
+import { renderNodesToSVG } from '@open\u002dpencil/core/io'
 
 jest.mock('@open\u002dpencil/core/io', () => ({
   renderNodesToSVG: jest.fn(() => '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"></svg>')
@@ -63,6 +64,22 @@ describe('PencilArtifactViewerService', () => {
     expect(html).not.toContain('Internal page')
     expect(html).not.toContain('https://example.com')
     expect(html).not.toContain('fetch(')
+  })
+
+  it('loads managed online fonts used by the published SVG', async () => {
+    jest.mocked(renderNodesToSVG).mockReturnValueOnce(
+      '<svg xmlns="http://www.w3.org/2000/svg"><text font-family="Caveat">Hello</text><text font-family="Unmanaged Font">World</text></svg>'
+    )
+    const result = await new PencilArtifactViewerService().render({
+      title: 'Handwritten design',
+      revision: 1,
+      graphSnapshot: createEmptyPencilGraphSnapshot()
+    })
+
+    const html = result.buffer.toString('utf8')
+    expect(html).toContain("font-family: 'Caveat'")
+    expect(html).toContain('https://cdn.jsdelivr.net/npm/@fontsource/caveat@5.2.8/files/caveat-latin-400-normal.woff2')
+    expect(html).not.toContain("font-family: 'Unmanaged Font'")
   })
 
   it.each([

--- a/xpertai/packages/design-fonts/src/index.ts
+++ b/xpertai/packages/design-fonts/src/index.ts
@@ -135,11 +135,11 @@ const EXCALIDRAW_FONT_FAMILY_IDS: Readonly<Record<NonNullable<TypographyPreset['
   Virgil: 1,
   Helvetica: 2,
   Cascadia: 3,
-  Excalifont: 4,
-  Nunito: 5,
-  'Lilita One': 6,
-  'Comic Shanns': 7,
-  'Liberation Sans': 8
+  Excalifont: 5,
+  Nunito: 6,
+  'Lilita One': 7,
+  'Comic Shanns': 8,
+  'Liberation Sans': 9
 }
 
 function preset(


### PR DESCRIPTION
## Summary

Published Excalidraw artifacts could select managed typography presets whose font family IDs no longer matched Excalidraw 0.18. The artifact viewer also restricted `font-src` to embedded data, preventing Excalidraw's official HTTPS font assets from loading.

This change aligns the shared typography catalog and diagram schema with the registered Excalidraw font IDs, and allows HTTPS font resources while keeping network connections, frames, objects, and form actions blocked.

## Changes

- Correct Excalidraw managed font family IDs in the shared design-font catalog.
- Accept only registered Excalidraw font IDs and reject the unused ID 4.
- Permit HTTPS font assets in the artifact viewer CSP.
- Add focused regression coverage for preset IDs, schema validation, and CSP behavior.
- Add a patch changeset for `@xpert-ai/plugin-excalidraw`.

## Validation

- `tsc -p packages/design-fonts/tsconfig.lib.json --noEmit`
- Focused Jest suites: 2 passed, 21 tests passed.
- `tsc -p apps/excalidraw/tsconfig.spec.json --noEmit`
- `git diff --check`

The validation used the existing local binaries because Corepack could not download the newly required pnpm version due to the local certificate chain (`UNABLE_TO_GET_ISSUER_CERT_LOCALLY`).
