### PR TITLE
[codex] improve DingTalk file and streaming support

### DIFF
--- a/xpertai/integrations/dingtalk/README.md
+++ b/xpertai/integrations/dingtalk/README.md
@@ -9,8 +9,9 @@ DingTalk integration plugin for Xpert AI platform.
 - Optional HTTP Mode provider for HTTP callback event handling (messages, mentions, card actions)
 - HTTP callback signature verification + AES decrypt
 - Encrypted callback ACK response (`msg_signature + encrypt + timeStamp + nonce`)
-- Inbound image receiving and ordinary file receiving in human-to-bot conversations; ordinary files are stored in the Xpert workspace. DingTalk does not deliver group @-mention or person-to-person file messages to bots.
-- Outbound text/markdown/interactive card/workspace file message sending. The middleware takes its integration and recipient directly from the trusted DingTalk trigger, so no integration or recipient selector is shown. Legacy stored notification targets remain runtime-compatible. Workspace files are limited to 10 MiB and the DingTalk-supported `xlsx`, `pdf`, `zip`, `rar`, `doc`, and `docx` formats.
+- Inbound image receiving and ordinary file receiving in human-to-bot conversations; ordinary files are stored in the Xpert workspace. Quoted file replies are also resolved from DingTalk's `repliedMsg` metadata. DingTalk does not deliver file events from group @-mentions or person-to-person chats to bots.
+- Configurable inbound summary window for merging separate file and text events that DingTalk actually delivers to the bot.
+- Outbound text/markdown/interactive card/workspace media sending. The middleware takes its integration and recipient directly from the trusted DingTalk trigger, so no integration or recipient selector is shown. Legacy stored notification targets remain runtime-compatible. Workspace media is limited to 10 MiB. Images (`jpg`, `jpeg`, `png`, `gif`, `webp`) use DingTalk image messages; documents and archives (`xlsx`, `pdf`, `zip`, `rar`, `doc`, `docx`) use DingTalk file messages.
 - Message update/recall with degrade fallback (`degraded=true`)
 - Anonymous conversation key strategy:
   - `integrationId + conversationId + senderId`

--- a/xpertai/integrations/dingtalk/package.json
+++ b/xpertai/integrations/dingtalk/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "zod": "3.25.67",
     "@xpert-ai/chatkit-types": "^0.0.12",
-    "@xpert-ai/plugin-sdk": "^3.13.0",
+    "@xpert-ai/plugin-sdk": "^3.15.2",
     "i18next": "25.6.0",
     "@xpert-ai/contracts": "^3.13.0",
     "@nestjs/common": "^11.1.6",

--- a/xpertai/integrations/dingtalk/src/lib/conversation.service.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/conversation.service.spec.ts
@@ -244,6 +244,45 @@ describe('DingTalkConversationService', () => {
 	    expect(first.getUserQueueName('integration-1:user-1')).not.toBe(second.getUserQueueName('integration-1:user-1'))
 	  })
 
+  it('does not retry the whole inbound queue job after file side effects may have run', async () => {
+    const { service } = createService()
+    const queue = {
+      add: jest.fn().mockResolvedValue(undefined)
+    }
+    jest.spyOn(service, 'getUserQueue').mockResolvedValue(queue as never)
+
+    await service.handleMessage(
+      {
+        chatId: 'chat-1',
+        chatType: 'private',
+        senderId: 'sender-open-id',
+        content: 'hello',
+        raw: {
+          msgType: 'text'
+        }
+      } as never,
+      {
+        tenantId: 'tenant-1',
+        organizationId: 'org-1',
+        integration: {
+          id: 'integration-1',
+          createdById: '11111111-1111-4111-8111-111111111111',
+          options: {}
+        }
+      } as never
+    )
+
+    expect(queue.add).toHaveBeenCalledTimes(1)
+    expect(queue.add.mock.calls[0]).toHaveLength(1)
+    expect(queue.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationId: 'integration-1',
+        input: 'hello',
+        senderOpenId: 'sender-open-id'
+      })
+    )
+  })
+
 	  it('forwards inbound image messages as vision files', async () => {
 	    const { service, commandBus, conversationBindingRepository, dingtalkClient, dingtalkChannel, triggerBindingRepository, triggerStrategy } =
 	      createService()
@@ -381,6 +420,88 @@ describe('DingTalkConversationService', () => {
     )
     const dispatchedFile = (commandBus.execute.mock.calls[0][0] as any).input.files[0]
     expect(dispatchedFile.fileUrl).not.toMatch(/^data:/)
+  })
+
+  it('stores files embedded in DingTalk quoted-message metadata before dispatch', async () => {
+    const {
+      service,
+      commandBus,
+      conversationBindingRepository,
+      dingtalkClient,
+      triggerBindingRepository,
+      triggerStrategy,
+      workspaceFiles
+    } = createService()
+    dingtalkClient.downloadMessageFile.mockResolvedValueOnce({
+      buffer: Buffer.from('%PDF-quoted-report'),
+      mimeType: 'application/pdf',
+      fileName: 'quoted-report.pdf'
+    })
+    workspaceFiles.understandFile.mockResolvedValueOnce({
+      fileAssetId: 'quoted-file-asset-1',
+      fileId: 'quoted-file-1',
+      filePath: 'files/dingtalk/integration-1/hash/quoted-report.pdf',
+      workspacePath: '/workspace/files/dingtalk/integration-1/hash/quoted-report.pdf',
+      fileUrl: 'workspace://files/dingtalk/integration-1/hash/quoted-report.pdf',
+      originalName: 'quoted-report.pdf',
+      mimeType: 'application/pdf',
+      size: 18
+    })
+    triggerBindingRepository.findOne.mockResolvedValueOnce({ xpertId: 'xpert-1' })
+    conversationBindingRepository.findOne.mockResolvedValueOnce({
+      conversationUserKey: 'integration-1:chat-1:sender-open-id',
+      xpertId: 'xpert-1',
+      conversationId: 'conversation-1',
+      updatedAt: new Date()
+    })
+    triggerStrategy.handleInboundMessage.mockResolvedValueOnce(false)
+
+    await service.processMessage({
+      integrationId: 'integration-1',
+      senderOpenId: 'sender-open-id',
+      chatId: 'chat-1',
+      userId: 'user-1',
+      message: {
+        eventId: 'msg-reply-1',
+        conversationId: 'chat-1',
+        senderId: 'sender-open-id',
+        msgType: 'text',
+        robotCode: 'robot-code-1',
+        originalMsgId: 'msg-file-1',
+        text: {
+          content: '看一下文件内容',
+          isReplyMsg: true,
+          repliedMsg: {
+            msgType: 'file',
+            content: JSON.stringify({
+              downloadCode: 'download-code-quoted-file-1',
+              fileName: 'quoted-report.pdf'
+            })
+          }
+        }
+      }
+    } as any)
+
+    expect(dingtalkClient.downloadMessageFile).toHaveBeenCalledWith({
+      downloadCode: 'download-code-quoted-file-1',
+      robotCode: 'robot-code-1'
+    })
+    expect(commandBus.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({
+          xpertId: 'xpert-1',
+          input: '看一下文件内容',
+          files: [
+            expect.objectContaining({
+              fileAssetId: 'quoted-file-asset-1',
+              fileId: 'quoted-file-1',
+              originalName: 'quoted-report.pdf',
+              mimeType: 'application/pdf'
+            })
+          ]
+        })
+      })
+    )
   })
 
   it('forwards DingTalk picture messages as vision files', async () => {

--- a/xpertai/integrations/dingtalk/src/lib/conversation.service.ts
+++ b/xpertai/integrations/dingtalk/src/lib/conversation.service.ts
@@ -920,6 +920,11 @@ export class DingTalkConversationService implements OnModuleDestroy {
       return message.text.trim()
     }
 
+    const messageText = this.extractContentText(message.text)
+    if (messageText) {
+      return messageText
+    }
+
     const contentText = this.extractContentText(message.content)
     if (contentText) {
       return contentText
@@ -1125,8 +1130,15 @@ export class DingTalkConversationService implements OnModuleDestroy {
     const content = this.normalizeRecord(payload.content) ?? this.safeJsonRecord(payload.content)
     const nestedMessage = this.normalizeRecord(payload.message)
     const nestedContent = this.normalizeRecord(nestedMessage?.content) ?? this.safeJsonRecord(nestedMessage?.content)
+    const textContent = this.normalizeRecord(payload.text) ?? this.safeJsonRecord(payload.text)
+    const repliedMessageValue = textContent?.repliedMsg ?? content?.repliedMsg ?? nestedContent?.repliedMsg
+    const repliedMessage = this.normalizeRecord(repliedMessageValue) ?? this.safeJsonRecord(repliedMessageValue)
+    const repliedContent =
+      this.normalizeRecord(repliedMessage?.content) ?? this.safeJsonRecord(repliedMessage?.content)
     const refs: DingTalkInboundFileRef[] = []
-    const baseRecords = [payload, content, nestedContent].filter((item): item is Record<string, unknown> => Boolean(item))
+    const baseRecords = [payload, content, nestedContent, textContent, repliedMessage, repliedContent].filter(
+      (item): item is Record<string, unknown> => Boolean(item)
+    )
 
     if (msgType === 'image' || msgType === 'picture') {
       const image =
@@ -1154,21 +1166,48 @@ export class DingTalkConversationService implements OnModuleDestroy {
       }
     }
 
+    const repliedMsgType = this.resolveDingTalkMessageType(repliedMessage)
+    if (repliedMsgType === 'image' || repliedMsgType === 'picture') {
+      const ref = this.extractInboundFileRef(
+        'image',
+        [repliedContent, repliedMessage, textContent, payload],
+        baseRecords
+      )
+      if (ref) {
+        refs.push(ref)
+      }
+    }
+    if (repliedMsgType === 'file') {
+      const ref = this.extractInboundFileRef(
+        'file',
+        [repliedContent, repliedMessage, textContent, payload],
+        baseRecords
+      )
+      if (ref) {
+        refs.push(ref)
+      }
+    }
+
     const richTextItems = [
       ...(Array.isArray(payload.richText) ? payload.richText : []),
       ...(Array.isArray(content?.richText) ? content.richText : []),
-      ...(Array.isArray(nestedContent?.richText) ? nestedContent.richText : [])
+      ...(Array.isArray(nestedContent?.richText) ? nestedContent.richText : []),
+      ...(Array.isArray(repliedContent?.richText) ? repliedContent.richText : [])
     ]
     for (const rawItem of richTextItems) {
       const item = this.normalizeRecord(rawItem)
       const itemType = this.resolveDingTalkMessageType(item, true)
-      if (itemType !== 'image' && itemType !== 'picture') {
+      if (itemType !== 'image' && itemType !== 'picture' && itemType !== 'file') {
         continue
       }
 
       const image = this.normalizeRecord(item?.image)
       const file = this.normalizeRecord(item?.file)
-      const ref = this.extractInboundFileRef('image', [item, image, file, content, nestedContent, payload], baseRecords)
+      const ref = this.extractInboundFileRef(
+        itemType === 'file' ? 'file' : 'image',
+        [item, image, file, repliedContent, content, nestedContent, payload],
+        baseRecords
+      )
       if (ref) {
         refs.push(ref)
       }

--- a/xpertai/integrations/dingtalk/src/lib/dingtalk-channel.strategy.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/dingtalk-channel.strategy.spec.ts
@@ -42,6 +42,7 @@ describe('DingTalkChannelStrategy', () => {
         buffer: content,
         fileName: 'report.pdf',
         fileType: 'pdf',
+        mediaType: 'file',
         mimeType: 'application/pdf'
       })
     )
@@ -84,7 +85,49 @@ describe('DingTalkChannelStrategy', () => {
     )
   })
 
-  it.each(['image', 'audio', 'video'] as const)('rejects unsupported %s media without uploading', async (type) => {
+  it('uploads and sends image content through the DingTalk sampleImageMsg template', async () => {
+    const { strategy, client } = createFixture()
+    const content = Buffer.from('png bytes')
+
+    await expect(
+      strategy.sendMedia(
+        {
+          integration: { id: 'integration-1' },
+          chatId: 'chat-1'
+        } as any,
+        {
+          type: 'image',
+          content,
+          filename: 'chart.png'
+        }
+      )
+    ).resolves.toEqual({ success: true, messageId: 'message-1' })
+
+    expect(strategy.uploadFile).toHaveBeenCalledWith(
+      'integration-1',
+      expect.objectContaining({
+        buffer: content,
+        fileName: 'chart.png',
+        fileType: 'png',
+        mediaType: 'image',
+        mimeType: 'image/png'
+      })
+    )
+    expect(client.sendMessage).toHaveBeenCalledWith({
+      recipient: { type: 'chat_id', id: 'chat-1' },
+      robotCodeOverride: undefined,
+      msgType: 'interactive',
+      content: {
+        msgKey: 'sampleImageMsg',
+        msgParam: {
+          photoURL: 'media-1'
+        }
+      },
+      allowFallback: false
+    })
+  })
+
+  it.each(['audio', 'video'] as const)('rejects unsupported %s media without uploading', async (type) => {
     const { strategy, client } = createFixture()
 
     await expect(
@@ -101,7 +144,7 @@ describe('DingTalkChannelStrategy', () => {
       )
     ).resolves.toEqual({
       success: false,
-      error: 'DingTalk sendMedia currently supports file content only'
+      error: 'DingTalk sendMedia supports image or file content only'
     })
 
     expect(strategy.uploadFile).not.toHaveBeenCalled()

--- a/xpertai/integrations/dingtalk/src/lib/dingtalk-channel.strategy.ts
+++ b/xpertai/integrations/dingtalk/src/lib/dingtalk-channel.strategy.ts
@@ -29,7 +29,12 @@ import {
   TIntegrationDingTalkOptions
 } from './types.js'
 import { DingTalkClient } from './dingtalk.client.js'
-import { resolveDingTalkSendFileFromBuffer, type DingTalkResolvedSendFile } from './dingtalk-send-file.js'
+import {
+  buildDingTalkSendMediaContent,
+  resolveDingTalkSendFileFromBuffer,
+  resolveDingTalkSendImageFromBuffer,
+  type DingTalkResolvedSendFile
+} from './dingtalk-send-file.js'
 
 type DingTalkRecipient = {
   type: 'chat_id' | 'open_id' | 'user_id' | 'union_id' | 'email'
@@ -617,14 +622,16 @@ export class DingTalkChannelStrategy implements IChatChannel<TIntegrationDingTal
     }
   ): Promise<TChatSendResult> {
     try {
-      if (media.type !== 'file' || !media.content) {
+      if ((media.type !== 'file' && media.type !== 'image') || !media.content) {
         return {
           success: false,
-          error: 'DingTalk sendMedia currently supports file content only'
+          error: 'DingTalk sendMedia supports image or file content only'
         }
       }
 
-      const file = resolveDingTalkSendFileFromBuffer(media.content, {
+      const resolveMedia =
+        media.type === 'image' ? resolveDingTalkSendImageFromBuffer : resolveDingTalkSendFileFromBuffer
+      const file = resolveMedia(media.content, {
         descriptor: {
           originalName: media.filename || 'file'
         }
@@ -635,14 +642,7 @@ export class DingTalkChannelStrategy implements IChatChannel<TIntegrationDingTal
         recipient: this.resolveRecipient(ctx),
         robotCodeOverride: this.resolveRobotCode(ctx) || undefined,
         msgType: 'interactive',
-        content: {
-          msgKey: 'sampleFile',
-          msgParam: {
-            mediaId: uploaded.mediaId,
-            fileName: file.fileName,
-            fileType: file.fileType
-          }
-        },
+        content: buildDingTalkSendMediaContent(file, uploaded.mediaId),
         allowFallback: false
       })
 
@@ -651,10 +651,10 @@ export class DingTalkChannelStrategy implements IChatChannel<TIntegrationDingTal
         messageId: result.messageId || undefined
       }
     } catch (error: any) {
-      this.logger.error('Failed to send DingTalk file message', error)
+      this.logger.error('Failed to send DingTalk media message', error)
       return {
         success: false,
-        error: error?.message || 'Failed to send file message'
+        error: error?.message || 'Failed to send media message'
       }
     }
   }
@@ -665,6 +665,7 @@ export class DingTalkChannelStrategy implements IChatChannel<TIntegrationDingTal
       buffer: file.buffer,
       fileName: file.fileName,
       mimeType: file.mimeType,
+      mediaType: file.mediaType,
       timeoutMs
     })
   }

--- a/xpertai/integrations/dingtalk/src/lib/dingtalk-send-file.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/dingtalk-send-file.spec.ts
@@ -5,8 +5,11 @@ jest.mock('@xpert-ai/plugin-sdk', () => ({
 import { createHash } from 'node:crypto'
 import { WORKSPACE_FILES_SOURCE } from '@xpert-ai/plugin-sdk'
 import {
+  buildDingTalkSendMediaContent,
   resolveDingTalkSendFileFromBuffer,
   resolveDingTalkSendFileFromWorkspace,
+  resolveDingTalkSendImageFromBuffer,
+  resolveDingTalkSendMediaFromWorkspace,
   sanitizeDingTalkFileName,
   toDingTalkSendFileMetadata
 } from './dingtalk-send-file.js'
@@ -49,6 +52,7 @@ describe('dingtalk-send-file', () => {
         buffer,
         fileName: 'report.pdf',
         fileType: 'pdf',
+        mediaType: 'file',
         mimeType: 'application/pdf',
         size: buffer.length
       })
@@ -70,11 +74,71 @@ describe('dingtalk-send-file', () => {
     expect(toDingTalkSendFileMetadata(file)).toEqual({
       fileName: 'report.pdf',
       fileType: 'pdf',
+      mediaType: 'file',
       mimeType: 'application/pdf',
       size: buffer.length,
       sha256: file.sha256
     })
     expect(toDingTalkSendFileMetadata(file)).not.toHaveProperty('buffer')
+  })
+
+  it.each([
+    ['jpg', 'image/jpeg'],
+    ['jpeg', 'image/jpeg'],
+    ['png', 'image/png'],
+    ['gif', 'image/gif'],
+    ['webp', 'image/webp']
+  ])('routes .%s through the DingTalk image message channel', (extension, mimeType) => {
+    const image = resolveDingTalkSendImageFromBuffer(Buffer.from('image bytes'), {
+      descriptor: { path: `files/image.${extension}` }
+    })
+
+    expect(image).toEqual(
+      expect.objectContaining({
+        fileName: `image.${extension}`,
+        fileType: extension,
+        mediaType: 'image',
+        mimeType
+      })
+    )
+    expect(buildDingTalkSendMediaContent(image, 'media-image-1')).toEqual({
+      msgKey: 'sampleImageMsg',
+      msgParam: {
+        photoURL: 'media-image-1'
+      }
+    })
+  })
+
+  it('routes workspace images through media resolution while keeping file resolution file-only', async () => {
+    const buffer = Buffer.from('workspace image')
+    const workspaceFiles = {
+      readRuntimeBuffer: jest.fn().mockResolvedValue({
+        name: 'chart.png',
+        filePath: 'files/chart.png',
+        workspacePath: '/workspace/files/chart.png',
+        mimeType: 'image/png',
+        size: buffer.length,
+        buffer
+      })
+    }
+
+    await expect(
+      resolveDingTalkSendMediaFromWorkspace(
+        { path: 'files/chart.png' },
+        { workspaceFiles: workspaceFiles as any }
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        mediaType: 'image',
+        fileType: 'png'
+      })
+    )
+    await expect(
+      resolveDingTalkSendFileFromWorkspace(
+        { path: 'files/chart.png' },
+        { workspaceFiles: workspaceFiles as any }
+      )
+    ).rejects.toThrow('DingTalk file send supports only')
   })
 
   it.each([

--- a/xpertai/integrations/dingtalk/src/lib/dingtalk-send-file.ts
+++ b/xpertai/integrations/dingtalk/src/lib/dingtalk-send-file.ts
@@ -4,8 +4,12 @@ import { WORKSPACE_FILES_SOURCE, type WorkspaceFileLocator, type WorkspaceFilesA
 import { DINGTALK_MAX_FILE_BYTES } from './types.js'
 
 export const DINGTALK_SUPPORTED_FILE_TYPES = ['xlsx', 'pdf', 'zip', 'rar', 'doc', 'docx'] as const
+export const DINGTALK_SUPPORTED_IMAGE_TYPES = ['gif', 'jpeg', 'jpg', 'png', 'webp'] as const
 
 const DINGTALK_SUPPORTED_FILE_TYPE_SET = new Set<string>(DINGTALK_SUPPORTED_FILE_TYPES)
+const DINGTALK_SUPPORTED_IMAGE_TYPE_SET = new Set<string>(DINGTALK_SUPPORTED_IMAGE_TYPES)
+
+export type DingTalkSendMediaType = 'file' | 'image'
 
 export type DingTalkSendFileReference = {
   source?: string | null
@@ -34,6 +38,7 @@ export type DingTalkResolvedSendFile = {
   buffer: Buffer
   fileName: string
   fileType: string
+  mediaType: DingTalkSendMediaType
   mimeType: string
   size: number
   sha256: string
@@ -60,6 +65,7 @@ const MIME_BY_EXTENSION: Record<string, string> = {
   txt: 'text/plain',
   xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  webp: 'image/webp',
   zip: 'application/zip'
 }
 
@@ -70,15 +76,36 @@ export async function resolveDingTalkSendFileFromWorkspace(
     maxBytes?: number
   }
 ): Promise<DingTalkResolvedSendFile> {
+  return resolveDingTalkSendMediaFromWorkspaceInternal(descriptor, options, 'file')
+}
+
+export async function resolveDingTalkSendMediaFromWorkspace(
+  descriptor: DingTalkSendFileDescriptor,
+  options: {
+    workspaceFiles: Pick<WorkspaceFilesApi, 'readRuntimeBuffer'>
+    maxBytes?: number
+  }
+): Promise<DingTalkResolvedSendFile> {
+  return resolveDingTalkSendMediaFromWorkspaceInternal(descriptor, options)
+}
+
+async function resolveDingTalkSendMediaFromWorkspaceInternal(
+  descriptor: DingTalkSendFileDescriptor,
+  options: {
+    workspaceFiles: Pick<WorkspaceFilesApi, 'readRuntimeBuffer'>
+    maxBytes?: number
+  },
+  expectedMediaType?: DingTalkSendMediaType
+): Promise<DingTalkResolvedSendFile> {
   const locator = toWorkspaceFileLocator(descriptor)
   const file = await options.workspaceFiles.readRuntimeBuffer(locator)
-  return resolveDingTalkSendFileFromBuffer(file.buffer, {
+  return resolveDingTalkSendMediaFromBufferInternal(file.buffer, {
     descriptor,
     fallbackName: file.name,
     fallbackMimeType: file.mimeType,
     fallbackPath: file.workspacePath || file.filePath,
     maxBytes: options.maxBytes
-  })
+  }, expectedMediaType)
 }
 
 export function resolveDingTalkSendFileFromBuffer(
@@ -90,6 +117,33 @@ export function resolveDingTalkSendFileFromBuffer(
     fallbackPath?: string | null
     maxBytes?: number
   }
+): DingTalkResolvedSendFile {
+  return resolveDingTalkSendMediaFromBufferInternal(buffer, options, 'file')
+}
+
+export function resolveDingTalkSendImageFromBuffer(
+  buffer: Buffer,
+  options: {
+    descriptor: DingTalkSendFileDescriptor
+    fallbackName?: string | null
+    fallbackMimeType?: string | null
+    fallbackPath?: string | null
+    maxBytes?: number
+  }
+): DingTalkResolvedSendFile {
+  return resolveDingTalkSendMediaFromBufferInternal(buffer, options, 'image')
+}
+
+function resolveDingTalkSendMediaFromBufferInternal(
+  buffer: Buffer,
+  options: {
+    descriptor: DingTalkSendFileDescriptor
+    fallbackName?: string | null
+    fallbackMimeType?: string | null
+    fallbackPath?: string | null
+    maxBytes?: number
+  },
+  expectedMediaType?: DingTalkSendMediaType
 ): DingTalkResolvedSendFile {
   const maxBytes = options.maxBytes ?? DINGTALK_MAX_FILE_BYTES
   if (!buffer.length) {
@@ -106,10 +160,18 @@ export function resolveDingTalkSendFileFromBuffer(
     options.fallbackName || basenamePortable(fallbackPath) || 'file'
   )
   const extension = resolveFileExtension(fileName, fallbackPath, descriptor.extension)
-  if (!extension || !DINGTALK_SUPPORTED_FILE_TYPE_SET.has(extension)) {
+  const mediaType = resolveDingTalkSendMediaType(extension)
+  if (!mediaType || (expectedMediaType && mediaType !== expectedMediaType)) {
     const received = extension ? `.${extension}` : 'a file without an extension'
+    const supportedTypes =
+      expectedMediaType === 'file'
+        ? DINGTALK_SUPPORTED_FILE_TYPES
+        : expectedMediaType === 'image'
+          ? DINGTALK_SUPPORTED_IMAGE_TYPES
+          : [...DINGTALK_SUPPORTED_FILE_TYPES, ...DINGTALK_SUPPORTED_IMAGE_TYPES]
+    const sendType = expectedMediaType || 'media'
     throw new Error(
-      `DingTalk file send supports only ${DINGTALK_SUPPORTED_FILE_TYPES.map((type) => `.${type}`).join(', ')} files; received ${received}.`
+      `DingTalk ${sendType} send supports only ${supportedTypes.map((type) => `.${type}`).join(', ')} files; received ${received}.`
     )
   }
   const mimeType = resolveDingTalkFileMimeType(
@@ -121,6 +183,7 @@ export function resolveDingTalkSendFileFromBuffer(
     buffer,
     fileName,
     fileType: extension,
+    mediaType,
     mimeType,
     size: buffer.length,
     sha256: createHash('sha256').update(buffer).digest('hex')
@@ -131,9 +194,30 @@ export function toDingTalkSendFileMetadata(file: DingTalkResolvedSendFile): Ding
   return {
     fileName: file.fileName,
     fileType: file.fileType,
+    mediaType: file.mediaType,
     mimeType: file.mimeType,
     size: file.size,
     sha256: file.sha256
+  }
+}
+
+export function buildDingTalkSendMediaContent(file: DingTalkResolvedSendFile, mediaId: string) {
+  if (file.mediaType === 'image') {
+    return {
+      msgKey: 'sampleImageMsg',
+      msgParam: {
+        photoURL: mediaId
+      }
+    }
+  }
+
+  return {
+    msgKey: 'sampleFile',
+    msgParam: {
+      mediaId,
+      fileName: file.fileName,
+      fileType: file.fileType
+    }
   }
 }
 
@@ -240,6 +324,16 @@ function resolveFileExtension(fileName: string, fallbackPath: string, explicit?:
 
 function normalizeExtension(value?: string | null): string {
   return normalizeString(value).replace(/^\./, '').toLowerCase()
+}
+
+function resolveDingTalkSendMediaType(extension?: string): DingTalkSendMediaType | undefined {
+  if (extension && DINGTALK_SUPPORTED_FILE_TYPE_SET.has(extension)) {
+    return 'file'
+  }
+  if (extension && DINGTALK_SUPPORTED_IMAGE_TYPE_SET.has(extension)) {
+    return 'image'
+  }
+  return undefined
 }
 
 function basenamePortable(value?: string | null): string {

--- a/xpertai/integrations/dingtalk/src/lib/dingtalk.client.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/dingtalk.client.spec.ts
@@ -140,4 +140,55 @@ describe('DingTalkClient', () => {
     expect(media.type).toBe('application/pdf')
     expect(media.size).toBe(Buffer.byteLength('report bytes'))
   })
+
+  it('uploads images with the DingTalk image media type', async () => {
+    const http = {
+      get: jest.fn().mockResolvedValue({
+        data: {
+          errcode: 0,
+          access_token: 'legacy-access-token'
+        }
+      }),
+      post: jest.fn().mockResolvedValue({
+        data: {
+          errcode: 0,
+          media_id: 'media-image-1',
+          type: 'image',
+          created_at: 123
+        }
+      })
+    }
+    mockedAxios.create.mockReturnValue(http as any)
+
+    const client = new DingTalkClient({
+      id: 'integration-1',
+      provider: 'dingtalk',
+      options: {
+        clientId: 'app-key',
+        clientSecret: 'app-secret',
+        robotCode: 'robot-code-1'
+      }
+    } as any)
+
+    await expect(
+      client.uploadMediaFile({
+        buffer: Buffer.from('image bytes'),
+        fileName: 'chart.png',
+        mimeType: 'image/png',
+        mediaType: 'image'
+      })
+    ).resolves.toEqual({
+      mediaId: 'media-image-1',
+      type: 'image',
+      createdAt: 123
+    })
+    expect(http.post).toHaveBeenCalledWith('https://oapi.dingtalk.com/media/upload', expect.any(FormData), {
+      params: {
+        access_token: 'legacy-access-token',
+        type: 'image'
+      },
+      timeout: 15_000,
+      maxBodyLength: Infinity
+    })
+  })
 })

--- a/xpertai/integrations/dingtalk/src/lib/dingtalk.client.ts
+++ b/xpertai/integrations/dingtalk/src/lib/dingtalk.client.ts
@@ -310,6 +310,7 @@ export class DingTalkClient {
     buffer: Buffer
     fileName: string
     mimeType?: string | null
+    mediaType?: 'file' | 'image'
     timeoutMs?: number
   }): Promise<DingTalkUploadedMedia> {
     if (!input.buffer.length) {
@@ -342,7 +343,7 @@ export class DingTalkClient {
     }>(`${this.legacyApiBaseUrl}/media/upload`, form, {
       params: {
         access_token: token,
-        type: 'file'
+        type: input.mediaType || 'file'
       },
       timeout: input.timeoutMs || 15_000,
       maxBodyLength: Infinity

--- a/xpertai/integrations/dingtalk/src/lib/handoff/commands/dispatch-dingtalk-chat.command.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/commands/dispatch-dingtalk-chat.command.ts
@@ -3,6 +3,7 @@ import type { DingTalkInboundFile } from '../../types.js'
 
 export type DispatchDingTalkChatPayload = {
 	xpertId: string
+	dispatchMessageId?: string
 	input?: string
 	files?: DingTalkInboundFile[]
 	dingtalkMessage: ChatDingTalkMessage

--- a/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-callback.processor.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-callback.processor.spec.ts
@@ -41,14 +41,45 @@ jest.mock('@xpert-ai/contracts', () => ({
 }))
 
 import { DingTalkChatStreamCallbackProcessor } from './dingtalk-chat-callback.processor.js'
+import type { DingTalkChatRunState } from './dingtalk-chat-run-state.service.js'
 
 describe('DingTalkChatStreamCallbackProcessor', () => {
-	function createProcessor() {
-		return new DingTalkChatStreamCallbackProcessor(
-			{} as any,
-			{} as any,
+	function createProcessor(dingtalkChannel: Record<string, unknown> = {}) {
+		const processor = new DingTalkChatStreamCallbackProcessor(
+			dingtalkChannel as any,
 			{} as any
 		) as any
+		processor.conversationService = {
+			setActiveMessage: jest.fn().mockResolvedValue(undefined)
+		}
+		return processor
+	}
+
+	function createState(): DingTalkChatRunState {
+		return {
+			sourceMessageId: 'source-message-id',
+			nextSequence: 1,
+			responseMessageContent: '',
+			pendingSegmentText: '',
+			deliveredSegmentCount: 0,
+			context: {
+				tenantId: 'tenant-1',
+				organizationId: 'organization-1',
+				userId: 'user-1',
+				xpertId: 'xpert-1',
+				integrationId: 'integration-1',
+				chatId: 'chat-1',
+				chatType: 'group',
+				robotCode: 'robot-code',
+				sessionWebhook: 'https://example.com/session-webhook',
+				message: {
+					status: 'thinking',
+					elements: []
+				}
+			},
+			pendingEvents: {},
+			renderItems: []
+		}
 	}
 
 	it('preserves markdown structural whitespace in stream text deltas', () => {
@@ -62,4 +93,176 @@ describe('DingTalkChatStreamCallbackProcessor', () => {
 		expect(delta).toBe('\n\n## 标题\n\n- 第一项\n- 第二项\n')
 		expect(processor.extractMessageTextDelta({ type: 'text_delta', delta: '\n\n' })).toBe('\n\n')
 	})
+
+	it('keeps streamed text together until a tool call starts', async () => {
+		const createMessage = jest.fn().mockResolvedValue({
+			data: { message_id: 'segment-message-id' }
+		})
+		const processor = createProcessor({ createMessage })
+		const state = createState()
+
+		await processor.applyStreamEvent(state, {
+			data: {
+				type: 'message',
+				data: {
+					type: 'text_delta',
+					delta: '第一句已经完成。第二句也完成！第三句仍在生成'
+				}
+			}
+		})
+
+		expect(createMessage).not.toHaveBeenCalled()
+		expect(state.pendingSegmentText).toBe('第一句已经完成。第二句也完成！第三句仍在生成')
+		expect(state.deliveredSegmentCount).toBe(0)
+	})
+
+	it('flushes the current text segment when a tool call starts', async () => {
+		const createMessage = jest.fn().mockResolvedValue({
+			data: { message_id: 'segment-message-id' }
+		})
+		const processor = createProcessor({ createMessage })
+		const state = createState()
+		state.pendingSegmentText = '工具调用前的完整分析。\n\n包括表格和多行内容。'
+
+		await processor.applyStreamEvent(state, {
+			data: {
+				type: 'event',
+				event: 'on_tool_start',
+				data: {
+					id: 'tool-call-1',
+					tool: 'search',
+					status: 'running'
+				}
+			}
+		})
+
+		expect(createMessage).toHaveBeenCalledWith(
+			'integration-1',
+			expect.objectContaining({
+				content: expect.objectContaining({
+					markdown: '工具调用前的完整分析。\n\n包括表格和多行内容。'
+				})
+			})
+		)
+		expect(state.pendingSegmentText).toBe('')
+		expect(state.deliveredSegmentCount).toBe(1)
+	})
+
+	it('flushes the current text segment for the real component payload emitted by tool start', async () => {
+		const createMessage = jest.fn().mockResolvedValue({
+			data: { message_id: 'segment-message-id' }
+		})
+		const processor = createProcessor({ createMessage })
+		const state = createState()
+		state.pendingSegmentText = '开始调用工具前的执行计划。'
+
+		await processor.applyStreamEvent(state, {
+			data: {
+				type: 'message',
+				data: {
+					id: 'tool-call-1',
+					type: 'component',
+					data: {
+						category: 'Tool',
+						tool: 'sandbox_shell',
+						status: 'running'
+					}
+				}
+			}
+		})
+
+		expect(createMessage).toHaveBeenCalledWith(
+			'integration-1',
+			expect.objectContaining({
+				content: expect.objectContaining({
+					markdown: '开始调用工具前的执行计划。'
+				})
+			})
+		)
+		expect(state.pendingSegmentText).toBe('')
+		expect(state.deliveredSegmentCount).toBe(1)
+	})
+
+	it('splits text at each real tool start and keeps the final card with the last segment', async () => {
+		const createMessage = jest.fn().mockResolvedValue({
+			data: { message_id: 'segment-message-id' }
+		})
+		const interactiveMessage = jest.fn().mockResolvedValue({
+			data: { message_id: 'final-message-id' }
+		})
+		const processor = createProcessor({ createMessage, interactiveMessage })
+		const state = createState()
+		const emitText = (delta: string) =>
+			processor.applyStreamEvent(state, {
+				data: {
+					type: 'message',
+					data: {
+						type: 'text_delta',
+						delta
+					}
+				}
+			})
+		const emitToolStart = (id: string) =>
+			processor.applyStreamEvent(state, {
+				data: {
+					type: 'message',
+					data: {
+						id,
+						type: 'component',
+						data: {
+							category: 'Tool',
+							tool: 'sandbox_shell',
+							status: 'running'
+						}
+					}
+				}
+			})
+
+		await emitText('执行计划')
+		await emitToolStart('tool-call-1')
+		await emitText('第一次工具结果说明')
+		await emitToolStart('tool-call-2')
+		await emitText('最终总结')
+		await processor.completeRun(state)
+
+		expect(createMessage.mock.calls.map(([, message]) => message.content.markdown)).toEqual([
+			'执行计划',
+			'第一次工具结果说明'
+		])
+		const finalCard = interactiveMessage.mock.calls[0][1]
+		const finalMarkdown = finalCard.elements
+			.filter((element: { tag?: string }) => element.tag === 'markdown')
+			.map((element: { content?: string }) => element.content)
+			.join('\n')
+		expect(finalMarkdown).toContain('最终总结')
+		expect(finalMarkdown).not.toContain('执行计划')
+		expect(finalMarkdown).not.toContain('第一次工具结果说明')
+	})
+
+	it('does not duplicate delivered text in the final card', async () => {
+		const interactiveMessage = jest.fn().mockResolvedValue({
+			data: { message_id: 'final-message-id' }
+		})
+		const processor = createProcessor({ interactiveMessage })
+		const state = createState()
+		state.deliveredSegmentCount = 1
+		state.pendingSegmentText = '最终结论'
+		state.renderItems = [
+			{
+				kind: 'stream_text',
+				text: '已经单独发送的中间段落'
+			}
+		]
+
+		await processor.completeRun(state)
+
+		const card = interactiveMessage.mock.calls[0][1]
+		const markdown = card.elements
+			.filter((element: { tag?: string }) => element.tag === 'markdown')
+			.map((element: { content?: string }) => element.content)
+			.join('\n')
+		expect(markdown).toContain('最终结论')
+		expect(markdown).not.toContain('已经单独发送的中间段落')
+	})
+
 })

--- a/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-callback.processor.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-callback.processor.ts
@@ -3,7 +3,6 @@ import {
 	HandoffMessage,
 	HandoffProcessorStrategy,
 	IHandoffProcessor,
-	type PluginContext,
 	ProcessContext,
 	ProcessResult,
 } from '@xpert-ai/plugin-sdk'
@@ -13,21 +12,12 @@ import { DingTalkConversationService } from '../conversation.service.js'
 import { resolveConversationUserKey as resolveDingTalkConversationUserKey } from '../conversation-user-key.js'
 import { DingTalkChannelStrategy } from '../dingtalk-channel.strategy.js'
 import {
-	DEFAULT_STREAM_UPDATE_WINDOW_MS,
-	DEFAULT_FIRST_FLUSH_MIN_CHARS,
-	MAX_FIRST_FLUSH_MIN_CHARS,
-	IntegrationDingTalkPluginConfig,
-	MAX_STREAM_UPDATE_WINDOW_MS,
-	MIN_FIRST_FLUSH_MIN_CHARS,
-	MIN_STREAM_UPDATE_WINDOW_MS
-} from '../plugin-config.js'
-import { DINGTALK_PLUGIN_CONTEXT } from '../tokens.js'
-import {
 	DINGTALK_CHAT_STREAM_CALLBACK_MESSAGE_TYPE,
 	DingTalkChatCallbackContext,
 	DingTalkChatMessageSnapshot,
 	DingTalkChatStreamCallbackPayload,
 	DingTalkEventRenderItem,
+	DingTalkRenderItem,
 } from './dingtalk-chat.types.js'
 import { DingTalkChatRunState, DingTalkChatRunStateService } from './dingtalk-chat-run-state.service.js'
 import { DingTalkCardElement, DingTalkStructuredElement } from '../types.js'
@@ -61,9 +51,7 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 	
 	constructor(
 		private readonly dingtalkChannel: DingTalkChannelStrategy,
-		private readonly runStateService: DingTalkChatRunStateService,
-		@Inject(DINGTALK_PLUGIN_CONTEXT)
-		private readonly pluginContext: PluginContext<IntegrationDingTalkPluginConfig>
+		private readonly runStateService: DingTalkChatRunStateService
 	) {}
 
 	async process(
@@ -185,7 +173,7 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 	 * MESSAGE:
 	 * - append content into response buffer
 	 * - keep compatibility with structured update payload
-	 * - flush buffered text to DingTalk by configurable time window
+	 * - flush buffered text at tool-call boundaries
 	 *
 	 * EVENT:
 	 * - apply conversation/message lifecycle events
@@ -218,9 +206,13 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 			const structuredMessageData = this.toRecord(messageData)
 			const textDelta = this.extractMessageTextDelta(messageData)
 
+			if (this.isToolCallStartMessage(structuredMessageData)) {
+				await this.flushPendingTextSegment(state)
+			}
+
 			if (textDelta) {
 				state.responseMessageContent += textDelta
-				this.appendStreamTextDelta(state, textDelta)
+				state.pendingSegmentText += textDelta
 			}
 
 			if (typeof messageData !== 'string') {
@@ -252,24 +244,9 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 				return
 			}
 
-			this.logger.debug(`Appended stream content for source message "${state.sourceMessageId}", current buffered length: ${state.responseMessageContent.length}`)
-			const now = Date.now()
-			const updateWindowMs = this.resolveStreamUpdateWindowMs(context)
-			const firstFlushMinChars = this.resolveFirstFlushMinChars(context)
-			if (
-				this.shouldFlushStreamContent(
-					state,
-					now,
-					updateWindowMs,
-					firstFlushMinChars,
-					Boolean(context.message?.id)
-				)
-			) {
-				const message = ensureDingTalkMessage()
-				await this.flushStreamContent(state, message, now)
-				context.message = this.toMessageSnapshot(message, context.message?.text)
-				await this.syncActiveMessageCache(context)
-			}
+			this.logger.debug(
+				`Appended stream content for source message "${state.sourceMessageId}", current buffered length: ${state.responseMessageContent.length}`
+			)
 			return
 		}
 
@@ -329,6 +306,9 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 			case ChatMessageEventTypeEnum.ON_TOOL_ERROR:
 			case ChatMessageEventTypeEnum.ON_TOOL_MESSAGE:
 			case ChatMessageEventTypeEnum.ON_CHAT_EVENT: {
+				if (eventPayload.event === ChatMessageEventTypeEnum.ON_TOOL_START) {
+					await this.flushPendingTextSegment(state)
+				}
 				const data = (eventPayload.data ?? {}) as Record<string, unknown>
 				const toolName = this.resolveManagedEventTool(data)
 				if (this.shouldSkipManagedToolEventRender(toolName)) {
@@ -367,11 +347,26 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 			currentStatus === XpertAgentExecutionStatusEnum.ERROR
 
 		if (!keepTerminalState) {
-			if (state.renderItems.length > 0 || context.reject || dingtalkMessage.elements.length > 0) {
-				dingtalkMessage.renderItems = state.renderItems
+			const finalSegmentText = state.pendingSegmentText.trim()
+			const finalRenderItems: DingTalkRenderItem[] = state.renderItems.filter(
+				(item) => item.kind !== 'stream_text'
+			)
+			if (finalSegmentText) {
+				finalRenderItems.push({
+					kind: 'stream_text',
+					text: finalSegmentText
+				})
+			}
+			if (
+				finalRenderItems.length > 0 ||
+				context.reject ||
+				dingtalkMessage.elements.length > 0
+			) {
+				dingtalkMessage.renderItems = finalRenderItems
 				await dingtalkMessage.update({
 					status: XpertAgentExecutionStatusEnum.SUCCESS
 				})
+				state.pendingSegmentText = ''
 			}
 		}
 
@@ -434,10 +429,10 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 			sourceMessageId,
 			nextSequence: 1,
 			responseMessageContent: '',
+			pendingSegmentText: '',
+			deliveredSegmentCount: 0,
 			context,
 			pendingEvents: {},
-			lastFlushAt: 0,
-			lastFlushedLength: 0,
 			renderItems
 		}
 	}
@@ -446,68 +441,50 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 		return {
 			...state,
 			pendingEvents: state.pendingEvents ?? {},
-			lastFlushAt: state.lastFlushAt ?? 0,
-			lastFlushedLength: state.lastFlushedLength ?? 0
+			pendingSegmentText: state.pendingSegmentText ?? '',
+			deliveredSegmentCount: state.deliveredSegmentCount ?? 0
 		}
 	}
 
-	private resolveStreamUpdateWindowMs(context: DingTalkChatCallbackContext): number {
-		const fromContext = context.streaming?.updateWindowMs
-		const fromConfig = this.pluginContext.config?.streaming?.updateWindowMs
-		const candidate = fromContext ?? fromConfig ?? DEFAULT_STREAM_UPDATE_WINDOW_MS
-		return Math.min(
-			MAX_STREAM_UPDATE_WINDOW_MS,
-			Math.max(MIN_STREAM_UPDATE_WINDOW_MS, candidate)
-		)
-	}
-
-	private resolveFirstFlushMinChars(context: DingTalkChatCallbackContext): number {
-		const fromContext = context.streaming?.firstFlushMinChars
-		const fromConfig = this.pluginContext.config?.streaming?.firstFlushMinChars
-		const candidate = fromContext ?? fromConfig ?? DEFAULT_FIRST_FLUSH_MIN_CHARS
-		return Math.min(
-			MAX_FIRST_FLUSH_MIN_CHARS,
-			Math.max(MIN_FIRST_FLUSH_MIN_CHARS, candidate)
-		)
-	}
-
-	private shouldFlushStreamContent(
-		state: DingTalkChatRunState,
-		now: number,
-		updateWindowMs: number,
-		firstFlushMinChars: number,
-		hasMessageId: boolean
-	): boolean {
-		if (!state.responseMessageContent) {
-			return false
-		}
-		if (state.responseMessageContent.length <= state.lastFlushedLength) {
-			return false
-		}
-		if (!hasMessageId) {
-			const text = state.responseMessageContent
-			if (text.length < firstFlushMinChars) {
-				return false
-			}
-		}
-		return now - state.lastFlushAt >= updateWindowMs
-	}
-
-	private appendStreamTextDelta(state: DingTalkChatRunState, textDelta: string): void {
-		if (!textDelta) {
+	private async flushPendingTextSegment(state: DingTalkChatRunState): Promise<void> {
+		const content = state.pendingSegmentText.trim()
+		if (!content) {
+			state.pendingSegmentText = ''
 			return
 		}
 
-		const items = state.renderItems
-		const last = items[items.length - 1]
-		if (last?.kind === 'stream_text') {
-			last.text = `${last.text}${textDelta}`
-		} else {
-			items.push({
-				kind: 'stream_text',
-				text: textDelta
-			})
+		await this.sendStandaloneTextSegment(state, content)
+		state.pendingSegmentText = ''
+	}
+
+	private async sendStandaloneTextSegment(
+		state: DingTalkChatRunState,
+		content: string
+	): Promise<void> {
+		const context = state.context
+		if (!context.integrationId || !context.chatId) {
+			throw new Error('DingTalk stream segment requires integrationId and chatId')
 		}
+
+		await this.dingtalkChannel.createMessage(context.integrationId, {
+			recipient: {
+				type: 'chat_id',
+				id: context.chatId
+			},
+			sessionWebhook: context.sessionWebhook,
+			robotCodeOverride: context.robotCode,
+			msgType: 'markdown',
+			content: {
+				title: 'Xpert Notification',
+				markdown: content
+			},
+			preferSessionWebhook: Boolean(context.sessionWebhook)
+		})
+
+		state.deliveredSegmentCount += 1
+		this.logger.debug(
+			`Delivered DingTalk stream segment for source message "${state.sourceMessageId}", segment=${state.deliveredSegmentCount}, length=${content.length}`
+		)
 	}
 
 	private appendStructuredElements(
@@ -520,18 +497,6 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 				element: cloneStructuredElement(element)
 			})
 		}
-	}
-
-	private async flushStreamContent(
-		state: DingTalkChatRunState,
-		dingtalkMessage: ChatDingTalkMessage,
-		now: number
-	) {
-		this.logger.debug(`Flushing stream content for source message "${state.sourceMessageId}", content length: ${state.responseMessageContent.length}`)
-		dingtalkMessage.renderItems = state.renderItems
-		await dingtalkMessage.update()
-		state.lastFlushAt = now
-		state.lastFlushedLength = state.responseMessageContent.length
 	}
 
 	private upsertManagedEventElement(
@@ -669,6 +634,15 @@ export class DingTalkChatStreamCallbackProcessor implements IHandoffProcessor<Di
 	private isKnownMessagePayloadType(value: unknown): boolean {
 		const type = this.toNonEmptyString(value)
 		return type === 'text' || type === 'text_delta' || type === 'update' || type === 'reasoning' || type === 'component'
+	}
+
+	private isToolCallStartMessage(value: Record<string, unknown> | null): boolean {
+		if (value?.type !== 'component') {
+			return false
+		}
+
+		const component = this.toRecord(value.data)
+		return component?.category === 'Tool' && component?.status === 'running'
 	}
 
 	private normalizeStreamText(value: string | null | undefined): string {

--- a/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-dispatch.service.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-dispatch.service.spec.ts
@@ -55,15 +55,11 @@ function mockRequestContext(params?: {
 	tenantId?: string
 	organizationId?: string
 	language?: string
-	headers?: Record<string, unknown>
 }) {
 	jest.spyOn(RequestContext, 'currentUserId').mockReturnValue((params?.userId ?? 'request-user-id') as any)
 	jest.spyOn(RequestContext, 'currentTenantId').mockReturnValue((params?.tenantId ?? 'request-tenant-id') as any)
 	jest.spyOn(RequestContext, 'getOrganizationId').mockReturnValue((params?.organizationId ?? 'request-organization-id') as any)
 	jest.spyOn(RequestContext, 'getLanguageCode').mockReturnValue((params?.language ?? 'zh-Hans') as any)
-	jest.spyOn(RequestContext, 'currentRequest').mockReturnValue({
-		headers: params?.headers ?? {}
-	} as any)
 }
 
 describe('DingTalkChatDispatchService', () => {
@@ -159,6 +155,27 @@ describe('DingTalkChatDispatchService', () => {
 			sessionWebhook: 'https://oapi.dingtalk.com/robot/send/session',
 			xpertId: 'xpert-1'
 		})
+	})
+
+	it('buildDispatchMessage preserves a stable aggregate dispatch message id', async () => {
+		mockRequestContext()
+		const { service, runStateService } = createFixture()
+		const dingtalkMessage = createDingTalkMessage()
+
+		const message = await service.buildDispatchMessage({
+			xpertId: 'xpert-1',
+			dispatchMessageId: 'dingtalk-chat-aggregate-stable-id',
+			input: 'hi',
+			dingtalkMessage: dingtalkMessage as any
+		})
+
+		expect(message.id).toBe('dingtalk-chat-aggregate-stable-id')
+		expect(message.traceId).toBe('dingtalk-chat-aggregate-stable-id')
+		expect(runStateService.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				sourceMessageId: 'dingtalk-chat-aggregate-stable-id'
+			})
+		)
 	})
 
 	it('buildDispatchMessage forwards inbound files to the chat request input', async () => {

--- a/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-dispatch.service.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-dispatch.service.ts
@@ -116,7 +116,7 @@ export class DingTalkChatDispatchService {
 			)
 		}
 
-		const runId = `dingtalk-chat-${randomUUID()}`
+		const runId = input.dispatchMessageId ?? `dingtalk-chat-${randomUUID()}`
 		const sessionKey = conversationId ?? runId
 		const language = dingtalkMessage.language || RequestContext.getLanguageCode()
 		const callbackContext: DingTalkChatCallbackContext = {
@@ -132,7 +132,6 @@ export class DingTalkChatDispatchService {
 			robotCode: dingtalkMessage.robotCode,
 			sessionWebhook: dingtalkMessage.sessionWebhook,
 			reject: Boolean(input.options?.reject),
-			streaming: this.resolveStreamingOverrideFromRequest(),
 			message: this.toMessageSnapshot(dingtalkMessage, input.input)
 		}
 
@@ -140,10 +139,10 @@ export class DingTalkChatDispatchService {
 			sourceMessageId: runId,
 			nextSequence: 1,
 			responseMessageContent: '',
+			pendingSegmentText: '',
+			deliveredSegmentCount: 0,
 			context: callbackContext,
 			pendingEvents: {},
-			lastFlushAt: 0,
-			lastFlushedLength: 0,
 			renderItems: (callbackContext.message?.elements ?? []).map((element) => ({
 				kind: 'structured' as const,
 				element: { ...element }
@@ -294,24 +293,6 @@ export class DingTalkChatDispatchService {
 				header: message.header,
 				elements: [...(message.elements ?? [])]
 			}
-		}
-	}
-
-	private resolveStreamingOverrideFromRequest(): DingTalkChatCallbackContext['streaming'] | undefined {
-		const request = RequestContext.currentRequest()
-		const rawHeader =
-			request?.headers?.['x-dingtalk-update-window-ms'] ??
-			request?.headers?.['dingtalk-update-window-ms']
-		const rawValue = Array.isArray(rawHeader) ? rawHeader[0] : rawHeader
-		if (!rawValue) {
-			return undefined
-		}
-		const parsed = parseInt(String(rawValue), 10)
-		if (!Number.isFinite(parsed) || parsed <= 0) {
-			return undefined
-		}
-		return {
-			updateWindowMs: parsed
 		}
 	}
 

--- a/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-run-state.service.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat-run-state.service.ts
@@ -22,14 +22,14 @@ export interface DingTalkChatRunState<TRenderItem extends DingTalkRenderItem = D
 	nextSequence: number
 	/** Buffered full response text built from stream MESSAGE callbacks. */
 	responseMessageContent: string
+	/** Text not yet delivered as a standalone DingTalk segment. */
+	pendingSegmentText: string
+	/** Number of standalone text segments already delivered for this run. */
+	deliveredSegmentCount: number
 	/** Snapshot to reconstruct ChatDingTalkMessage and conversation context for every callback. */
 	context: DingTalkChatCallbackContext
 	/** Out-of-order callbacks are parked here until nextSequence is available. */
 	pendingEvents: Record<string, DingTalkChatStreamCallbackPayload>
-	/** Last timestamp when stream text was flushed to DingTalk card. */
-	lastFlushAt: number
-	/** Length of responseMessageContent already flushed to DingTalk. */
-	lastFlushedLength: number
 	/** Ordered, mixed internal render items by callback arrival time. */
 	renderItems: TRenderItem[]
 }

--- a/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat.types.ts
+++ b/xpertai/integrations/dingtalk/src/lib/handoff/dingtalk-chat.types.ts
@@ -61,10 +61,6 @@ export interface DingTalkChatCallbackContext extends Record<string, unknown> {
 	robotCode?: string
 	sessionWebhook?: string
 	reject?: boolean
-	streaming?: {
-		updateWindowMs?: number
-		firstFlushMinChars?: number
-	}
 	message: DingTalkChatMessageSnapshot
 }
 

--- a/xpertai/integrations/dingtalk/src/lib/middlewares/dingtalk-notify.middleware.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/middlewares/dingtalk-notify.middleware.spec.ts
@@ -117,6 +117,7 @@ describe('DingTalkNotifyMiddleware', () => {
         buffer: fileBuffer,
         fileName: 'report.pdf',
         fileType: 'pdf',
+        mediaType: 'file',
         mimeType: 'application/pdf'
       }),
       1000
@@ -131,6 +132,50 @@ describe('DingTalkNotifyMiddleware', () => {
           mediaId: 'media-1',
           fileName: 'report.pdf',
           fileType: 'pdf'
+        }
+      },
+      allowFallback: false
+    })
+  })
+
+  it('sends workspace images through the DingTalk image message channel', async () => {
+    const { middleware, dingtalkChannel, workspaceFiles } = createFixture()
+    const imageBuffer = Buffer.from('chart bytes')
+    workspaceFiles.readRuntimeBuffer.mockResolvedValueOnce({
+      name: 'chart.png',
+      filePath: 'files/chart.png',
+      workspacePath: '/workspace/files/chart.png',
+      mimeType: 'image/png',
+      size: imageBuffer.length,
+      buffer: imageBuffer
+    })
+    const sendFile = getTool(middleware, 'dingtalk_send_file')
+
+    await sendFile.invoke({
+      path: 'files/chart.png',
+      originalName: 'chart.png',
+      mimeType: 'image/png'
+    })
+
+    expect(dingtalkChannel.uploadFile).toHaveBeenCalledWith(
+      'integration-1',
+      expect.objectContaining({
+        buffer: imageBuffer,
+        fileName: 'chart.png',
+        fileType: 'png',
+        mediaType: 'image',
+        mimeType: 'image/png'
+      }),
+      1000
+    )
+    expect(dingtalkChannel.createMessage).toHaveBeenCalledWith('integration-1', {
+      recipient: { type: 'chat_id', id: 'chat-1' },
+      robotCodeOverride: null,
+      msgType: 'interactive',
+      content: {
+        msgKey: 'sampleImageMsg',
+        msgParam: {
+          photoURL: 'media-1'
         }
       },
       allowFallback: false

--- a/xpertai/integrations/dingtalk/src/lib/middlewares/dingtalk-notify.middleware.ts
+++ b/xpertai/integrations/dingtalk/src/lib/middlewares/dingtalk-notify.middleware.ts
@@ -19,7 +19,8 @@ import { DingTalkConversationService } from '../conversation.service.js'
 import { toRecipientConversationUserKey } from '../conversation-user-key.js'
 import { DingTalkChannelStrategy } from '../dingtalk-channel.strategy.js'
 import {
-  resolveDingTalkSendFileFromWorkspace,
+  buildDingTalkSendMediaContent,
+  resolveDingTalkSendMediaFromWorkspace,
   toDingTalkSendFileMetadata,
   type DingTalkSendFileDescriptor
 } from '../dingtalk-send-file.js'
@@ -954,7 +955,7 @@ export class DingTalkNotifyMiddleware implements IAgentMiddlewareStrategy {
             )
           }
 
-          const file = await resolveDingTalkSendFileFromWorkspace(
+          const file = await resolveDingTalkSendMediaFromWorkspace(
             buildDingTalkSendFileDescriptor(renderedInput as Record<string, unknown>),
             { workspaceFiles }
           )
@@ -985,14 +986,7 @@ export class DingTalkNotifyMiddleware implements IAgentMiddlewareStrategy {
                 recipient,
                 robotCodeOverride,
                 msgType: 'interactive',
-                content: {
-                  msgKey: 'sampleFile',
-                  msgParam: {
-                    mediaId: uploaded.mediaId,
-                    fileName: file.fileName,
-                    fileType: file.fileType
-                  }
-                },
+                content: buildDingTalkSendMediaContent(file, uploaded.mediaId),
                 allowFallback: false
               })
 
@@ -1011,7 +1005,7 @@ export class DingTalkNotifyMiddleware implements IAgentMiddlewareStrategy {
         {
           name: 'dingtalk_send_file',
           description:
-            'Send a generated, edited, or previously found Xpert workspace file to the trusted current DingTalk conversation. The tool cannot choose another integration, chat, or user.',
+            'Send a generated, edited, or previously found Xpert workspace image or file to the trusted current DingTalk conversation. Images use the DingTalk image message channel; documents and archives use the file message channel. The tool cannot choose another integration, chat, or user.',
           schema: sendFileSchema,
           verboseParsingErrors: true
         }

--- a/xpertai/integrations/dingtalk/src/lib/plugin-config.ts
+++ b/xpertai/integrations/dingtalk/src/lib/plugin-config.ts
@@ -1,30 +1,8 @@
 import { z } from 'zod'
 
-export const DEFAULT_STREAM_UPDATE_WINDOW_MS = 2000
-export const MIN_STREAM_UPDATE_WINDOW_MS = 100
-export const MAX_STREAM_UPDATE_WINDOW_MS = 10000
-export const DEFAULT_FIRST_FLUSH_MIN_CHARS = 24
-export const MIN_FIRST_FLUSH_MIN_CHARS = 1
-export const MAX_FIRST_FLUSH_MIN_CHARS = 500
 export const DEFAULT_EVENT_DEDUP_TTL_SECONDS = 300
 
 export const IntegrationDingTalkPluginConfigSchema = z.object({
-  streaming: z
-    .object({
-      updateWindowMs: z
-        .coerce.number()
-        .int()
-        .min(MIN_STREAM_UPDATE_WINDOW_MS)
-        .max(MAX_STREAM_UPDATE_WINDOW_MS)
-        .default(DEFAULT_STREAM_UPDATE_WINDOW_MS),
-      firstFlushMinChars: z
-        .coerce.number()
-        .int()
-        .min(MIN_FIRST_FLUSH_MIN_CHARS)
-        .max(MAX_FIRST_FLUSH_MIN_CHARS)
-        .default(DEFAULT_FIRST_FLUSH_MIN_CHARS)
-    })
-    .default({}),
   dedupe: z
     .object({
       ttlSeconds: z.coerce.number().int().min(10).max(3600).default(DEFAULT_EVENT_DEDUP_TTL_SECONDS)

--- a/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger-aggregation.service.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger-aggregation.service.spec.ts
@@ -1,0 +1,279 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+	MANAGED_QUEUE_SERVICE_TOKEN: 'MANAGED_QUEUE_SERVICE_TOKEN'
+}))
+
+import { DingTalkTriggerAggregationService } from './dingtalk-trigger-aggregation.service.js'
+import type { DingTalkTriggerAggregationState } from './dingtalk-trigger-aggregation.types.js'
+
+describe('DingTalkTriggerAggregationService', () => {
+	function createRedis(overrides: Record<string, jest.Mock> = {}) {
+		return {
+			get: jest.fn(async () => null),
+			set: jest.fn(async () => 'OK'),
+			del: jest.fn(async () => 1),
+			eval: jest.fn(async () => 1),
+			...overrides
+		}
+	}
+
+	function createStatefulRedis() {
+		const values = new Map<string, string>()
+		return {
+			get: jest.fn(async (key: string) => values.get(key) ?? null),
+			set: jest.fn(
+				async (
+					key: string,
+					value: string,
+					_mode?: string,
+					_ttlMode?: string | number,
+					ttlOrMode?: number | string
+				) => {
+					if (ttlOrMode === 'NX' && values.has(key)) {
+						return null
+					}
+					values.set(key, value)
+					return 'OK'
+				}
+			),
+			del: jest.fn(async (...keys: string[]) => {
+				let deleted = 0
+				for (const key of keys) {
+					if (values.delete(key)) {
+						deleted += 1
+					}
+				}
+				return deleted
+			}),
+			eval: jest.fn(async (script: string, _keyCount: number, ...args: string[]) => {
+				const lockKey = args[0]
+				const token = script.includes("KEYS[2], KEYS[3]") ? args[3] : args[1]
+				if (values.get(lockKey) !== token) {
+					return script.includes("KEYS[2], KEYS[3]") ? -1 : 0
+				}
+				if (script.includes("redis.call('pexpire'")) {
+					return 1
+				}
+				if (script.includes("KEYS[2], KEYS[3]")) {
+					values.delete(args[1])
+					values.delete(args[2])
+					return 1
+				}
+				values.delete(lockKey)
+				return 1
+			})
+		}
+	}
+
+	function createCacheManager(overrides: Record<string, jest.Mock> = {}) {
+		return {
+			get: jest.fn(async () => null),
+			del: jest.fn(async () => true),
+			...overrides
+		}
+	}
+
+	function createService(redis = createRedis(), cacheManager = createCacheManager()) {
+		const managedQueue = {
+			getRedis: jest.fn(async () => redis)
+		}
+		const pluginContext = {
+			resolve: jest.fn(() => managedQueue)
+		}
+		return {
+			service: new DingTalkTriggerAggregationService(
+				pluginContext as any,
+				cacheManager as any
+			),
+			redis,
+			cacheManager
+		}
+	}
+
+	function createState(): DingTalkTriggerAggregationState {
+		return {
+			aggregateKey: 'integration-1:chat-1:sender-1',
+			integrationId: 'integration-1',
+			conversationUserKey: 'integration-1:chat-1:sender-1',
+			xpertId: 'xpert-1',
+			version: 1,
+			inputParts: ['hello'],
+			lastMessageAt: 1,
+			latestMessage: {
+				integrationId: 'integration-1'
+			}
+		}
+	}
+
+	it('stores aggregate state as JSON in plugin-scoped Redis keys', async () => {
+		const state = createState()
+		const redis = createRedis({
+			get: jest.fn(async () => JSON.stringify(state))
+		})
+		const { service } = createService(redis)
+
+		await service.save(state, 60)
+		await expect(service.get(state.aggregateKey)).resolves.toEqual(state)
+
+		expect(redis.set).toHaveBeenCalledWith(
+			`plugin_dingtalk:trigger:aggregate:${state.aggregateKey}`,
+			JSON.stringify(state),
+			'PX',
+			60000
+		)
+	})
+
+	it('reads legacy aggregate state during the Redis key migration', async () => {
+		const state = createState()
+		const redis = createRedis()
+		const cacheManager = createCacheManager({
+			get: jest.fn(async () => state)
+		})
+		const { service } = createService(redis, cacheManager)
+
+		await expect(service.get(state.aggregateKey)).resolves.toEqual(state)
+
+		expect(redis.get).toHaveBeenCalledWith(
+			`plugin_dingtalk:trigger:aggregate:${state.aggregateKey}`
+		)
+		expect(cacheManager.get).toHaveBeenCalledWith(
+			`dingtalk:trigger:aggregate:${state.aggregateKey}`
+		)
+	})
+
+	it('clears current and legacy aggregate keys together', async () => {
+		const { service, redis, cacheManager } = createService()
+
+		await service.clear('aggregate-1')
+
+		expect(cacheManager.del).toHaveBeenCalledWith(
+			'dingtalk:trigger:aggregate:aggregate-1'
+		)
+		expect(redis.del).toHaveBeenCalledWith(
+			'plugin_dingtalk:trigger:aggregate:aggregate-1',
+			'dingtalk:trigger:aggregate:aggregate-1'
+		)
+	})
+
+	it('clears aggregate state only while the per-conversation lock is still owned', async () => {
+		const { service, redis, cacheManager } = createService()
+
+		await service.withAggregateLock('aggregate-1', async (lease) => {
+			await lease.clearStateIfOwned()
+		})
+
+		expect(cacheManager.del).toHaveBeenCalledWith(
+			'dingtalk:trigger:aggregate:aggregate-1'
+		)
+		expect(redis.eval).toHaveBeenCalledWith(
+			expect.stringContaining("redis.call('del', KEYS[2], KEYS[3])"),
+			3,
+			'plugin_dingtalk:lock:inbound:aggregate-1',
+			'plugin_dingtalk:trigger:aggregate:aggregate-1',
+			'dingtalk:trigger:aggregate:aggregate-1',
+			expect.any(String)
+		)
+	})
+
+	it('does not revive legacy aggregate state after it is cleared', async () => {
+		const state = createState()
+		let legacyState: DingTalkTriggerAggregationState | undefined = state
+		const cacheManager = createCacheManager({
+			get: jest.fn(async () => legacyState),
+			del: jest.fn(async () => {
+				legacyState = undefined
+				return true
+			})
+		})
+		const { service } = createService(createRedis(), cacheManager)
+
+		await expect(service.get(state.aggregateKey)).resolves.toEqual(state)
+		await service.clear(state.aggregateKey)
+		await expect(service.get(state.aggregateKey)).resolves.toBeNull()
+	})
+
+	it('waits for another worker to release the aggregate lock before running', async () => {
+		const { service } = createService(createStatefulRedis())
+		const order: string[] = []
+		let signalFirstEntered: () => void = () => undefined
+		let releaseFirst: () => void = () => undefined
+		const firstEntered = new Promise<void>((resolve) => {
+			signalFirstEntered = resolve
+		})
+		const firstCanFinish = new Promise<void>((resolve) => {
+			releaseFirst = resolve
+		})
+
+		const first = service.withAggregateLock('aggregate-1', async () => {
+			order.push('first')
+			signalFirstEntered()
+			await firstCanFinish
+		})
+		await firstEntered
+
+		const second = service.withAggregateLock(
+			'aggregate-1',
+			async () => {
+				order.push('second')
+			},
+			{
+				acquireTimeoutMs: 1000,
+				retryMinDelayMs: 1,
+				retryMaxDelayMs: 1
+			}
+		)
+		await new Promise<void>((resolve) => setTimeout(resolve, 10))
+		expect(order).toEqual(['first'])
+
+		releaseFirst()
+		await Promise.all([first, second])
+		expect(order).toEqual(['first', 'second'])
+	})
+
+	it('rejects work after the bounded aggregate lock wait expires', async () => {
+		const redis = createRedis({
+			set: jest.fn(async () => null)
+		})
+		const { service } = createService(redis)
+		const callback = jest.fn(async () => undefined)
+
+		await expect(
+			service.withAggregateLock('aggregate-1', callback, { acquireTimeoutMs: 0 })
+		).rejects.toThrow('inbound_aggregate_lock_unavailable')
+		expect(callback).not.toHaveBeenCalled()
+	})
+
+	it('does not clear a newer aggregate after lock ownership is lost', async () => {
+		let lockToken = ''
+		let aggregateState = 'version-2'
+		const redis = createRedis({
+			set: jest.fn(async (_key: string, token: string) => {
+				lockToken = token
+				return 'OK'
+			}),
+			eval: jest.fn(async (script: string, _keyCount: number, ...args: string[]) => {
+				if (script.includes("redis.call('del', KEYS[2], KEYS[3])")) {
+					if (lockToken !== args[3]) {
+						return -1
+					}
+					aggregateState = ''
+					return 1
+				}
+				if (script.includes("redis.call('pexpire'")) {
+					return lockToken === args[1] ? 1 : 0
+				}
+				return lockToken === args[1] ? 1 : 0
+			})
+		})
+		const { service } = createService(redis)
+
+		await expect(
+			service.withAggregateLock('aggregate-1', async (lease) => {
+				lockToken = 'new-owner-token'
+				aggregateState = 'version-3'
+				await lease.clearStateIfOwned()
+			})
+		).rejects.toThrow('inbound_aggregate_lock_lost')
+
+		expect(aggregateState).toBe('version-3')
+	})
+})

--- a/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger-aggregation.service.ts
+++ b/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger-aggregation.service.ts
@@ -1,34 +1,265 @@
 import { CACHE_MANAGER } from '@nestjs/cache-manager'
 import { Inject, Injectable } from '@nestjs/common'
-import { type Cache } from 'cache-manager'
+import {
+	MANAGED_QUEUE_SERVICE_TOKEN,
+	type ManagedQueueRedis,
+	type ManagedQueueService,
+	type PluginContext
+} from '@xpert-ai/plugin-sdk'
+import type { Cache } from 'cache-manager'
+import { randomUUID } from 'crypto'
+import { DINGTALK_PLUGIN_CONTEXT } from '../tokens.js'
 import { DingTalkTriggerAggregationState } from './dingtalk-trigger-aggregation.types.js'
 
 const DEFAULT_AGGREGATION_TTL_SECONDS = 2 * 60 * 60
+const DEFAULT_LOCK_TTL_MS = 5000
+const DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS = 15_000
+const DEFAULT_LOCK_RETRY_MIN_DELAY_MS = 50
+const DEFAULT_LOCK_RETRY_MAX_DELAY_MS = 250
+
+export type DingTalkAggregateLockLease = {
+	ensureOwned(): Promise<void>
+	clearStateIfOwned(): Promise<void>
+}
+
+export type DingTalkAggregateLockOptions = {
+	ttlMs?: number
+	acquireTimeoutMs?: number
+	retryMinDelayMs?: number
+	retryMaxDelayMs?: number
+}
 
 @Injectable()
 export class DingTalkTriggerAggregationService {
+	private _managedQueueService?: ManagedQueueService
+
 	constructor(
+		@Inject(DINGTALK_PLUGIN_CONTEXT)
+		private readonly pluginContext: PluginContext,
 		@Inject(CACHE_MANAGER)
 		private readonly cacheManager: Cache
 	) {}
+
+	private get managedQueueService(): ManagedQueueService {
+		if (!this._managedQueueService) {
+			this._managedQueueService = this.pluginContext.resolve(MANAGED_QUEUE_SERVICE_TOKEN)
+		}
+		return this._managedQueueService
+	}
 
 	async save(
 		state: DingTalkTriggerAggregationState,
 		ttlSeconds: number = DEFAULT_AGGREGATION_TTL_SECONDS
 	): Promise<void> {
-		await this.cacheManager.set(this.buildKey(state.aggregateKey), state, ttlSeconds * 1000)
+		await (await this.getRedis()).set(
+			this.buildKey(state.aggregateKey),
+			JSON.stringify(state),
+			'PX',
+			ttlSeconds * 1000
+		)
 	}
 
 	async get(aggregateKey: string): Promise<DingTalkTriggerAggregationState | null> {
-		const state = await this.cacheManager.get<DingTalkTriggerAggregationState>(this.buildKey(aggregateKey))
-		return state ?? null
+		const redis = await this.getRedis()
+		const raw = await redis.get(this.buildKey(aggregateKey))
+		if (raw) {
+			try {
+				return JSON.parse(raw) as DingTalkTriggerAggregationState
+			} catch {
+				await this.clear(aggregateKey)
+				return null
+			}
+		}
+
+		const legacyState = await this.cacheManager.get<DingTalkTriggerAggregationState>(
+			this.buildLegacyKey(aggregateKey)
+		)
+		return legacyState ?? null
 	}
 
 	async clear(aggregateKey: string): Promise<void> {
-		await this.cacheManager.del(this.buildKey(aggregateKey))
+		await this.cacheManager.del(this.buildLegacyKey(aggregateKey))
+		await (await this.getRedis()).del(
+			this.buildKey(aggregateKey),
+			this.buildLegacyKey(aggregateKey)
+		)
+	}
+
+	async withAggregateLock<T>(
+		aggregateKey: string,
+		callback: (lease: DingTalkAggregateLockLease) => Promise<T>,
+		options: DingTalkAggregateLockOptions = {}
+	): Promise<T> {
+		const ttlMs = Math.max(1, options.ttlMs ?? DEFAULT_LOCK_TTL_MS)
+		const acquireTimeoutMs = Math.max(
+			0,
+			options.acquireTimeoutMs ?? DEFAULT_LOCK_ACQUIRE_TIMEOUT_MS
+		)
+		const retryMinDelayMs = Math.max(
+			1,
+			options.retryMinDelayMs ?? DEFAULT_LOCK_RETRY_MIN_DELAY_MS
+		)
+		const retryMaxDelayMs = Math.max(
+			retryMinDelayMs,
+			options.retryMaxDelayMs ?? DEFAULT_LOCK_RETRY_MAX_DELAY_MS
+		)
+		const token = randomUUID()
+		const key = this.buildLockKey(aggregateKey)
+		const stateKey = this.buildKey(aggregateKey)
+		const legacyStateKey = this.buildLegacyKey(aggregateKey)
+		const acquired = await this.acquireLockWithWait(
+			key,
+			token,
+			ttlMs,
+			acquireTimeoutMs,
+			retryMinDelayMs,
+			retryMaxDelayMs
+		)
+		if (!acquired) {
+			throw new Error('inbound_aggregate_lock_unavailable')
+		}
+
+		let stopped = false
+		let lostError: Error | undefined
+		let renewalInFlight: Promise<void> | undefined
+		const renew = async (): Promise<void> => {
+			if (stopped || lostError) {
+				return
+			}
+			try {
+				if (!(await this.renewLock(key, token, ttlMs))) {
+					lostError = new Error('inbound_aggregate_lock_lost')
+				}
+			} catch {
+				lostError = new Error('inbound_aggregate_lock_renew_failed')
+			}
+		}
+		const ensureOwned = async (): Promise<void> => {
+			if (renewalInFlight) {
+				await renewalInFlight
+			}
+			if (lostError) {
+				throw lostError
+			}
+			await renew()
+			if (lostError) {
+				throw lostError
+			}
+		}
+		const clearStateIfOwned = async (): Promise<void> => {
+			if (renewalInFlight) {
+				await renewalInFlight
+			}
+			if (lostError) {
+				throw lostError
+			}
+			await this.cacheManager.del(legacyStateKey)
+			if (!(await this.deleteAggregateStateIfLockOwned(key, stateKey, legacyStateKey, token))) {
+				lostError = new Error('inbound_aggregate_lock_lost')
+				throw lostError
+			}
+		}
+		const renewTimer = setInterval(() => {
+			if (!renewalInFlight && !lostError) {
+				renewalInFlight = renew().finally(() => {
+					renewalInFlight = undefined
+				})
+			}
+		}, Math.max(1, Math.floor(ttlMs / 3)))
+
+		try {
+			const result = await callback({ ensureOwned, clearStateIfOwned })
+			await ensureOwned()
+			return result
+		} finally {
+			stopped = true
+			clearInterval(renewTimer)
+			await renewalInFlight?.catch(() => undefined)
+			await this.releaseLock(key, token)
+		}
+	}
+
+	private async getRedis(): Promise<ManagedQueueRedis> {
+		return this.managedQueueService.getRedis()
+	}
+
+	private async acquireLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+		const result = await (await this.getRedis()).set(key, token, 'PX', ttlMs, 'NX')
+		return result === 'OK'
+	}
+
+	private async acquireLockWithWait(
+		key: string,
+		token: string,
+		ttlMs: number,
+		acquireTimeoutMs: number,
+		retryMinDelayMs: number,
+		retryMaxDelayMs: number
+	): Promise<boolean> {
+		const deadline = Date.now() + acquireTimeoutMs
+		while (!(await this.acquireLock(key, token, ttlMs))) {
+			const remainingMs = deadline - Date.now()
+			if (remainingMs <= 0) {
+				return false
+			}
+			const jitterMs =
+				retryMinDelayMs +
+				Math.floor(Math.random() * (retryMaxDelayMs - retryMinDelayMs + 1))
+			await this.delay(Math.min(jitterMs, remainingMs))
+		}
+		return true
+	}
+
+	private async renewLock(key: string, token: string, ttlMs: number): Promise<boolean> {
+		const result = await (await this.getRedis()).eval(
+			"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end",
+			1,
+			key,
+			token,
+			String(ttlMs)
+		)
+		return result === 1
+	}
+
+	private async releaseLock(key: string, token: string): Promise<void> {
+		await (await this.getRedis()).eval(
+			"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end",
+			1,
+			key,
+			token
+		)
+	}
+
+	private async deleteAggregateStateIfLockOwned(
+		lockKey: string,
+		stateKey: string,
+		legacyStateKey: string,
+		token: string
+	): Promise<boolean> {
+		const result = await (await this.getRedis()).eval(
+			"if redis.call('get', KEYS[1]) ~= ARGV[1] then return -1 end redis.call('del', KEYS[2], KEYS[3]) return 1",
+			3,
+			lockKey,
+			stateKey,
+			legacyStateKey,
+			token
+		)
+		return result === 1
 	}
 
 	private buildKey(aggregateKey: string): string {
+		return `plugin_dingtalk:trigger:aggregate:${aggregateKey}`
+	}
+
+	private buildLegacyKey(aggregateKey: string): string {
 		return `dingtalk:trigger:aggregate:${aggregateKey}`
+	}
+
+	private buildLockKey(aggregateKey: string): string {
+		return `plugin_dingtalk:lock:inbound:${aggregateKey}`
+	}
+
+	private async delay(milliseconds: number): Promise<void> {
+		await new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
 	}
 }

--- a/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger-aggregation.types.ts
+++ b/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger-aggregation.types.ts
@@ -27,6 +27,8 @@ export interface DingTalkTriggerAggregationState {
 	conversationUserKey: string
 	xpertId: string
 	version: number
+	dispatchMessageId: string
+	deliveryStatus?: 'pending' | 'dispatching' | 'dispatched'
 	inputParts: string[]
 	files?: DingTalkInboundFile[]
 	lastMessageAt: number

--- a/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger.strategy.spec.ts
+++ b/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger.strategy.spec.ts
@@ -1,6 +1,7 @@
 jest.mock('@xpert-ai/plugin-sdk', () => ({
 	HANDOFF_PERMISSION_SERVICE_TOKEN: 'HANDOFF_PERMISSION_SERVICE_TOKEN',
 	INTEGRATION_PERMISSION_SERVICE_TOKEN: 'INTEGRATION_PERMISSION_SERVICE_TOKEN',
+	MANAGED_QUEUE_SERVICE_TOKEN: 'MANAGED_QUEUE_SERVICE_TOKEN',
 	WorkflowTriggerStrategy: () => () => undefined,
 	defineChannelMessageType: (...parts: Array<string | number>) => parts.join('.'),
 	RequestContext: {
@@ -40,6 +41,15 @@ describe('DingTalkTriggerStrategy', () => {
 			])
 		)
 		const aggregationStates = new Map<string, any>()
+		let lockedAggregateKey: string | undefined
+		const aggregateLockLease = {
+			ensureOwned: jest.fn().mockResolvedValue(undefined),
+			clearStateIfOwned: jest.fn().mockImplementation(async () => {
+				if (lockedAggregateKey) {
+					aggregationStates.delete(lockedAggregateKey)
+				}
+			})
+		}
 		const dispatchService = {
 			buildDispatchMessage: jest.fn().mockResolvedValue({
 				id: 'handoff-id'
@@ -55,7 +65,17 @@ describe('DingTalkTriggerStrategy', () => {
 			}),
 			clear: jest.fn().mockImplementation(async (key: string) => {
 				aggregationStates.delete(key)
-			})
+			}),
+			withAggregateLock: jest.fn(
+				async (key: string, callback: (lease: typeof aggregateLockLease) => Promise<unknown>) => {
+					lockedAggregateKey = key
+					try {
+						return await callback(aggregateLockLease)
+					} finally {
+						lockedAggregateKey = undefined
+					}
+				}
+			)
 		}
 		const handoffPermissionService = {
 			enqueue: jest.fn().mockResolvedValue({
@@ -143,9 +163,11 @@ describe('DingTalkTriggerStrategy', () => {
 			strategy,
 			dispatchService,
 			aggregationService,
+			aggregateLockLease,
 			handoffPermissionService,
 			bindingRepository,
-			persistedBindings
+			persistedBindings,
+			aggregationStates
 		}
 	}
 
@@ -366,5 +388,254 @@ describe('DingTalkTriggerStrategy', () => {
 			}
 		)
 		expect(dispatchService.enqueueDispatch).not.toHaveBeenCalled()
+	})
+
+	it('flushes and clears one aggregate while holding the same lock used by updates', async () => {
+		const { strategy, aggregationService, aggregateLockLease, dispatchService, handoffPermissionService } =
+			createStrategy({
+				dbBindings: [['integration-1', { xpertId: 'xpert-1', summaryWindowSeconds: 3 }]]
+			})
+
+		await strategy.handleInboundMessage({
+			integrationId: 'integration-1',
+			input: '看一下文件',
+			files: [{ fileAssetId: 'file-asset-1', originalName: 'report.pdf' }],
+			dingtalkMessage: {
+				integrationId: 'integration-1',
+				chatId: 'chat-1',
+				dingtalkUserId: 'user-1',
+				senderOpenId: 'sender-1',
+				chatType: 'private'
+			} as any,
+			conversationUserKey: 'integration-1:chat-1:sender-1'
+		})
+
+		const flushPayload = handoffPermissionService.enqueue.mock.calls[0][0].payload
+		await expect(strategy.flushBufferedConversation(flushPayload)).resolves.toBe(true)
+
+		expect(aggregationService.withAggregateLock).toHaveBeenCalledTimes(2)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				dispatchMessageId: expect.stringMatching(/^dingtalk-chat-aggregate-/),
+				input: '看一下文件',
+				files: [{ fileAssetId: 'file-asset-1', originalName: 'report.pdf' }]
+			})
+		)
+		expect(aggregateLockLease.clearStateIfOwned).toHaveBeenCalledTimes(1)
+	})
+
+	it('merges separate file and text events and ignores the stale first flush', async () => {
+		const { strategy, aggregateLockLease, dispatchService, handoffPermissionService } = createStrategy({
+			dbBindings: [['integration-1', { xpertId: 'xpert-1', summaryWindowSeconds: 3 }]]
+		})
+		const message = {
+			integrationId: 'integration-1',
+			chatId: 'chat-1',
+			dingtalkUserId: 'user-1',
+			senderOpenId: 'sender-1',
+			chatType: 'private'
+		} as any
+		const conversationUserKey = 'integration-1:chat-1:sender-1'
+
+		await strategy.handleInboundMessage({
+			integrationId: 'integration-1',
+			files: [{ fileAssetId: 'file-asset-1', originalName: 'report.pdf' }],
+			dingtalkMessage: message,
+			conversationUserKey
+		})
+		await strategy.handleInboundMessage({
+			integrationId: 'integration-1',
+			input: '看一下文件内容',
+			dingtalkMessage: message,
+			conversationUserKey
+		})
+
+		const firstFlush = handoffPermissionService.enqueue.mock.calls[0][0].payload
+		const latestFlush = handoffPermissionService.enqueue.mock.calls[1][0].payload
+		await expect(strategy.flushBufferedConversation(firstFlush)).resolves.toBe(false)
+		await expect(strategy.flushBufferedConversation(latestFlush)).resolves.toBe(true)
+
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				input: '看一下文件内容',
+				files: [{ fileAssetId: 'file-asset-1', originalName: 'report.pdf' }]
+			})
+		)
+		expect(aggregateLockLease.clearStateIfOwned).toHaveBeenCalledTimes(1)
+		for (const [message] of handoffPermissionService.enqueue.mock.calls) {
+			expect(message.maxAttempts).toBe(3)
+		}
+	})
+
+	it('retries a transient flush enqueue with the same handoff message', async () => {
+		const { strategy, handoffPermissionService } = createStrategy({
+			dbBindings: [['integration-1', { xpertId: 'xpert-1', summaryWindowSeconds: 3 }]]
+		})
+		handoffPermissionService.enqueue
+			.mockRejectedValueOnce(new Error('temporary enqueue failure'))
+			.mockResolvedValueOnce({ id: 'flush-message-id' })
+
+		await expect(
+			strategy.handleInboundMessage({
+				integrationId: 'integration-1',
+				input: '看一下文件',
+				dingtalkMessage: {
+					integrationId: 'integration-1',
+					chatId: 'chat-1',
+					dingtalkUserId: 'user-1',
+					senderOpenId: 'sender-1',
+					chatType: 'private'
+				} as any,
+				conversationUserKey: 'integration-1:chat-1:sender-1'
+			})
+		).resolves.toBe(true)
+
+		expect(handoffPermissionService.enqueue).toHaveBeenCalledTimes(2)
+		expect(handoffPermissionService.enqueue.mock.calls[1][0]).toBe(
+			handoffPermissionService.enqueue.mock.calls[0][0]
+		)
+		expect(handoffPermissionService.enqueue.mock.calls[0][0].maxAttempts).toBe(3)
+	})
+
+	it('dispatches synchronously when delayed flush scheduling is exhausted', async () => {
+		const { strategy, dispatchService, handoffPermissionService, aggregationStates } =
+			createStrategy({
+				dbBindings: [['integration-1', { xpertId: 'xpert-1', summaryWindowSeconds: 3 }]]
+			})
+		handoffPermissionService.enqueue.mockRejectedValue(new Error('queue unavailable'))
+
+		await expect(
+			strategy.handleInboundMessage({
+				integrationId: 'integration-1',
+				input: '立即降级派发',
+				dingtalkMessage: {
+					integrationId: 'integration-1',
+					chatId: 'chat-1',
+					dingtalkUserId: 'user-1',
+					senderOpenId: 'sender-1',
+					chatType: 'private'
+				} as any,
+				conversationUserKey: 'integration-1:chat-1:sender-1'
+			})
+		).resolves.toBe(true)
+
+		expect(handoffPermissionService.enqueue).toHaveBeenCalledTimes(3)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				input: '立即降级派发'
+			})
+		)
+		expect(aggregationStates.has('integration-1:chat-1:sender-1')).toBe(false)
+	})
+
+	it('does not retry dispatch when both the dispatched marker and aggregate cleanup fail', async () => {
+		const {
+			strategy,
+			aggregationService,
+			aggregateLockLease,
+			dispatchService,
+			handoffPermissionService,
+			aggregationStates
+		} = createStrategy({
+			dbBindings: [['integration-1', { xpertId: 'xpert-1', summaryWindowSeconds: 3 }]]
+		})
+		await strategy.handleInboundMessage({
+			integrationId: 'integration-1',
+			input: '只派发一次',
+			dingtalkMessage: {
+				integrationId: 'integration-1',
+				chatId: 'chat-1',
+				dingtalkUserId: 'user-1',
+				senderOpenId: 'sender-1',
+				chatType: 'private'
+			} as any,
+			conversationUserKey: 'integration-1:chat-1:sender-1'
+		})
+		const flushPayload = handoffPermissionService.enqueue.mock.calls[0][0].payload
+		aggregationService.save
+			.mockImplementationOnce(async (state: any) => {
+				aggregationStates.set(state.aggregateKey, state)
+			})
+			.mockRejectedValueOnce(new Error('marker save failed'))
+			.mockRejectedValueOnce(new Error('marker save failed'))
+			.mockRejectedValueOnce(new Error('marker save failed'))
+		aggregateLockLease.clearStateIfOwned.mockRejectedValue(new Error('aggregate clear failed'))
+
+		await expect(strategy.flushBufferedConversation(flushPayload)).resolves.toBe(true)
+		await expect(strategy.flushBufferedConversation(flushPayload)).resolves.toBe(true)
+
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+		expect(aggregationService.save).toHaveBeenCalledTimes(5)
+		expect(aggregateLockLease.clearStateIfOwned).toHaveBeenCalledTimes(2)
+		expect(aggregationStates.get('integration-1:chat-1:sender-1')).toEqual(
+			expect.objectContaining({
+				deliveryStatus: 'dispatching',
+				dispatchMessageId: expect.stringMatching(/^dingtalk-chat-aggregate-/)
+			})
+		)
+	})
+
+	it('does not merge an already dispatched aggregate after cleanup fails', async () => {
+		const {
+			strategy,
+			aggregateLockLease,
+			dispatchService,
+			handoffPermissionService,
+			aggregationStates
+		} = createStrategy({
+			dbBindings: [['integration-1', { xpertId: 'xpert-1', summaryWindowSeconds: 3 }]]
+		})
+		const dingtalkMessage = {
+			integrationId: 'integration-1',
+			chatId: 'chat-1',
+			dingtalkUserId: 'user-1',
+			senderOpenId: 'sender-1',
+			chatType: 'private'
+		} as any
+		const conversationUserKey = 'integration-1:chat-1:sender-1'
+
+		await strategy.handleInboundMessage({
+			integrationId: 'integration-1',
+			input: '第一条',
+			files: [{ fileAssetId: 'file-asset-1', originalName: 'report.pdf' }],
+			dingtalkMessage,
+			conversationUserKey
+		})
+
+		const firstFlushMessage = handoffPermissionService.enqueue.mock.calls[0][0]
+		aggregateLockLease.clearStateIfOwned.mockRejectedValueOnce(new Error('aggregate clear failed'))
+
+		await expect(strategy.flushBufferedConversation(firstFlushMessage.payload)).resolves.toBe(true)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+		expect(aggregationStates.get(conversationUserKey)).toEqual(
+			expect.objectContaining({
+				deliveryStatus: 'dispatched',
+				inputParts: ['第一条']
+			})
+		)
+
+		await expect(
+			strategy.flushBufferedConversation(firstFlushMessage.payload)
+		).resolves.toBe(false)
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(1)
+
+		await strategy.handleInboundMessage({
+			integrationId: 'integration-1',
+			input: '第二条',
+			dingtalkMessage,
+			conversationUserKey
+		})
+		const secondFlushMessage = handoffPermissionService.enqueue.mock.calls[1][0]
+		await expect(strategy.flushBufferedConversation(secondFlushMessage.payload)).resolves.toBe(true)
+
+		expect(dispatchService.enqueueDispatch).toHaveBeenCalledTimes(2)
+		expect(dispatchService.enqueueDispatch).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				input: '第二条',
+				files: []
+			})
+		)
 	})
 })

--- a/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger.strategy.ts
+++ b/xpertai/integrations/dingtalk/src/lib/workflow/dingtalk-trigger.strategy.ts
@@ -24,7 +24,10 @@ import { ChatDingTalkMessage } from '../message.js'
 import { DINGTALK_PLUGIN_CONTEXT } from '../tokens.js'
 import { DINGTALK_INTEGRATION_SELECT_URL, type DingTalkInboundFile, iconImage } from '../types.js'
 import { DingTalkTriggerBindingEntity } from '../entities/dingtalk-trigger-binding.entity.js'
-import { DingTalkTriggerAggregationService } from './dingtalk-trigger-aggregation.service.js'
+import {
+	type DingTalkAggregateLockLease,
+	DingTalkTriggerAggregationService
+} from './dingtalk-trigger-aggregation.service.js'
 import {
 	DINGTALK_TRIGGER_FLUSH_MESSAGE_TYPE,
 	DingTalkTriggerAggregationState,
@@ -34,6 +37,9 @@ import { DingTalkTrigger, TDingTalkTriggerConfig } from './dingtalk-trigger.type
 
 const DEFAULT_SESSION_TIMEOUT_SECONDS = 3600
 const DEFAULT_SUMMARY_WINDOW_SECONDS = 0
+const FLUSH_ENQUEUE_MAX_ATTEMPTS = 3
+const FLUSH_ENQUEUE_RETRY_DELAY_MS = 50
+const DISPATCHED_MARKER_MAX_ATTEMPTS = 3
 
 @Injectable()
 @WorkflowTriggerStrategy(DingTalkTrigger)
@@ -287,7 +293,9 @@ export class DingTalkTriggerStrategy implements IWorkflowTriggerStrategy<TDingTa
 		if (!aggregateKey) {
 			return
 		}
-		await this.aggregationService.clear(aggregateKey)
+		await this.aggregationService.withAggregateLock(aggregateKey, async (lease) => {
+			await lease.clearStateIfOwned()
+		})
 	}
 
 	async handleInboundMessage(params: {
@@ -339,52 +347,77 @@ export class DingTalkTriggerStrategy implements IWorkflowTriggerStrategy<TDingTa
 			return false
 		}
 
-		const currentState = await this.aggregationService.get(aggregateKey)
-		const sameRoutingTarget =
-			currentState?.integrationId === params.integrationId && currentState?.xpertId === binding.xpertId
-		const nextVersion = (currentState?.version ?? 0) + 1
-		const aggregateState: DingTalkTriggerAggregationState = {
-			aggregateKey,
-			integrationId: params.integrationId,
-			conversationUserKey: aggregateKey,
-			xpertId: binding.xpertId,
-			version: nextVersion,
-			inputParts: [...(sameRoutingTarget ? currentState?.inputParts ?? [] : []), params.input || ''],
-			files: [...(sameRoutingTarget ? currentState?.files ?? [] : []), ...(params.files ?? [])],
-			lastMessageAt: Date.now(),
-			conversationId: params.conversationId ?? (sameRoutingTarget ? currentState?.conversationId : undefined),
-			tenantId: params.tenantId,
-			organizationId: params.organizationId,
-			executorUserId: params.executorUserId,
-			endUserId: params.endUserId,
-			latestMessage: {
-				integrationId: params.dingtalkMessage.integrationId,
+		return this.aggregationService.withAggregateLock(aggregateKey, async (lease) => {
+			const currentState = await this.aggregationService.get(aggregateKey)
+			const sameRoutingTarget =
+				currentState?.integrationId === params.integrationId && currentState?.xpertId === binding.xpertId
+			const canMergeCurrent =
+				sameRoutingTarget &&
+				(currentState?.deliveryStatus === undefined || currentState.deliveryStatus === 'pending')
+			const nextVersion = (currentState?.version ?? 0) + 1
+			const aggregateState: DingTalkTriggerAggregationState = {
+				aggregateKey,
+				integrationId: params.integrationId,
+				conversationUserKey: aggregateKey,
+				xpertId: binding.xpertId,
+				version: nextVersion,
+				dispatchMessageId: `dingtalk-chat-aggregate-${randomUUID()}`,
+				deliveryStatus: 'pending',
+				inputParts: [
+					...(canMergeCurrent ? currentState?.inputParts ?? [] : []),
+					...(params.input ? [params.input] : [])
+				],
+				files: [...(canMergeCurrent ? currentState?.files ?? [] : []), ...(params.files ?? [])],
+				lastMessageAt: Date.now(),
+				conversationId: params.conversationId ?? (sameRoutingTarget ? currentState?.conversationId : undefined),
+				tenantId: params.tenantId,
 				organizationId: params.organizationId,
-				chatId: params.dingtalkMessage.chatId,
-				userId: params.dingtalkMessage.dingtalkUserId,
-				senderOpenId: params.dingtalkMessage.senderOpenId,
-				senderRecipient: params.dingtalkMessage.senderRecipient,
-				chatType: params.dingtalkMessage.chatType,
-				sessionWebhook: params.dingtalkMessage.sessionWebhook,
-				robotCode: params.dingtalkMessage.robotCode,
-				language: params.dingtalkMessage.language
+				executorUserId: params.executorUserId,
+				endUserId: params.endUserId,
+				latestMessage: {
+					integrationId: params.dingtalkMessage.integrationId,
+					organizationId: params.organizationId,
+					chatId: params.dingtalkMessage.chatId,
+					userId: params.dingtalkMessage.dingtalkUserId,
+					senderOpenId: params.dingtalkMessage.senderOpenId,
+					senderRecipient: params.dingtalkMessage.senderRecipient,
+					chatType: params.dingtalkMessage.chatType,
+					sessionWebhook: params.dingtalkMessage.sessionWebhook,
+					robotCode: params.dingtalkMessage.robotCode,
+					language: params.dingtalkMessage.language
+				}
 			}
-		}
 
-		const ttlSeconds = Math.max(
-			DEFAULT_SESSION_TIMEOUT_SECONDS,
-			this.normalizePositiveSeconds(binding.sessionTimeoutSeconds, DEFAULT_SESSION_TIMEOUT_SECONDS),
-			summaryWindowSeconds * 3
-		)
-		await this.aggregationService.save(aggregateState, ttlSeconds)
-		await this.handoffPermissionService.enqueue(this.buildFlushMessage(aggregateState), {
-			delayMs: summaryWindowSeconds * 1000
+			const ttlSeconds = Math.max(
+				DEFAULT_SESSION_TIMEOUT_SECONDS,
+				this.normalizePositiveSeconds(binding.sessionTimeoutSeconds, DEFAULT_SESSION_TIMEOUT_SECONDS),
+				summaryWindowSeconds * 3
+			)
+			await lease.ensureOwned()
+			await this.aggregationService.save(aggregateState, ttlSeconds)
+			const flushScheduled = await this.enqueueFlushMessage(
+				aggregateState,
+				summaryWindowSeconds * 1000
+			)
+			if (!flushScheduled) {
+				this.logger.warn(
+					`[dingtalk-trigger] flush scheduling exhausted; dispatching synchronously aggregateKey=${aggregateKey} version=${nextVersion}`
+				)
+				await this.flushBufferedConversationUnderLock(
+					aggregateKey,
+					{
+						aggregateKey,
+						version: nextVersion
+					},
+					lease
+				)
+			}
+
+			this.logger.debug(
+				`[dingtalk-trigger] buffered inbound integrationId=${params.integrationId} xpertId=${binding.xpertId} aggregateKey=${aggregateKey} version=${nextVersion}`
+			)
+			return true
 		})
-
-		this.logger.debug(
-			`[dingtalk-trigger] buffered inbound integrationId=${params.integrationId} xpertId=${binding.xpertId} aggregateKey=${aggregateKey} version=${nextVersion}`
-		)
-		return true
 	}
 
 	async flushBufferedConversation(payload: DingTalkTriggerFlushPayload): Promise<boolean> {
@@ -393,46 +426,164 @@ export class DingTalkTriggerStrategy implements IWorkflowTriggerStrategy<TDingTa
 			return false
 		}
 
+		return this.aggregationService.withAggregateLock(aggregateKey, (lease) =>
+			this.flushBufferedConversationUnderLock(aggregateKey, payload, lease)
+		)
+	}
+
+	private async flushBufferedConversationUnderLock(
+		aggregateKey: string,
+		payload: DingTalkTriggerFlushPayload,
+		lease: DingTalkAggregateLockLease
+	): Promise<boolean> {
 		const state = await this.aggregationService.get(aggregateKey)
-		if (!state || state.version !== payload.version) {
+		if (
+			!state ||
+			state.version !== payload.version ||
+			state.deliveryStatus === 'dispatched'
+		) {
 			return false
 		}
 
-		await this.dispatchInboundMessage({
-			integrationId: state.integrationId,
-			xpertId: state.xpertId,
-			dispatchMode: `buffered version=${state.version}`,
-			dispatchPayload: {
-				xpertId: state.xpertId,
-				input: state.inputParts.join('\n'),
-				files: state.files,
-				dingtalkMessage: new ChatDingTalkMessage(
-					{
-						integrationId: state.latestMessage.integrationId,
-						organizationId: state.latestMessage.organizationId,
-						preferLanguage: state.latestMessage.language,
-						userId: state.latestMessage.userId,
-						senderOpenId: state.latestMessage.senderOpenId,
-						senderRecipient: state.latestMessage.senderRecipient,
-						chatType: state.latestMessage.chatType,
-						sessionWebhook: state.latestMessage.sessionWebhook,
-						robotCode: state.latestMessage.robotCode,
-						chatId: state.latestMessage.chatId,
-						dingtalkChannel: this.dingtalkChannel
-					},
-					{
-						text: state.inputParts.join('\n'),
-						status: 'thinking',
-						language: state.latestMessage.language
-					}
-				),
-				conversationId: state.conversationId,
-				conversationUserKey: state.conversationUserKey
+		if (state.deliveryStatus === 'dispatching') {
+			try {
+				await lease.clearStateIfOwned()
+			} catch (error) {
+				this.logger.warn(
+					`[dingtalk-trigger] dispatching aggregate cleanup failed aggregateKey=${aggregateKey} version=${state.version}: ${this.getErrorMessage(error)}`
+				)
 			}
-		})
+			return true
+		}
 
-		await this.aggregationService.clear(aggregateKey)
+		await lease.ensureOwned()
+		const dispatchMessageId =
+			state.dispatchMessageId || `dingtalk-chat-aggregate-${randomUUID()}`
+		const dispatchingState: DingTalkTriggerAggregationState = {
+			...state,
+			dispatchMessageId,
+			deliveryStatus: 'dispatching'
+		}
+		await this.aggregationService.save(dispatchingState)
+
+		try {
+			await this.dispatchInboundMessage({
+				integrationId: state.integrationId,
+				xpertId: state.xpertId,
+				dispatchMode: `buffered version=${state.version}`,
+				dispatchPayload: {
+					xpertId: state.xpertId,
+					dispatchMessageId,
+					input: state.inputParts.join('\n'),
+					files: state.files,
+					dingtalkMessage: new ChatDingTalkMessage(
+						{
+							integrationId: state.latestMessage.integrationId,
+							organizationId: state.latestMessage.organizationId,
+							preferLanguage: state.latestMessage.language,
+							userId: state.latestMessage.userId,
+							senderOpenId: state.latestMessage.senderOpenId,
+							senderRecipient: state.latestMessage.senderRecipient,
+							chatType: state.latestMessage.chatType,
+							sessionWebhook: state.latestMessage.sessionWebhook,
+							robotCode: state.latestMessage.robotCode,
+							chatId: state.latestMessage.chatId,
+							dingtalkChannel: this.dingtalkChannel
+						},
+						{
+							text: state.inputParts.join('\n'),
+							status: 'thinking',
+							language: state.latestMessage.language
+						}
+					),
+					conversationId: state.conversationId,
+					conversationUserKey: state.conversationUserKey
+				}
+			})
+		} catch (error) {
+			try {
+				await lease.ensureOwned()
+				await this.aggregationService.save({
+					...state,
+					deliveryStatus: 'pending'
+				})
+			} catch (restoreError) {
+				this.logger.error(
+					`[dingtalk-trigger] aggregate pending restore failed aggregateKey=${aggregateKey} version=${state.version}: ${this.getErrorMessage(restoreError)}`
+				)
+			}
+			throw error
+		}
+
+		await lease.ensureOwned()
+		const dispatchedState: DingTalkTriggerAggregationState = {
+			...dispatchingState,
+			deliveryStatus: 'dispatched'
+		}
+		let markerError: unknown
+		let markerSaved = false
+		for (let attempt = 1; attempt <= DISPATCHED_MARKER_MAX_ATTEMPTS; attempt += 1) {
+			try {
+				await lease.ensureOwned()
+				await this.aggregationService.save(dispatchedState)
+				markerSaved = true
+				break
+			} catch (error) {
+				markerError = error
+				if (attempt < DISPATCHED_MARKER_MAX_ATTEMPTS) {
+					await this.delay(FLUSH_ENQUEUE_RETRY_DELAY_MS * attempt)
+				}
+			}
+		}
+		if (!markerSaved) {
+			this.logger.error(
+				`[dingtalk-trigger] dispatched marker save failed aggregateKey=${aggregateKey} version=${state.version}: ${this.getErrorMessage(markerError)}`
+			)
+			try {
+				await lease.clearStateIfOwned()
+			} catch (clearError) {
+				this.logger.error(
+					`[dingtalk-trigger] aggregate cleanup also failed after dispatch aggregateKey=${aggregateKey} version=${state.version}: ${this.getErrorMessage(clearError)}`
+				)
+			}
+			return true
+		}
+		try {
+			await lease.clearStateIfOwned()
+		} catch (error) {
+			this.logger.warn(
+				`[dingtalk-trigger] dispatched aggregate cleanup failed aggregateKey=${aggregateKey} version=${state.version}: ${this.getErrorMessage(error)}`
+			)
+		}
 		return true
+	}
+
+	private async enqueueFlushMessage(
+		state: DingTalkTriggerAggregationState,
+		delayMs: number
+	): Promise<boolean> {
+		const message = this.buildFlushMessage(state)
+		let lastError: unknown
+
+		for (let attempt = 1; attempt <= FLUSH_ENQUEUE_MAX_ATTEMPTS; attempt += 1) {
+			try {
+				await this.handoffPermissionService.enqueue(message, { delayMs })
+				return true
+			} catch (error) {
+				lastError = error
+				if (attempt < FLUSH_ENQUEUE_MAX_ATTEMPTS) {
+					this.logger.warn(
+						`[dingtalk-trigger] flush enqueue failed aggregateKey=${state.aggregateKey} version=${state.version} attempt=${attempt}`
+					)
+					await this.delay(FLUSH_ENQUEUE_RETRY_DELAY_MS * attempt)
+				}
+			}
+		}
+
+		this.logger.error(
+			`[dingtalk-trigger] flush enqueue exhausted aggregateKey=${state.aggregateKey} version=${state.version}: ${this.getErrorMessage(lastError)}`
+		)
+		return false
 	}
 
 	private buildFlushMessage(
@@ -446,7 +597,7 @@ export class DingTalkTriggerStrategy implements IWorkflowTriggerStrategy<TDingTa
 			sessionKey: state.aggregateKey,
 			businessKey: state.aggregateKey,
 			attempt: 1,
-			maxAttempts: 1,
+			maxAttempts: 3,
 			enqueuedAt: Date.now(),
 			traceId: `${state.aggregateKey}:${state.version}`,
 			payload: {
@@ -484,6 +635,20 @@ export class DingTalkTriggerStrategy implements IWorkflowTriggerStrategy<TDingTa
 			return Math.floor(value)
 		}
 		return defaultValue
+	}
+
+	private async delay(milliseconds: number): Promise<void> {
+		await new Promise<void>((resolve) => setTimeout(resolve, milliseconds))
+	}
+
+	private getErrorMessage(error: unknown): string {
+		if (error instanceof Error) {
+			return error.message
+		}
+		if (typeof error === 'string') {
+			return error
+		}
+		return 'unknown_error'
 	}
 
 	private async dispatchInboundMessage(params: {


### PR DESCRIPTION
## Summary

- Receive quoted DingTalk files, persist them into the workspace, and aggregate a file with its follow-up text.
- Send supported document files and image media through their corresponding DingTalk message channels.
- Emit intermediate assistant output at tool-call boundaries and attach the terminal card to the final segment.
- Harden trigger aggregation with a distributed lease and idempotent dispatch state.
- Remove obsolete timed-streaming configuration and callback state.

## Root cause

The DingTalk integration had separate gaps in its inbound media, outbound media, and streaming paths:

- quoted files and follow-up text could arrive as separate callbacks without a stable aggregation lifecycle;
- image media was rejected by the generic file-only sending path;
- intermediate output segmentation did not follow tool-call boundaries;
- a failure after dispatch but before cleanup could leave an aggregate eligible for duplicate delivery;
- stale timed-streaming options no longer matched the current callback flow.

## Validation

- DingTalk Jest suite: 20 suites passed, 118 tests passed.
- TypeScript library build passed with `tsc --build tsconfig.lib.json`.
- Plugin lifecycle validation passed through `plugin-dev-harness`.
- `git diff --check origin/main...HEAD` passed.
