### PR TITLE
fix: normalize Moonshot tool schema references

### DIFF
--- a/xpertai/.changeset/moonshot-tool-schema-refs.md
+++ b/xpertai/.changeset/moonshot-tool-schema-refs.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-moonshot': patch
+---
+
+Normalize tool JSON Schema references for Moonshot API compatibility.

--- a/xpertai/models/moonshot/src/llm/llm.ts
+++ b/xpertai/models/moonshot/src/llm/llm.ts
@@ -1,4 +1,3 @@
-import { ChatOpenAI } from '@langchain/openai';
 import { AiModelTypeEnum, ICopilotModel } from '@xpert-ai/contracts';
 import { Injectable, Logger } from '@nestjs/common';
 import {
@@ -10,6 +9,7 @@ import {
 } from '@xpert-ai/plugin-sdk';
 import { MoonshotProviderStrategy } from '../provider.strategy.js';
 import { MoonshotModelCredentials, toCredentialKwargs } from '../types.js';
+import { createMoonshotChatModel } from './moonshot-chat-model.js';
 
 @Injectable()
 export class MoonshotLargeLanguageModel extends LargeLanguageModel {
@@ -25,7 +25,7 @@ export class MoonshotLargeLanguageModel extends LargeLanguageModel {
   ): Promise<void> {
     try {
       const params = toCredentialKwargs(credentials, model);
-      const chatModel = new ChatOpenAI({
+      const chatModel = createMoonshotChatModel({
         ...params,
         temperature: 0,
         maxTokens: 10,
@@ -63,7 +63,7 @@ export class MoonshotLargeLanguageModel extends LargeLanguageModel {
       verbose: options?.verbose,
     };
 
-    return new ChatOpenAI({
+    return createMoonshotChatModel({
       ...fields,
       callbacks: [
         ...this.createHandleUsageCallbacks(
@@ -77,4 +77,3 @@ export class MoonshotLargeLanguageModel extends LargeLanguageModel {
     });
   }
 }
-

--- a/xpertai/models/moonshot/src/llm/moonshot-chat-model.spec.ts
+++ b/xpertai/models/moonshot/src/llm/moonshot-chat-model.spec.ts
@@ -1,0 +1,136 @@
+import { tool } from '@langchain/core/tools'
+import { ChatOpenAI } from '@langchain/openai'
+import { z } from 'zod'
+import { createMoonshotChatModel } from './moonshot-chat-model.js'
+
+describe('createMoonshotChatModel', () => {
+  it('normalizes every JSON schema surface in the final request parameters', () => {
+    const model = createMoonshotChatModel({
+      apiKey: 'test-key',
+      model: 'kimi-k3',
+      configuration: {
+        baseURL: 'https://api.moonshot.cn/v1'
+      }
+    })
+    const parameters = {
+      type: 'object',
+      properties: {
+        audience: {
+          type: 'string',
+          enum: ['admins_only', 'workspace_all', 'custom', 'public_link']
+        },
+        accessMode: {
+          $ref: '#/properties/audience'
+        }
+      }
+    }
+
+    const invocationParams = model.invocationParams({
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'sites_create_and_deploy',
+            parameters
+          }
+        }
+      ],
+      functions: [
+        {
+          name: 'sites_create_and_deploy_legacy',
+          parameters
+        }
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'sites_deployment',
+          schema: parameters
+        }
+      }
+    })
+
+    expect(invocationParams).toMatchObject({
+      tools: [
+        {
+          type: 'function',
+          function: {
+            parameters: {
+              properties: {
+                accessMode: {
+                  $ref: '#/$defs/moonshot_ref_1'
+                }
+              }
+            }
+          }
+        }
+      ],
+      functions: [
+        {
+          parameters: {
+            properties: {
+              accessMode: {
+                $ref: '#/$defs/moonshot_ref_1'
+              }
+            }
+          }
+        }
+      ],
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          schema: {
+            properties: {
+              accessMode: {
+                $ref: '#/$defs/moonshot_ref_1'
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('normalizes reused Zod schemas through bindTools', () => {
+    const model = createMoonshotChatModel({
+      apiKey: 'test-key',
+      model: 'kimi-k3',
+      configuration: {
+        baseURL: 'https://api.moonshot.cn/v1'
+      }
+    })
+    const audience = z.enum(['admins_only', 'workspace_all', 'custom', 'public_link'])
+    const deployTool = tool(async () => 'deployed', {
+      name: 'sites_create_and_deploy',
+      description: 'Create and deploy a site',
+      schema: z.object({
+        audience,
+        accessMode: audience
+      })
+    })
+
+    const boundModel = model.bindTools([deployTool])
+
+    expect(boundModel).toBeInstanceOf(ChatOpenAI)
+    if (!(boundModel instanceof ChatOpenAI)) {
+      throw new Error('Expected bindTools to return a ChatOpenAI model')
+    }
+    expect(boundModel.invocationParams()).toMatchObject({
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'sites_create_and_deploy',
+            parameters: {
+              properties: {
+                accessMode: {
+                  $ref: '#/$defs/moonshot_ref_1'
+                }
+              }
+            }
+          }
+        }
+      ]
+    })
+  })
+})

--- a/xpertai/models/moonshot/src/llm/moonshot-chat-model.ts
+++ b/xpertai/models/moonshot/src/llm/moonshot-chat-model.ts
@@ -1,0 +1,56 @@
+import { ChatOpenAI, ChatOpenAICompletions, ChatOpenAIFields } from '@langchain/openai'
+import { normalizeMoonshotJsonSchema } from './moonshot-json-schema.js'
+
+type MoonshotInvocationParams = ReturnType<ChatOpenAICompletions['invocationParams']>
+
+export class MoonshotChatOpenAICompletions extends ChatOpenAICompletions {
+  override invocationParams(
+    options?: this['ParsedCallOptions'],
+    extra?: {
+      streaming?: boolean
+    }
+  ): MoonshotInvocationParams {
+    const params = super.invocationParams(options, extra)
+    const responseFormat =
+      params.response_format?.type === 'json_schema' && params.response_format.json_schema.schema
+        ? {
+            ...params.response_format,
+            json_schema: {
+              ...params.response_format.json_schema,
+              schema: normalizeMoonshotJsonSchema(params.response_format.json_schema.schema)
+            }
+          }
+        : params.response_format
+
+    return {
+      ...params,
+      functions: params.functions?.map((definition) =>
+        definition.parameters
+          ? {
+              ...definition,
+              parameters: normalizeMoonshotJsonSchema(definition.parameters)
+            }
+          : definition
+      ),
+      tools: params.tools?.map((tool) =>
+        tool.type === 'function' && tool.function.parameters
+          ? {
+              ...tool,
+              function: {
+                ...tool.function,
+                parameters: normalizeMoonshotJsonSchema(tool.function.parameters)
+              }
+            }
+          : tool
+      ),
+      response_format: responseFormat
+    }
+  }
+}
+
+export function createMoonshotChatModel(fields: ChatOpenAIFields): ChatOpenAI {
+  return new ChatOpenAI({
+    ...fields,
+    completions: new MoonshotChatOpenAICompletions(fields)
+  })
+}

--- a/xpertai/models/moonshot/src/llm/moonshot-json-schema.spec.ts
+++ b/xpertai/models/moonshot/src/llm/moonshot-json-schema.spec.ts
@@ -1,0 +1,208 @@
+import { normalizeMoonshotJsonSchema } from './moonshot-json-schema.js'
+
+describe('normalizeMoonshotJsonSchema', () => {
+  it('moves local property references into root definitions', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        audience: {
+          type: 'string',
+          enum: ['admins_only', 'workspace_all', 'custom', 'public_link']
+        },
+        accessMode: {
+          $ref: '#/properties/audience'
+        }
+      }
+    }
+
+    const normalized = normalizeMoonshotJsonSchema(schema)
+
+    expect(normalized).toEqual({
+      type: 'object',
+      properties: {
+        audience: {
+          type: 'string',
+          enum: ['admins_only', 'workspace_all', 'custom', 'public_link']
+        },
+        accessMode: {
+          $ref: '#/$defs/moonshot_ref_1'
+        }
+      },
+      $defs: {
+        moonshot_ref_1: {
+          type: 'string',
+          enum: ['admins_only', 'workspace_all', 'custom', 'public_link']
+        }
+      }
+    })
+    expect(schema.properties.accessMode.$ref).toBe('#/properties/audience')
+  })
+
+  it('rewrites recursive local references without expanding them infinitely', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        node: {
+          type: 'object',
+          properties: {
+            children: {
+              type: 'array',
+              items: {
+                $ref: '#/properties/node'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(normalizeMoonshotJsonSchema(schema)).toMatchObject({
+      properties: {
+        node: {
+          properties: {
+            children: {
+              items: {
+                $ref: '#/$defs/moonshot_ref_1'
+              }
+            }
+          }
+        }
+      },
+      $defs: {
+        moonshot_ref_1: {
+          properties: {
+            children: {
+              items: {
+                $ref: '#/$defs/moonshot_ref_1'
+              }
+            }
+          }
+        }
+      }
+    })
+  })
+
+  it('keeps schemas that already use root definitions unchanged', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        accessMode: {
+          $ref: '#/$defs/accessMode'
+        }
+      },
+      $defs: {
+        accessMode: {
+          type: 'string',
+          enum: ['admins_only']
+        }
+      }
+    }
+
+    expect(normalizeMoonshotJsonSchema(schema)).toBe(schema)
+  })
+
+  it('does not interpret annotation values as nested schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        payload: {
+          type: 'object',
+          default: {
+            $ref: 'literal-default'
+          },
+          const: {
+            $ref: 'literal-const'
+          },
+          enum: [
+            {
+              $ref: 'literal-enum'
+            }
+          ],
+          examples: [
+            {
+              $ref: 'literal-example'
+            }
+          ]
+        }
+      }
+    }
+
+    expect(normalizeMoonshotJsonSchema(schema)).toBe(schema)
+  })
+
+  it('preserves annotation values while normalizing nested schema references', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        audience: {
+          type: 'string'
+        },
+        payload: {
+          type: 'array',
+          default: {
+            $ref: 'literal-default'
+          },
+          items: {
+            $ref: '#/properties/audience'
+          }
+        }
+      }
+    }
+
+    expect(normalizeMoonshotJsonSchema(schema)).toMatchObject({
+      properties: {
+        payload: {
+          default: {
+            $ref: 'literal-default'
+          },
+          items: {
+            $ref: '#/$defs/moonshot_ref_1'
+          }
+        }
+      }
+    })
+  })
+
+  it('resolves escaped JSON pointer segments', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        'access/mode': {
+          type: 'string'
+        },
+        selected: {
+          $ref: '#/properties/access~1mode'
+        }
+      }
+    }
+
+    expect(normalizeMoonshotJsonSchema(schema)).toMatchObject({
+      properties: {
+        selected: {
+          $ref: '#/$defs/moonshot_ref_1'
+        }
+      },
+      $defs: {
+        moonshot_ref_1: {
+          type: 'string'
+        }
+      }
+    })
+  })
+
+  it.each([
+    ['external', 'https://example.com/schema.json'],
+    ['unresolved', '#/properties/missing']
+  ])('rejects %s references explicitly', (_label, reference) => {
+    expect(() =>
+      normalizeMoonshotJsonSchema({
+        type: 'object',
+        properties: {
+          value: {
+            $ref: reference
+          }
+        }
+      })
+    ).toThrow(`Cannot normalize Moonshot JSON schema reference "${reference}"`)
+  })
+})

--- a/xpertai/models/moonshot/src/llm/moonshot-json-schema.ts
+++ b/xpertai/models/moonshot/src/llm/moonshot-json-schema.ts
@@ -1,0 +1,207 @@
+export interface MoonshotJsonSchema {
+  [key: string]: unknown
+}
+
+const MoonshotDefinitionPrefix = '#/$defs/'
+const SchemaMapKeywords = ['$defs', 'definitions', 'properties', 'patternProperties', 'dependentSchemas'] as const
+const SchemaValueKeywords = [
+  'additionalItems',
+  'additionalProperties',
+  'contains',
+  'contentSchema',
+  'else',
+  'if',
+  'not',
+  'propertyNames',
+  'then',
+  'unevaluatedItems',
+  'unevaluatedProperties'
+] as const
+const SchemaArrayKeywords = ['allOf', 'anyOf', 'oneOf', 'prefixItems'] as const
+
+export function normalizeMoonshotJsonSchema(schema: MoonshotJsonSchema): MoonshotJsonSchema {
+  if (!hasReferenceNeedingNormalization(schema)) {
+    return schema
+  }
+
+  const sourceRoot = structuredClone(schema)
+  const normalizedRoot = structuredClone(schema)
+  const definitionNames = new Map<string, string>()
+  const visited = new WeakSet<object>()
+  let nextDefinitionId = 1
+
+  function ensureDefinitions(): MoonshotJsonSchema {
+    const existingDefinitions = normalizedRoot['$defs']
+    if (existingDefinitions === undefined) {
+      const definitions: MoonshotJsonSchema = {}
+      normalizedRoot['$defs'] = definitions
+      return definitions
+    }
+    if (!isSchemaObject(existingDefinitions)) {
+      throw new Error('Cannot normalize Moonshot JSON schema because root "$defs" is not an object')
+    }
+    return existingDefinitions
+  }
+
+  function materializeDefinition(reference: string): string {
+    const existingName = definitionNames.get(reference)
+    if (existingName) {
+      return existingName
+    }
+    if (!reference.startsWith('#')) {
+      throw cannotNormalizeReference(reference, 'external references are unsupported')
+    }
+
+    const target = resolveLocalReference(sourceRoot, reference)
+    const definitions = ensureDefinitions()
+    let definitionName = `moonshot_ref_${nextDefinitionId++}`
+    while (Object.hasOwn(definitions, definitionName)) {
+      definitionName = `moonshot_ref_${nextDefinitionId++}`
+    }
+
+    definitionNames.set(reference, definitionName)
+    const definition: unknown = structuredClone(target)
+    definitions[definitionName] = definition
+    normalizeValue(definition)
+    return definitionName
+  }
+
+  function normalizeValue(value: unknown): void {
+    if (!isSchemaObject(value) || visited.has(value)) {
+      return
+    }
+    visited.add(value)
+
+    const reference = value['$ref']
+    if (reference !== undefined) {
+      if (typeof reference !== 'string') {
+        throw new Error('Cannot normalize Moonshot JSON schema reference because "$ref" is not a string')
+      }
+      if (!reference.startsWith(MoonshotDefinitionPrefix)) {
+        value['$ref'] = `${MoonshotDefinitionPrefix}${materializeDefinition(reference)}`
+      }
+    }
+
+    forEachChildSchema(value, normalizeValue)
+  }
+
+  normalizeValue(normalizedRoot)
+  return normalizedRoot
+}
+
+function hasReferenceNeedingNormalization(value: unknown, visited = new WeakSet<object>()): boolean {
+  if (!isSchemaObject(value) || visited.has(value)) {
+    return false
+  }
+  visited.add(value)
+
+  const reference = value['$ref']
+  if (reference !== undefined && (typeof reference !== 'string' || !reference.startsWith(MoonshotDefinitionPrefix))) {
+    return true
+  }
+
+  let hasReference = false
+  forEachChildSchema(value, (child) => {
+    if (!hasReference && hasReferenceNeedingNormalization(child, visited)) {
+      hasReference = true
+    }
+  })
+  return hasReference
+}
+
+function forEachChildSchema(schema: MoonshotJsonSchema, visit: (child: unknown) => void): void {
+  for (const keyword of SchemaMapKeywords) {
+    const schemas = schema[keyword]
+    if (isSchemaObject(schemas)) {
+      Object.values(schemas).forEach(visitSchema)
+    }
+  }
+
+  const dependencies = schema['dependencies']
+  if (isSchemaObject(dependencies)) {
+    Object.values(dependencies).forEach((dependency) => {
+      if (!Array.isArray(dependency)) {
+        visitSchema(dependency)
+      }
+    })
+  }
+
+  for (const keyword of SchemaValueKeywords) {
+    visitSchema(schema[keyword])
+  }
+
+  const items = schema['items']
+  if (Array.isArray(items)) {
+    items.forEach(visitSchema)
+  } else {
+    visitSchema(items)
+  }
+
+  for (const keyword of SchemaArrayKeywords) {
+    const schemas = schema[keyword]
+    if (Array.isArray(schemas)) {
+      schemas.forEach(visitSchema)
+    }
+  }
+
+  function visitSchema(value: unknown): void {
+    if (isSchemaObject(value) || typeof value === 'boolean') {
+      visit(value)
+    }
+  }
+}
+
+function resolveLocalReference(root: MoonshotJsonSchema, reference: string): unknown {
+  const segments = parseLocalReference(reference)
+  let current: unknown = root
+
+  for (const segment of segments) {
+    if (Array.isArray(current)) {
+      const index = Number(segment)
+      if (!Number.isInteger(index) || index < 0 || String(index) !== segment || index >= current.length) {
+        throw cannotNormalizeReference(reference, 'array index does not exist')
+      }
+      current = current[index]
+      continue
+    }
+    if (!isSchemaObject(current) || !Object.hasOwn(current, segment)) {
+      throw cannotNormalizeReference(reference, 'target does not exist')
+    }
+    current = current[segment]
+  }
+
+  return current
+}
+
+function parseLocalReference(reference: string): string[] {
+  let pointer: string
+  try {
+    pointer = decodeURIComponent(reference.slice(1))
+  } catch {
+    throw cannotNormalizeReference(reference, 'URI fragment is invalid')
+  }
+  if (pointer === '') {
+    return []
+  }
+  if (!pointer.startsWith('/')) {
+    throw cannotNormalizeReference(reference, 'JSON pointer is invalid')
+  }
+
+  return pointer
+    .slice(1)
+    .split('/')
+    .map((segment) => {
+      if (/~(?:[^01]|$)/.test(segment)) {
+        throw cannotNormalizeReference(reference, 'JSON pointer escape is invalid')
+      }
+      return segment.replace(/~1/g, '/').replace(/~0/g, '~')
+    })
+}
+
+function isSchemaObject(value: unknown): value is MoonshotJsonSchema {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cannotNormalizeReference(reference: string, reason: string): Error {
+  return new Error(`Cannot normalize Moonshot JSON schema reference "${reference}": ${reason}`)
+}


### PR DESCRIPTION
## Summary

- route Moonshot chat model creation through a provider-specific completions adapter
- rewrite local tool JSON Schema references into root $defs accepted by Moonshot
- traverse only schema-bearing keywords so annotation data remains unchanged
- cover direct request parameters and the real LangChain bindTools path

## Validation

- corepack pnpm@10.24.0 exec nx test @xpert-ai/plugin-moonshot --runInBand
- NX_DAEMON=false corepack pnpm@10.24.0 exec nx build @xpert-ai/plugin-moonshot
- NX_DAEMON=false corepack pnpm@10.24.0 exec nx typecheck @xpert-ai/plugin-moonshot --skip-nx-cache
- NX_DAEMON=false corepack pnpm@10.24.0 exec nx lint @xpert-ai/plugin-moonshot
- npm pack --dry-run
- plugin-dev-harness lifecycle validation