### PR TITLE
[codex] report Moonshot streaming token usage

### DIFF
--- a/xpertai/.changeset/moonshot-stream-token-usage.md
+++ b/xpertai/.changeset/moonshot-stream-token-usage.md
@@ -1,0 +1,5 @@
+---
+'@xpert-ai/plugin-moonshot': patch
+---
+
+Report actual token usage for streamed Moonshot responses.

--- a/xpertai/models/moonshot/src/llm/llm.ts
+++ b/xpertai/models/moonshot/src/llm/llm.ts
@@ -59,7 +59,7 @@ export class MoonshotLargeLanguageModel extends LargeLanguageModel {
     const fields = {
       ...params,
       streaming: copilotModel.options?.['streaming'] ?? true,
-      streamUsage: false,
+      streamUsage: true,
       verbose: options?.verbose,
     };
 

--- a/xpertai/models/moonshot/src/llm/moonshot-chat-model.spec.ts
+++ b/xpertai/models/moonshot/src/llm/moonshot-chat-model.spec.ts
@@ -1,9 +1,114 @@
+jest.mock('@xpert-ai/plugin-sdk', () => ({
+  AIModelProviderStrategy: () => () => undefined,
+  CredentialsValidateFailedError: class extends Error {},
+  getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error)),
+  LargeLanguageModel: class {
+    createHandleUsageCallbacks() {
+      return []
+    }
+
+    createHandleLLMErrorCallbacks() {
+      return {}
+    }
+  },
+  mergeCredentials: (credentials: Record<string, unknown>, modelProperties?: Record<string, unknown>) => ({
+    ...credentials,
+    ...modelProperties
+  }),
+  ModelProvider: class {}
+}))
+
+import { AiProviderRole, ICopilotModel } from '@xpert-ai/contracts'
+import { HumanMessage } from '@langchain/core/messages'
 import { tool } from '@langchain/core/tools'
 import { ChatOpenAI } from '@langchain/openai'
 import { z } from 'zod'
+import { MoonshotProviderStrategy } from '../provider.strategy.js'
+import { MoonshotLargeLanguageModel } from './llm.js'
 import { createMoonshotChatModel } from './moonshot-chat-model.js'
 
 describe('createMoonshotChatModel', () => {
+  it('requests token usage for streaming responses', () => {
+    const copilotModel: ICopilotModel = {
+      model: 'kimi-k3',
+      options: {
+        streaming: true
+      },
+      copilot: {
+        role: AiProviderRole.Primary,
+        modelProvider: {
+          credentials: {
+            api_key: 'test-key'
+          }
+        }
+      }
+    }
+    const llm = new MoonshotLargeLanguageModel(new MoonshotProviderStrategy())
+    const model = llm.getChatModel(copilotModel)
+
+    expect(model.invocationParams()).toMatchObject({
+      stream_options: {
+        include_usage: true
+      }
+    })
+  })
+
+  it('maps final streaming usage to canonical message metadata', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<Response> =>
+        new Response(
+          [
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}',
+            '',
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}',
+            '',
+            'data: {"id":"chatcmpl-test","object":"chat.completion.chunk","created":1,"model":"kimi-k3","choices":[],"usage":{"prompt_tokens":7264,"completion_tokens":174,"total_tokens":7438,"completion_tokens_details":{"reasoning_tokens":41}}}',
+            '',
+            'data: [DONE]',
+            ''
+          ].join('\n'),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/event-stream'
+            }
+          }
+        )
+    )
+    const model = createMoonshotChatModel({
+      apiKey: 'test-key',
+      model: 'kimi-k3',
+      streaming: true,
+      streamUsage: true,
+      maxRetries: 0,
+      configuration: {
+        baseURL: 'https://api.moonshot.cn/v1',
+        fetch: fetchMock
+      }
+    })
+
+    const chunks = []
+    for await (const chunk of model._streamResponseChunks([new HumanMessage('hi')], {})) {
+      chunks.push(chunk)
+    }
+    const message = chunks.find((chunk) => chunk.message.usage_metadata)?.message
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(message?.usage_metadata).toMatchObject({
+      input_tokens: 7264,
+      output_tokens: 174,
+      total_tokens: 7438,
+      output_token_details: {
+        reasoning: 41
+      }
+    })
+    expect(message?.response_metadata['usage']).toMatchObject({
+      prompt_tokens: 7264,
+      completion_tokens: 174,
+      total_tokens: 7438
+    })
+  })
+
   it('normalizes every JSON schema surface in the final request parameters', () => {
     const model = createMoonshotChatModel({
       apiKey: 'test-key',


### PR DESCRIPTION
## Problem

Streamed Moonshot and Kimi calls can complete successfully while Xpert records zero token usage. The provider response can expose usage only in the final stream event, so execution logs and downstream usage consumers receive no actual count when the request does not ask for streaming usage.

## Root cause

The Moonshot adapter constructed `ChatOpenAI` with `streamUsage: false`. That prevents the OpenAI-compatible request from sending `stream_options.include_usage: true`, so Moonshot does not return the final aggregate usage event required by LangChain to populate canonical message usage metadata.

## Fix

Enable `streamUsage` for Moonshot chat models. Add focused regression coverage proving that:

- streaming invocation parameters request `include_usage: true`
- a final Moonshot SSE usage event is mapped to `AIMessage.usage_metadata`
- input, output, total, and reasoning token details remain available in canonical and raw response metadata

Add a patch changeset for `@xpert-ai/plugin-moonshot`.

This PR changes only the provider adapter. Shared actual-versus-estimated usage resolution remains a separate Plugin SDK change.

## Validation

- Moonshot Jest: 3 suites, 16 tests passed with Nx cache disabled
- Moonshot build passed
- Moonshot typecheck passed
- Moonshot lint passed with 0 errors and 3 pre-existing warnings
- Moonshot prepack passed
- `npm pack --dry-run` included the compiled plugin, provider YAML, model YAML, and assets
- Node 20 `plugin-dev-harness` completed register, start, bootstrap, destroy, and stop successfully
- Changesets reports one patch bump for `@xpert-ai/plugin-moonshot`
- `git diff --check origin/main...HEAD`

No browser or live Moonshot API validation was run; runtime verification remains a user-owned local test after installing the rebuilt plugin.