### PR TITLE
[codex] fix Moonshot provider credential validation

### DIFF
--- a/xpertai/.changeset/moonshot-model-list-validation.md
+++ b/xpertai/.changeset/moonshot-model-list-validation.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-moonshot": patch
+---
+
+Validate Moonshot provider credentials through the model list endpoint and honor configured API Base URLs.

--- a/xpertai/models/moonshot/README.md
+++ b/xpertai/models/moonshot/README.md
@@ -36,10 +36,10 @@ The `moonshot.yaml` schema backs the form fields you see in the console:
 
 | Field      | Description                                                                                                    |
 | ---------- | -------------------------------------------------------------------------------------------------------------- |
-| `api_key`  | Required. Your Moonshot API Key from [platform.moonshot.cn/console/api-keys](https://platform.moonshot.cn/console/api-keys). |
-| `base_url` | Optional. Base URL for API requests (defaults to `https://api.moonshot.cn/v1`). Useful for proxy configurations. |
+| `api_key`      | Required. Your Moonshot API Key from [platform.moonshot.cn/console/api-keys](https://platform.moonshot.cn/console/api-keys). |
+| `endpoint_url` | Optional. Base URL for API requests (defaults to `https://api.moonshot.cn/v1`). Useful for proxy configurations. |
 
-During validation, the plugin instantiates a ChatOpenAI client with your credentials and sends a test message ("你好") to ensure connectivity and permissions.
+During validation, the plugin sends an authenticated `GET /models` request to verify the API Key and endpoint without relying on a specific model.
 
 ## Model Capabilities
 

--- a/xpertai/models/moonshot/src/provider.strategy.spec.ts
+++ b/xpertai/models/moonshot/src/provider.strategy.spec.ts
@@ -1,0 +1,87 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  AIModelProviderStrategy: () => () => undefined,
+  CredentialsValidateFailedError: class extends Error {},
+  ModelProvider: class {
+    getProviderSchema() {
+      return { provider: 'moonshot' };
+    }
+  },
+}));
+
+import { CredentialsValidateFailedError } from '@xpert-ai/plugin-sdk';
+import { MoonshotProviderStrategy } from './provider.strategy.js';
+import { MoonshotBaseUrl, MoonshotCredentials } from './types.js';
+
+describe('MoonshotProviderStrategy', () => {
+  let strategy: MoonshotProviderStrategy;
+
+  beforeEach(() => {
+    strategy = new MoonshotProviderStrategy();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('validates credentials through the model list endpoint', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const credentials: MoonshotCredentials = {
+      api_key: 'test-api-key',
+    };
+
+    await expect(
+      strategy.validateProviderCredentials(credentials)
+    ).resolves.toBeUndefined();
+    expect(fetchSpy).toHaveBeenCalledWith(`${MoonshotBaseUrl}/models`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: 'Bearer test-api-key',
+      },
+    });
+  });
+
+  it('uses the API Base saved by the provider form', async () => {
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const credentials: MoonshotCredentials = {
+      api_key: 'test-api-key',
+      endpoint_url: ' https://proxy.example.com/v1/ ',
+      base_url: 'https://legacy.example.com/v1',
+    };
+
+    await strategy.validateProviderCredentials(credentials);
+
+    expect(strategy.getBaseUrl(credentials)).toBe(
+      'https://proxy.example.com/v1/'
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://proxy.example.com/v1/models',
+      expect.any(Object)
+    );
+  });
+
+  it('keeps legacy base_url credentials working', () => {
+    expect(
+      strategy.getBaseUrl({
+        api_key: 'test-api-key',
+        base_url: ' https://legacy.example.com/v1 ',
+      })
+    ).toBe('https://legacy.example.com/v1');
+  });
+
+  it('returns the provider error when credential validation fails', async () => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response('Permission denied', { status: 403 }));
+
+    await expect(
+      strategy.validateProviderCredentials({ api_key: 'test-api-key' })
+    ).rejects.toEqual(
+      new CredentialsValidateFailedError('Permission denied')
+    );
+  });
+});

--- a/xpertai/models/moonshot/src/provider.strategy.ts
+++ b/xpertai/models/moonshot/src/provider.strategy.ts
@@ -4,12 +4,10 @@ import {
   CredentialsValidateFailedError,
   ModelProvider,
 } from '@xpert-ai/plugin-sdk';
-import { AiModelTypeEnum } from '@xpert-ai/contracts';
 import {
+  getMoonshotBaseUrl,
   Moonshot,
-  MoonshotBaseUrl,
   MoonshotCredentials,
-  toCredentialKwargs,
 } from './types.js';
 
 @Injectable()
@@ -18,7 +16,7 @@ export class MoonshotProviderStrategy extends ModelProvider {
   override logger = new Logger(MoonshotProviderStrategy.name);
 
   getBaseUrl(credentials: MoonshotCredentials): string {
-    return credentials.base_url || MoonshotBaseUrl;
+    return getMoonshotBaseUrl(credentials);
   }
 
   getAuthorization(credentials: MoonshotCredentials): string {
@@ -29,9 +27,22 @@ export class MoonshotProviderStrategy extends ModelProvider {
     credentials: MoonshotCredentials
   ): Promise<void> {
     try {
-      const modelInstance = this.getModelManager(AiModelTypeEnum.LLM);
-      // Use moonshot-v1-8k for validation (most cost-effective)
-      await modelInstance.validateCredentials('moonshot-v1-8k', credentials);
+      const baseUrl = this.getBaseUrl(credentials).replace(/\/+$/, '');
+      const response = await fetch(`${baseUrl}/models`, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          Authorization: this.getAuthorization(credentials),
+        },
+      });
+
+      if (!response.ok) {
+        const errorMessage = await response.text();
+        throw new CredentialsValidateFailedError(
+          errorMessage ||
+            `Moonshot credentials verification failed with status ${response.status}`
+        );
+      }
     } catch (ex: unknown) {
       if (ex instanceof CredentialsValidateFailedError) {
         throw ex;
@@ -55,4 +66,3 @@ export class MoonshotProviderStrategy extends ModelProvider {
     }
   }
 }
-

--- a/xpertai/models/moonshot/src/types.ts
+++ b/xpertai/models/moonshot/src/types.ts
@@ -3,16 +3,20 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+const currentFilePath = fileURLToPath(import.meta.url);
+const currentDirectory = dirname(currentFilePath);
 
 export const Moonshot = 'moonshot';
 export const MoonshotBaseUrl = 'https://api.moonshot.cn/v1';
 
-export const SvgIcon = readFileSync(join(__dirname, '_assets/icon_s_en.svg'), 'utf8');
+export const SvgIcon = readFileSync(
+  join(currentDirectory, '_assets/icon_s_en.svg'),
+  'utf8'
+);
 
 export type MoonshotCredentials = {
   api_key: string;
+  endpoint_url?: string;
   base_url?: string;
 };
 
@@ -24,6 +28,14 @@ export type MoonshotModelCredentials = MoonshotCredentials & {
   presence_penalty?: number;
 };
 
+export function getMoonshotBaseUrl(credentials: MoonshotCredentials): string {
+  return (
+    credentials.endpoint_url?.trim() ||
+    credentials.base_url?.trim() ||
+    MoonshotBaseUrl
+  );
+}
+
 export function toCredentialKwargs(
   credentials: MoonshotCredentials,
   model?: string
@@ -33,7 +45,7 @@ export function toCredentialKwargs(
     model: model,
   } as OpenAIBaseInput;
   const configuration: ClientOptions = {
-    baseURL: credentials.base_url || MoonshotBaseUrl,
+    baseURL: getMoonshotBaseUrl(credentials),
   };
 
   return {


### PR DESCRIPTION
## Summary

- validate Moonshot provider credentials with the authenticated model list endpoint instead of a fixed model
- honor the provider form's `endpoint_url` while keeping legacy `base_url` credentials compatible
- add focused regression coverage and update the provider README
- add an independent patch changeset for `@xpert-ai/plugin-moonshot`

## Root cause

Credential validation was hard-coded to `moonshot-v1-8k`, so a valid API key could fail when that model was unavailable or not permitted. The runtime credential type also did not consume the `endpoint_url` field saved by the provider form.

## Validation

- Moonshot Jest suite: 4 tests passed
- TypeScript build: passed
- ESLint for changed TypeScript files: passed
- `plugin-dev-harness` lifecycle load: passed
- `git diff --check`: passed

## Scope

This PR intentionally leaves existing network-level exception handling unchanged.
