### PR TITLE
fix: connect Pencil assistant middleware

### DIFF
--- a/xpertai/.changeset/pencil-assistant-middleware.md
+++ b/xpertai/.changeset/pencil-assistant-middleware.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-pencil": patch
+---
+
+Connect the Pencil assistant template to its required middleware and document Agent-managed Artifact sharing.

--- a/xpertai/apps/pencil/src/lib/pencil.templates.spec.ts
+++ b/xpertai/apps/pencil/src/lib/pencil.templates.spec.ts
@@ -1,0 +1,34 @@
+import { pencilTemplates } from './pencil.templates.js'
+
+describe('pencil assistant template', () => {
+  it('connects the Pencil and common visual-workflow middleware', () => {
+    const template = pencilTemplates[0]
+
+    expect(template.dependencies?.plugins).toEqual(
+      expect.arrayContaining(['@xpert-ai/plugin-pencil', '@xpert-ai/plugin-view-image'])
+    )
+    expect(template.dependencies?.skills).toEqual([
+      {
+        componentKey: 'pencil-agent-skill',
+        targetAgentKey: 'Agent_Pencil'
+      }
+    ])
+    expect(template.dslContent).toContain('provider: PencilMiddleware')
+    expect(template.dslContent).toContain('provider: ViewImageMiddleware')
+    expect(template.dslContent).toContain('provider: skillsMiddleware')
+    expect(template.dslContent).toContain('provider: WebTools')
+    expect(template.dslContent).toContain('provider: SandboxShell')
+    expect(template.dslContent).toContain('Agent_Pencil/Middleware_Pencil')
+    expect(template.dslContent).toContain('Agent_Pencil/Middleware_ViewImage')
+    expect(template.dslContent).toContain('Agent_Pencil/Middleware_Skills')
+    expect(template.dslContent).toContain('Agent_Pencil/Middleware_WebTools')
+    expect(template.dslContent).toContain('Agent_Pencil/Middleware_SandboxShell')
+  })
+
+  it('instructs the assistant to return the tool-produced share link', () => {
+    const template = pencilTemplates[0]
+
+    expect(template.dslContent).toContain('pencil_publish_artifact_link')
+    expect(template.dslContent).toContain('Return the shareUrl to the user')
+  })
+})

--- a/xpertai/apps/pencil/src/xpert-pencil-assistant.yaml
+++ b/xpertai/apps/pencil/src/xpert-pencil-assistant.yaml
@@ -145,7 +145,11 @@ nodes:
         6. Use pencil_export_file for .fig, png, jpg, webp, svg, pdf, or jsx
            exports. Return the workspace reference, path, mime type, size, and
            sha256 to the user.
-        7. If a graph edit, import, or export cannot be completed, call
+        7. When the user explicitly asks to share a synchronized design, call
+           pencil_publish_artifact_link for the current or requested document.
+           Return the shareUrl to the user exactly as produced by the tool.
+           Never invent or modify the URL.
+        8. If a graph edit, import, export, or share cannot be completed, call
            pencil_report_failure with the operation, errorMessage,
            recoverable flag, and compact evidence.
 
@@ -157,4 +161,84 @@ nodes:
         - Use web_search/web_fetch when the user asks for current external facts
           or external design references.
       toolsetIds: []
-connections: []
+  - type: workflow
+    key: Middleware_Pencil
+    position:
+      x: 1160
+      y: 332
+    entity:
+      type: middleware
+      key: Middleware_Pencil
+      title: Pencil Agent Tools
+      provider: PencilMiddleware
+      required: true
+    hash: pencil-middleware-v1
+  - type: workflow
+    key: Middleware_ViewImage
+    position:
+      x: 1160
+      y: 480
+    entity:
+      type: middleware
+      key: Middleware_ViewImage
+      title: View Pencil Snapshot Images
+      provider: ViewImageMiddleware
+      required: true
+    hash: pencil-view-image-middleware-v1
+  - type: workflow
+    key: Middleware_Skills
+    position:
+      x: 500
+      y: 332
+    entity:
+      type: middleware
+      key: Middleware_Skills
+      title: Skills Middleware
+      provider: skillsMiddleware
+      required: true
+    hash: pencil-skills-middleware-v1
+  - type: workflow
+    key: Middleware_WebTools
+    position:
+      x: 500
+      y: 480
+    entity:
+      type: middleware
+      key: Middleware_WebTools
+      title: Web Tools
+      provider: WebTools
+      required: true
+    hash: pencil-web-tools-middleware-v1
+  - type: workflow
+    key: Middleware_SandboxShell
+    position:
+      x: 1460
+      y: 332
+    entity:
+      type: middleware
+      key: Middleware_SandboxShell
+      title: Sandbox Shell
+      provider: SandboxShell
+      required: true
+    hash: pencil-sandbox-shell-middleware-v1
+connections:
+  - type: workflow
+    key: Agent_Pencil/Middleware_Pencil
+    from: Agent_Pencil
+    to: Middleware_Pencil
+  - type: workflow
+    key: Agent_Pencil/Middleware_ViewImage
+    from: Agent_Pencil
+    to: Middleware_ViewImage
+  - type: workflow
+    key: Agent_Pencil/Middleware_Skills
+    from: Agent_Pencil
+    to: Middleware_Skills
+  - type: workflow
+    key: Agent_Pencil/Middleware_WebTools
+    from: Agent_Pencil
+    to: Middleware_WebTools
+  - type: workflow
+    key: Agent_Pencil/Middleware_SandboxShell
+    from: Agent_Pencil
+    to: Middleware_SandboxShell


### PR DESCRIPTION
## What changed

- connect the Pencil assistant template to `PencilMiddleware`, `ViewImageMiddleware`, `skillsMiddleware`, `WebTools`, and `SandboxShell`
- connect all five middleware nodes to `Agent_Pencil`
- instruct the assistant to call `pencil_publish_artifact_link` only for explicit share requests and return the tool-produced `shareUrl`
- add a focused template regression test and a patch changeset

## Root cause

The Pencil plugin registered its middleware providers, but the bundled assistant template did not declare or connect those middleware nodes. As a result, the Agent prompt referenced tools that were not available to the Agent, including the Artifact publishing tool.

## Impact

New Pencil assistants created from the updated template can use the Pencil editing, image inspection, skills, web, sandbox, and Artifact sharing tools. Existing behavior is preserved: a public Artifact link is created only when the user explicitly asks to share a synchronized design.

## Validation

- Pencil Jest suite: 11 suites, 60 tests passed
- Pencil typecheck passed
- Pencil production build passed
- YAML parsed with all five providers and connections present
- `plugin-dev-harness` lifecycle passed on Node 20
- `git diff --check` passed

## Manual verification

Browser validation was intentionally not run; verify the updated template in the host after reinstalling or updating the plugin.