### PR TITLE
[codex] Support custom Tongyi API host

### DIFF
--- a/xpertai/.changeset/tongyi-custom-api-host.md
+++ b/xpertai/.changeset/tongyi-custom-api-host.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-tongyi": patch
+---
+
+Support an optional custom API host for workspace-specific Tongyi endpoints.

--- a/xpertai/models/tongyi/src/tongyi.yaml
+++ b/xpertai/models/tongyi/src/tongyi.yaml
@@ -35,6 +35,15 @@ provider_credential_schema:
       placeholder:
         zh_Hans: 在此输入您的 API Key
         en_US: Enter your API Key
+    - variable: api_host
+      label:
+        zh_Hans: API Host
+        en_US: API Host
+      type: text-input
+      required: false
+      placeholder:
+        zh_Hans: 例如 llm-...cn-beijing.maas.aliyuncs.com
+        en_US: e.g. llm-...cn-beijing.maas.aliyuncs.com
     - variable: use_international_endpoint
       label:
         zh_Hans: 使用国际端点
@@ -68,6 +77,15 @@ model_credential_schema:
       placeholder:
         zh_Hans: 在此输入您的 API Key
         en_US: Enter your API Key
+    - variable: api_host
+      label:
+        zh_Hans: API Host
+        en_US: API Host
+      type: text-input
+      required: false
+      placeholder:
+        zh_Hans: 例如 llm-...cn-beijing.maas.aliyuncs.com
+        en_US: e.g. llm-...cn-beijing.maas.aliyuncs.com
     - variable: use_international_endpoint
       label:
         zh_Hans: 使用国际端点

--- a/xpertai/models/tongyi/src/types.spec.ts
+++ b/xpertai/models/tongyi/src/types.spec.ts
@@ -21,4 +21,31 @@ describe('Tongyi endpoint helpers', () => {
     expect(toCredentialKwargs(credentials).configuration.baseURL).toBe(TongyiIntlBaseUrl)
     expect(getTongyiHttpBaseUrl(credentials)).toBe(TongyiIntlHttpBaseUrl)
   })
+
+  it('uses an optional workspace API host for compatible and DashScope endpoints', () => {
+    const credentials = {
+      dashscope_api_key: 'test-key',
+      api_host: 'llm-wnsb9rvvimieg6nx.cn-beijing.maas.aliyuncs.com',
+      use_international_endpoint: 'true'
+    }
+
+    expect(toCredentialKwargs(credentials).configuration.baseURL).toBe(
+      'https://llm-wnsb9rvvimieg6nx.cn-beijing.maas.aliyuncs.com/compatible-mode/v1'
+    )
+    expect(getTongyiHttpBaseUrl(credentials)).toBe(
+      'https://llm-wnsb9rvvimieg6nx.cn-beijing.maas.aliyuncs.com/api/v1'
+    )
+  })
+
+  it('preserves the protocol and removes trailing slashes from a configured API host', () => {
+    const credentials = {
+      dashscope_api_key: 'test-key',
+      api_host: 'http://localhost:8080///'
+    }
+
+    expect(toCredentialKwargs(credentials).configuration.baseURL).toBe(
+      'http://localhost:8080/compatible-mode/v1'
+    )
+    expect(getTongyiHttpBaseUrl(credentials)).toBe('http://localhost:8080/api/v1')
+  })
 })

--- a/xpertai/models/tongyi/src/types.ts
+++ b/xpertai/models/tongyi/src/types.ts
@@ -16,6 +16,7 @@ export const SvgIcon = readFileSync(join(moduleDir, '_assets/icon_s_en.svg'), 'u
 
 export interface TongyiCredentials {
     dashscope_api_key: string
+    api_host?: string
     use_international_endpoint?: boolean | string
 }
 
@@ -42,11 +43,30 @@ export function isTongyiInternationalEndpointEnabled(credentials?: Partial<Tongy
     return value === true || value === 'true'
 }
 
+export function normalizeTongyiApiHost(apiHost?: string): string | undefined {
+    const normalizedHost = apiHost?.trim().replace(/\/+$/, '')
+    if (!normalizedHost) {
+        return undefined
+    }
+
+    return /^https?:\/\//i.test(normalizedHost) ? normalizedHost : `https://${normalizedHost}`
+}
+
 export function getTongyiCompatibleBaseUrl(credentials: TongyiCredentials): string {
+    const apiHost = normalizeTongyiApiHost(credentials.api_host)
+    if (apiHost) {
+        return joinTongyiApiUrl(apiHost, '/compatible-mode/v1')
+    }
+
     return isTongyiInternationalEndpointEnabled(credentials) ? TongyiIntlBaseUrl : TongyiDefaultBaseUrl
 }
 
 export function getTongyiHttpBaseUrl(credentials: TongyiCredentials): string {
+    const apiHost = normalizeTongyiApiHost(credentials.api_host)
+    if (apiHost) {
+        return joinTongyiApiUrl(apiHost, '/api/v1')
+    }
+
     return isTongyiInternationalEndpointEnabled(credentials) ? TongyiIntlHttpBaseUrl : TongyiDefaultHttpBaseUrl
 }
 


### PR DESCRIPTION
## Summary

Tongyi currently selects only the built-in domestic or international DashScope endpoints. Workspace-specific Alibaba Cloud Model Studio deployments use tenant subdomains, so those endpoints cannot be configured through the Tongyi provider.

This change adds an optional `API Host` credential field for both provider-level and model-level configuration. When supplied, the plugin normalizes the host and uses its OpenAI-compatible and DashScope HTTP paths. When omitted, the existing domestic and international endpoint behavior is unchanged.

## Changes

- add optional `api_host` to Tongyi credentials and configuration schemas
- support bare hosts as well as explicit HTTP/HTTPS URLs
- strip trailing slashes before appending endpoint paths
- add regression coverage for custom hosts and existing endpoint selection
- add a patch changeset

## Validation

- Tongyi Jest suites: 4 passed, 18 tests passed
- `nx build @xpert-ai/plugin-tongyi --skip-nx-cache`
- Tongyi plugin lifecycle test through `plugin-dev-harness`
- `git diff --check`
