### PR TITLE
fix(office-editor): preserve Excel references and workspace scope

### DIFF
--- a/xpertai/.changeset/calm-otters-fix-excel-scope.md
+++ b/xpertai/.changeset/calm-otters-fix-excel-scope.md
@@ -1,0 +1,7 @@
+---
+'@xpert-ai/plugin-office-editor': patch
+---
+
+Keep renamed XLSX worksheets valid by rewriting dependent cell formulas and defined names, while rejecting unsupported 3D references instead of producing broken workbooks.
+
+Preserve the persisted workspace storage scope for subsequent Excel edits and Workbench saves so documents opened from another assistant do not move file versions across Xpert-owned artifact scopes.

--- a/xpertai/apps/office-editor/src/lib/excel-automation.service.spec.ts
+++ b/xpertai/apps/office-editor/src/lib/excel-automation.service.spec.ts
@@ -43,6 +43,59 @@ describe('Excel automation engine', () => {
     }])).toThrow(/last Excel sheet/i)
   })
 
+  it('rewrites cell formulas and defined names when a referenced sheet is renamed', () => {
+    const XLSX = requireFromHere('xlsx') as any
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet([[10]]), 'OldName')
+    const summary = XLSX.utils.aoa_to_sheet([[]])
+    summary.A1 = { t: 'n', f: 'SUM(OldName!A1, 1)', v: 11 }
+    summary.A2 = { t: 's', f: '="OldName!A1"', v: 'OldName!A1' }
+    summary.A3 = { t: 'n', f: "SUM('OldName'!A1, 2)", v: 12 }
+    summary['!ref'] = 'A1:A3'
+    XLSX.utils.book_append_sheet(workbook, summary, 'Summary')
+    workbook.Workbook = {
+      ...(workbook.Workbook ?? {}),
+      Names: [
+        { Name: 'InputValue', Ref: 'OldName!$A$1' },
+        { Name: 'ExternalValue', Ref: "'[Other.xlsx]OldName'!$A$1" }
+      ]
+    }
+    const source = Buffer.from(XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }))
+
+    const edited = applyExcelOperations(source, [{
+      type: 'rename_sheet',
+      sheetName: 'OldName',
+      newSheetName: "New 'Name"
+    }])
+    const result = XLSX.read(edited.buffer, { type: 'buffer', cellFormula: true })
+
+    expect(result.Sheets.Summary.A1.f).toBe("SUM('New ''Name'!A1, 1)")
+    expect(result.Sheets.Summary.A2.f).toBe('="OldName!A1"')
+    expect(result.Sheets.Summary.A3.f).toBe("SUM('New ''Name'!A1, 2)")
+    expect(result.Workbook.Names).toEqual(expect.arrayContaining([
+      expect.objectContaining({ Name: 'InputValue', Ref: "'New ''Name'!$A$1" }),
+      expect.objectContaining({ Name: 'ExternalValue', Ref: "'[Other.xlsx]OldName'!$A$1" })
+    ]))
+  })
+
+  it('rejects sheet renames used by unsupported 3D formula references', () => {
+    const XLSX = requireFromHere('xlsx') as any
+    const workbook = XLSX.utils.book_new()
+    XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet([[1]]), 'Data')
+    XLSX.utils.book_append_sheet(workbook, XLSX.utils.aoa_to_sheet([[2]]), 'Other')
+    const summary = XLSX.utils.aoa_to_sheet([[]])
+    summary.A1 = { t: 'n', f: "SUM('Data':Other!A1)", v: 3 }
+    summary['!ref'] = 'A1'
+    XLSX.utils.book_append_sheet(workbook, summary, 'Summary')
+    const source = Buffer.from(XLSX.write(workbook, { type: 'buffer', bookType: 'xlsx' }))
+
+    expect(() => applyExcelOperations(source, [{
+      type: 'rename_sheet',
+      sheetName: 'Data',
+      newSheetName: 'Inputs'
+    }])).toThrow(/3D formula reference/i)
+  })
+
   it('exports a Univer spreadsheet snapshot to a downloadable XLSX buffer', () => {
     const buffer = exportSpreadsheetSnapshotToXlsx({
       sheetOrder: ['sheet-1'],

--- a/xpertai/apps/office-editor/src/lib/excel-automation.service.ts
+++ b/xpertai/apps/office-editor/src/lib/excel-automation.service.ts
@@ -136,6 +136,7 @@ export function applyExcelOperations(buffer: Buffer, operations: ExcelAutomation
       if (currentName !== nextName && workbook.Sheets[nextName]) {
         throw new BadRequestException(`Excel sheet "${nextName}" already exists.`)
       }
+      rewriteWorkbookSheetReferences(workbook, currentName, nextName)
       const index = workbook.SheetNames.indexOf(currentName)
       workbook.SheetNames[index] = nextName
       delete workbook.Sheets[currentName]
@@ -410,6 +411,176 @@ function preserveCellPresentation(cell: any) {
     ...(cell.s !== undefined ? { s: cell.s } : {}),
     ...(cell.z !== undefined ? { z: cell.z } : {})
   }
+}
+
+function rewriteWorkbookSheetReferences(
+  workbook: {
+    SheetNames: string[]
+    Sheets: Record<string, Record<string, unknown>>
+    Workbook?: {
+      Names?: Array<{ Ref?: unknown }>
+    }
+  },
+  currentName: string,
+  nextName: string
+) {
+  if (currentName === nextName) {
+    return
+  }
+
+  for (const sheetName of workbook.SheetNames) {
+    const worksheet = workbook.Sheets[sheetName]
+    for (const [address, cell] of Object.entries(worksheet ?? {})) {
+      if (address.startsWith('!') || !isUnknownRecord(cell) || typeof cell.f !== 'string') {
+        continue
+      }
+      cell.f = rewriteSheetReferenceExpression(cell.f, currentName, nextName)
+    }
+  }
+
+  for (const definedName of workbook.Workbook?.Names ?? []) {
+    if (typeof definedName.Ref === 'string') {
+      definedName.Ref = rewriteSheetReferenceExpression(definedName.Ref, currentName, nextName)
+    }
+  }
+}
+
+function rewriteSheetReferenceExpression(expression: string, currentName: string, nextName: string) {
+  const currentNameLower = currentName.toLowerCase()
+  const quotedNextName = quoteExcelSheetName(nextName)
+  let output = ''
+  let index = 0
+
+  while (index < expression.length) {
+    const character = expression[index]
+
+    if (character === '"') {
+      const end = copyExcelStringLiteral(expression, index)
+      output += expression.slice(index, end)
+      index = end
+      continue
+    }
+
+    if (character === "'") {
+      const quotedReference = readQuotedSheetReference(expression, index)
+      if (quotedReference) {
+        const previous = index > 0 ? expression[index - 1] : ''
+        if (
+          isThreeDimensionalSheetReference(quotedReference.sheetName, currentNameLower) ||
+          (
+            quotedReference.sheetName.toLowerCase() === currentNameLower &&
+            (previous === ':' || quotedReference.separator === ':')
+          )
+        ) {
+          throw unsupportedThreeDimensionalRename(currentName)
+        }
+        output +=
+          quotedReference.separator === '!' &&
+          quotedReference.sheetName.toLowerCase() === currentNameLower
+          ? `${quotedNextName}!`
+          : expression.slice(index, quotedReference.end)
+        index = quotedReference.end
+        continue
+      }
+    }
+
+    if (matchesUnquotedSheetName(expression, index, currentName)) {
+      const previous = index > 0 ? expression[index - 1] : ''
+      const next = expression[index + currentName.length] ?? ''
+      if (previous === ':' || next === ':') {
+        throw unsupportedThreeDimensionalRename(currentName)
+      }
+      if (next === '!') {
+        output += `${quotedNextName}!`
+        index += currentName.length + 1
+        continue
+      }
+    }
+
+    output += character
+    index += 1
+  }
+
+  return output
+}
+
+function copyExcelStringLiteral(expression: string, start: number) {
+  let index = start + 1
+  while (index < expression.length) {
+    if (expression[index] !== '"') {
+      index += 1
+      continue
+    }
+    if (expression[index + 1] === '"') {
+      index += 2
+      continue
+    }
+    return index + 1
+  }
+  return expression.length
+}
+
+function readQuotedSheetReference(expression: string, start: number) {
+  let sheetName = ''
+  let index = start + 1
+  while (index < expression.length) {
+    if (expression[index] !== "'") {
+      sheetName += expression[index]
+      index += 1
+      continue
+    }
+    if (expression[index + 1] === "'") {
+      sheetName += "'"
+      index += 2
+      continue
+    }
+    const separator = expression[index + 1]
+    if (separator !== '!' && separator !== ':') {
+      return null
+    }
+    return {
+      sheetName,
+      separator,
+      end: index + 2
+    }
+  }
+  return null
+}
+
+function matchesUnquotedSheetName(expression: string, index: number, sheetName: string) {
+  if (expression.slice(index, index + sheetName.length).toLowerCase() !== sheetName.toLowerCase()) {
+    return false
+  }
+  const previous = index > 0 ? expression[index - 1] : ''
+  if (previous && /[A-Za-z0-9_.\]'"]/.test(previous)) {
+    return false
+  }
+  const next = expression[index + sheetName.length] ?? ''
+  return next === '!' || next === ':'
+}
+
+function isThreeDimensionalSheetReference(sheetReference: string, currentNameLower: string) {
+  const separatorIndex = sheetReference.indexOf(':')
+  if (separatorIndex < 0) {
+    return false
+  }
+  const startName = sheetReference.slice(0, separatorIndex).toLowerCase()
+  const endName = sheetReference.slice(separatorIndex + 1).toLowerCase()
+  return startName === currentNameLower || endName === currentNameLower
+}
+
+function quoteExcelSheetName(sheetName: string) {
+  return `'${sheetName.replace(/'/g, "''")}'`
+}
+
+function unsupportedThreeDimensionalRename(sheetName: string) {
+  return new BadRequestException(
+    `Excel sheet "${sheetName}" is used in a 3D formula reference. Rename the dependent formulas before renaming the sheet.`
+  )
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
 function expandSheetRange(XLSX: any, worksheet: any, editedRange: any) {

--- a/xpertai/apps/office-editor/src/lib/office-editor.service.spec.ts
+++ b/xpertai/apps/office-editor/src/lib/office-editor.service.spec.ts
@@ -294,6 +294,73 @@ describe('OfficeEditorService', () => {
     expect((await fileVersions.find({ where: { documentId: imported.document.id } }))).toHaveLength(2)
   })
 
+  it('keeps later XLSX versions in the persisted owner scope when another assistant edits the document', async () => {
+    const ownerScope = {
+      ...testScope(),
+      projectId: null,
+      assistantId: 'assistant-a',
+      conversationId: 'conversation-a'
+    }
+    const imported = await service.importDocument(ownerScope, {
+      importFormat: 'xlsx',
+      documentType: 'spreadsheet',
+      title: 'Shared workbook',
+      fileName: 'shared.xlsx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      fileBase64: createXlsxBuffer().toString('base64')
+    })
+    expect(workspaceFiles.uploads[0]).toEqual(expect.objectContaining({
+      catalog: 'xperts',
+      scopeId: 'assistant-a',
+      xpertId: 'assistant-a'
+    }))
+
+    const otherAssistantScope = {
+      ...ownerScope,
+      assistantId: 'assistant-b',
+      conversationId: 'conversation-b'
+    }
+    await service.editExcel(otherAssistantScope, {
+      documentId: imported.document.id,
+      expectedVersionNumber: 1,
+      idempotencyKey: 'assistant-b-edit',
+      operations: [{
+        type: 'set_range_values',
+        sheetName: 'Data',
+        range: 'B2',
+        values: [[789]]
+      }]
+    })
+
+    expect(workspaceFiles.uploads[1]).toEqual(expect.objectContaining({
+      catalog: 'xperts',
+      scopeId: 'assistant-a',
+      xpertId: 'assistant-a'
+    }))
+    await service.saveSnapshot(otherAssistantScope, {
+      documentId: imported.document.id,
+      source: 'workbench',
+      snapshot: imported.snapshot.snapshot,
+      changeSummary: 'Saved by assistant B Workbench'
+    })
+    expect(workspaceFiles.uploads[2]).toEqual(expect.objectContaining({
+      catalog: 'xperts',
+      scopeId: 'assistant-a',
+      xpertId: 'assistant-a'
+    }))
+    const storedDocument = await documents.findOne({ where: { id: imported.document.id } })
+    expect(storedDocument).toEqual(expect.objectContaining({
+      assistantId: 'assistant-a',
+      workspaceCatalog: 'xperts',
+      workspaceScopeId: 'assistant-a',
+      currentFileVersionNumber: 3
+    }))
+    expect(
+      (await fileVersions.find({ where: { documentId: imported.document.id } }))
+        .map((version) => version.workspaceScopeId)
+    ).toEqual(['assistant-a', 'assistant-a', 'assistant-a'])
+  })
+
   it('rejects mismatched import discriminators without guessing from filenames', async () => {
     const buffer = createXlsxBuffer()
     await expect(
@@ -539,8 +606,28 @@ class MemoryRepository<T extends Record<string, any>> {
 class MemoryWorkspaceFiles {
   private readonly files = new Map<string, Buffer>()
   private sequence = 0
+  readonly uploads: Array<{
+    catalog?: string
+    scopeId?: string
+    xpertId?: string
+    projectId?: string
+  }> = []
 
-  async uploadBuffer(input: { buffer: Buffer; fileName?: string; originalName: string }) {
+  async uploadBuffer(input: {
+    buffer: Buffer
+    fileName?: string
+    originalName: string
+    catalog?: string
+    scopeId?: string
+    xpertId?: string
+    projectId?: string
+  }) {
+    this.uploads.push({
+      catalog: input.catalog,
+      scopeId: input.scopeId,
+      xpertId: input.xpertId,
+      projectId: input.projectId
+    })
     const filePath = `workspace/file-${++this.sequence}/${input.fileName ?? input.originalName}`
     this.files.set(filePath, Buffer.from(input.buffer))
     return {

--- a/xpertai/apps/office-editor/src/lib/office-editor.service.ts
+++ b/xpertai/apps/office-editor/src/lib/office-editor.service.ts
@@ -43,6 +43,7 @@ import type {
   OfficeOperationInput,
   OfficeOperationType,
   OfficeScope,
+  OfficeWorkspaceCatalog,
   OfficeWorkspaceFileScope,
   OfficeWorkspaceFilesApi,
   OfficeWorkbenchQuery,
@@ -1256,7 +1257,16 @@ function normalizeExpectedVersion(value: number | null | undefined) {
 }
 
 function resolveDocumentWorkspaceScope(scope: OfficeScope, document: OfficeDocument): OfficeWorkspaceFileScope {
-  const projectId = normalizeOptional(scope.projectId) ?? normalizeOptional(document.projectId)
+  const persistedScope = resolvePersistedWorkspaceScope(
+    scope,
+    document.workspaceCatalog,
+    document.workspaceScopeId
+  )
+  if (persistedScope) {
+    return persistedScope
+  }
+
+  const projectId = normalizeOptional(document.projectId) ?? normalizeOptional(scope.projectId)
   if (projectId) {
     return {
       tenantId: scope.tenantId,
@@ -1267,7 +1277,7 @@ function resolveDocumentWorkspaceScope(scope: OfficeScope, document: OfficeDocum
     }
   }
 
-  const xpertId = normalizeOptional(scope.assistantId) ?? normalizeOptional(document.assistantId)
+  const xpertId = normalizeOptional(document.assistantId) ?? normalizeOptional(scope.assistantId)
   if (!xpertId) {
     throw new BadRequestException('XLSX workspace storage requires an assistant or project scope.')
   }
@@ -1285,26 +1295,43 @@ function resolveFileVersionWorkspaceScope(
   scope: OfficeScope,
   version: OfficeFileVersion
 ): OfficeWorkspaceFileScope {
-  if (version.workspaceCatalog === 'projects' && version.workspaceScopeId) {
+  const persistedScope = resolvePersistedWorkspaceScope(
+    scope,
+    version.workspaceCatalog,
+    version.workspaceScopeId
+  )
+  if (persistedScope) {
+    return persistedScope
+  }
+  throw new BadRequestException('Excel file version workspace scope is missing. Re-import the XLSX file.')
+}
+
+function resolvePersistedWorkspaceScope(
+  scope: OfficeScope,
+  catalog: OfficeWorkspaceCatalog | null | undefined,
+  scopeId: string | null | undefined
+): OfficeWorkspaceFileScope | null {
+  const normalizedScopeId = normalizeOptional(scopeId)
+  if (catalog === 'projects' && normalizedScopeId) {
     return {
       tenantId: scope.tenantId,
       userId: scope.userId,
       catalog: 'projects',
-      scopeId: version.workspaceScopeId,
-      projectId: version.workspaceScopeId
+      scopeId: normalizedScopeId,
+      projectId: normalizedScopeId
     }
   }
-  if (version.workspaceCatalog === 'xperts' && version.workspaceScopeId) {
+  if (catalog === 'xperts' && normalizedScopeId) {
     return {
       tenantId: scope.tenantId,
       userId: scope.userId,
       catalog: 'xperts',
-      scopeId: version.workspaceScopeId,
-      xpertId: version.workspaceScopeId,
+      scopeId: normalizedScopeId,
+      xpertId: normalizedScopeId,
       isolateByUser: false
     }
   }
-  throw new BadRequestException('Excel file version workspace scope is missing. Re-import the XLSX file.')
+  return null
 }
 
 function buildExcelVersionFolder(documentId: string) {


### PR DESCRIPTION
## What changed

- Rewrite dependent cell formulas and workbook defined-name references when renaming a worksheet.
- Correctly handle quoted worksheet names and escaped apostrophes.
- Preserve string literals and external-workbook references, and reject unsupported 3D references instead of producing a corrupted XLSX.
- Prefer the persisted `workspaceCatalog` / `workspaceScopeId` and document ownership when creating subsequent file versions.
- Keep cross-assistant Excel edits and Workbench saves in the document's original storage scope.
- Add regression coverage and a patch changeset for `@xpert-ai/plugin-office-editor`.

## Root cause

Worksheet rename previously updated only the sheet map and metadata, leaving formulas and defined names pointing at the old worksheet name. File-version writes also preferred the current request assistant/project context over the persisted document scope, which could move an existing document between agent-scoped workspaces.

## Impact

This prevents broken formula/name references after worksheet renames and prevents Excel artifacts from drifting into another assistant's storage scope when edited from a different agent context.

## Validation

- `corepack pnpm -C xpertai --filter @xpert-ai/plugin-office-editor test` — 4 suites, 20 tests passed
- TypeScript spec typecheck passed
- Remote component build check passed
- Package build passed
- Plugin lifecycle harness passed (`load`, `onStart`, `bootstrap`, `destroy`, `onStop`)
- Plugin entity table-name check passed
