### PR TITLE
[codex] Fix Pencil shared theme colors

### DIFF
--- a/xpertai/.changeset/fix-pencil-shared-theme-colors.md
+++ b/xpertai/.changeset/fix-pencil-shared-theme-colors.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-pencil": patch
+---
+
+Resolve active theme color variables before rendering shared Pencil artifacts.

--- a/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.service.ts
+++ b/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.service.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common'
+import type { SceneGraph, SceneNode } from '@open-pencil/core/scene-graph'
 import { buildOnlineFontFaceCss } from '@xpert-ai/design-fonts'
 import { createHash } from 'node:crypto'
 import { graphFromSnapshot } from './pencil-graph.js'
@@ -30,6 +31,7 @@ export type PencilArtifactViewerRenderResult = {
 export class PencilArtifactViewerService {
   async render(input: PencilArtifactViewerRenderInput): Promise<PencilArtifactViewerRenderResult> {
     const graph = await graphFromSnapshot(input.graphSnapshot)
+    resolvePublishedVariableColors(graph)
     const { renderNodesToSVG } = await loadPencilCoreIo()
     const pages = graph
       .getPages()
@@ -62,6 +64,24 @@ export class PencilArtifactViewerService {
       pageCount: pages.length
     }
   }
+}
+
+function resolvePublishedVariableColors(graph: SceneGraph) {
+  for (const node of graph.nodes.values()) {
+    node.fills = node.fills.map((fill, index) => {
+      const color = resolveBoundColor(graph, node, `fills/${index}/color`)
+      return color ? { ...fill, color: { ...color } } : fill
+    })
+    node.strokes = node.strokes.map((stroke, index) => {
+      const color = resolveBoundColor(graph, node, `strokes/${index}/color`)
+      return color ? { ...stroke, color: { ...color } } : stroke
+    })
+  }
+}
+
+function resolveBoundColor(graph: SceneGraph, node: SceneNode, field: string) {
+  const variableId = node.boundVariables[field]
+  return variableId ? graph.resolveColorVariable(variableId) : undefined
 }
 
 function loadPencilCoreIo() {

--- a/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.spec.ts
+++ b/xpertai/apps/pencil/src/lib/pencil-artifact-viewer.spec.ts
@@ -9,7 +9,13 @@ jest.mock('@open\u002dpencil/core/scene-graph', () => ({
   SceneGraph: class MockSceneGraph {
     nodes = new Map<string, Record<string, unknown>>()
     images = new Map<string, Uint8Array>()
-    variables = new Map<string, Record<string, unknown>>()
+    variables = new Map<
+      string,
+      {
+        collectionId: string
+        valuesByMode: Record<string, { r: number; g: number; b: number; a: number }>
+      }
+    >()
     variableCollections = new Map<string, Record<string, unknown>>()
     activeMode = new Map<string, string>()
     instanceIndex = new Map<string, Set<string>>()
@@ -20,6 +26,13 @@ jest.mock('@open\u002dpencil/core/scene-graph', () => ({
 
     getPages() {
       return Array.from(this.nodes.values()).filter((node) => node.type === 'CANVAS')
+    }
+
+    resolveColorVariable(variableId: string) {
+      const variable = this.variables.get(variableId)
+      if (!variable) return undefined
+      const activeMode = this.activeMode.get(variable.collectionId)
+      return (activeMode ? variable.valuesByMode[activeMode] : undefined) ?? Object.values(variable.valuesByMode)[0]
     }
   }
 }))
@@ -89,6 +102,90 @@ describe('PencilArtifactViewerService', () => {
     expect(html).toContain("font-family: 'Caveat'")
     expect(html).toContain('https://cdn.jsdelivr.net/npm/@fontsource/caveat@5.2.8/files/caveat-latin-400-normal.woff2')
     expect(html).not.toContain("font-family: 'Unmanaged Font'")
+  })
+
+  it('resolves active theme colors before rendering the published SVG', async () => {
+    const graphSnapshot = createEmptyPencilGraphSnapshot()
+    const page = graphSnapshot.nodes.find(([, node]) => node.type === 'CANVAS')?.[1]
+    if (!page) throw new Error('Empty Pencil graph fixture has no page.')
+
+    const darkSurface = { r: 0.03, g: 0.01, b: 0.08, a: 1 }
+    const darkBorder = { r: 0.2, g: 0.12, b: 0.32, a: 1 }
+    page.childIds = ['themed-card']
+    graphSnapshot.nodes.push([
+      'themed-card',
+      {
+        id: 'themed-card',
+        type: 'FRAME',
+        name: 'Themed card',
+        parentId: page.id,
+        childIds: [],
+        x: 0,
+        y: 0,
+        width: 100,
+        height: 100,
+        visible: true,
+        fills: [{ type: 'SOLID', color: { r: 1, g: 1, b: 1, a: 1 }, opacity: 1, visible: true }],
+        strokes: [
+          {
+            color: { r: 1, g: 1, b: 1, a: 1 },
+            weight: 1,
+            opacity: 1,
+            visible: true,
+            align: 'INSIDE'
+          }
+        ],
+        boundVariables: {
+          'fills/0/color': 'surface-variable',
+          'strokes/0/color': 'border-variable'
+        }
+      }
+    ])
+    graphSnapshot.variableCollections.push([
+      'theme-collection',
+      {
+        id: 'theme-collection',
+        name: 'Theme',
+        modes: [{ modeId: 'dark-mode', name: 'Dark' }],
+        defaultModeId: 'dark-mode',
+        variableIds: ['surface-variable', 'border-variable']
+      }
+    ])
+    graphSnapshot.variables.push(
+      [
+        'surface-variable',
+        {
+          id: 'surface-variable',
+          name: 'Surface',
+          type: 'COLOR',
+          collectionId: 'theme-collection',
+          valuesByMode: { 'dark-mode': darkSurface }
+        }
+      ],
+      [
+        'border-variable',
+        {
+          id: 'border-variable',
+          name: 'Border',
+          type: 'COLOR',
+          collectionId: 'theme-collection',
+          valuesByMode: { 'dark-mode': darkBorder }
+        }
+      ]
+    )
+    graphSnapshot.activeMode.push(['theme-collection', 'dark-mode'])
+    jest.mocked(renderNodesToSVG).mockImplementationOnce((graph) => {
+      const themedCard = graph.nodes.get('themed-card')
+      expect(themedCard?.fills[0]?.color).toEqual(darkSurface)
+      expect(themedCard?.strokes[0]?.color).toEqual(darkBorder)
+      return '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100"></svg>'
+    })
+
+    await new PencilArtifactViewerService().render({
+      title: 'Dark theme',
+      revision: 1,
+      graphSnapshot
+    })
   })
 
   it.each([


### PR DESCRIPTION
## Summary

- resolve active Pencil color variables before shared artifacts are rendered to SVG
- apply resolved colors to bound fills and strokes in the transient publishing graph
- add a regression test covering dark theme fill and stroke bindings
- add a patch changeset for `@xpert-ai/plugin-pencil`

## Problem

The Pencil workbench resolves `boundVariables` against the active variable mode when drawing the editor canvas. The shared-artifact renderer previously passed the raw node paints directly to the SVG exporter. When a node retained a light raw fallback but was bound to a dark theme variable, the editor appeared dark while the published artifact appeared white.

## Root cause

`PencilArtifactViewerService` rehydrated the graph and immediately called `renderNodesToSVG`. Unlike the editor rendering path, the SVG export path did not resolve `fills/<index>/color` or `strokes/<index>/color` bindings first.

## Fix

Before SVG generation, the viewer now resolves bound fill and stroke colors through `SceneGraph.resolveColorVariable()` and writes cloned resolved colors into the transient rehydrated graph. Unbound or unresolved colors retain their existing values. The persisted document graph and public API contracts are unchanged.

## Validation

- Pencil Jest suite: 11 suites, 61 tests passed
- `tsc -p apps/pencil/tsconfig.spec.json --noEmit`
- `tsc -p apps/pencil/tsconfig.lib.json --noEmit`
- `nx build @xpert-ai/plugin-pencil`
- plugin lifecycle validation through `plugin-dev-harness` on Node 20
- `git diff --check`
- local shared-artifact test confirmed that bound dark surface, card, and border colors remain dark after publishing

## Out of scope

This change does not alter artifact bounds or clipping. Nodes such as unwrapped text that extend beyond the root frame can still expand the exported SVG and expose transparent page space.
