### PR TITLE
[codex] Forward Volcengine max tokens

### DIFF
--- a/xpertai/.changeset/volcengine-max-tokens.md
+++ b/xpertai/.changeset/volcengine-max-tokens.md
@@ -1,0 +1,5 @@
+---
+"@xpert-ai/plugin-volcengine": patch
+---
+
+Forward configured `max_tokens` values to Volcengine Ark requests and expand the configurable output limit for Doubao Seed 2.0 Mini.

--- a/xpertai/models/volcengine/src/llm/doubao-seed-2-0-mini-260215.yaml
+++ b/xpertai/models/volcengine/src/llm/doubao-seed-2-0-mini-260215.yaml
@@ -20,6 +20,8 @@ parameter_rules:
     use_template: top_p
   - name: max_tokens
     use_template: max_tokens
+    default: 4096
+    max: 131072
   - name: thinking
     label:
       zh_Hans: 深度思考模式

--- a/xpertai/models/volcengine/src/llm/llm.spec.ts
+++ b/xpertai/models/volcengine/src/llm/llm.spec.ts
@@ -1,10 +1,13 @@
 jest.mock('@xpert-ai/plugin-sdk', () => ({
   AIModelProviderStrategy: () => () => undefined,
   ChatOAICompatReasoningModel: class {
-    constructor(readonly clientConfig: { modelKwargs?: object }) {}
+    constructor(readonly clientConfig: { maxTokens?: number; modelKwargs?: object }) {}
 
     invocationParams() {
-      return this.clientConfig.modelKwargs ?? {}
+      return {
+        ...(this.clientConfig.modelKwargs ?? {}),
+        ...(this.clientConfig.maxTokens === undefined ? {} : { max_tokens: this.clientConfig.maxTokens })
+      }
     }
   },
   CredentialsValidateFailedError: class extends Error {},
@@ -31,12 +34,15 @@ import { AiProviderRole } from '@xpert-ai/contracts'
 import { VolcengineProviderStrategy } from '../provider.strategy.js'
 import { normalizeVolcengineToolSchema, VolcengineLargeLanguageModel } from './llm.js'
 
-function createCopilotModel(
+type VolcengineModelOptions = {
+  max_tokens?: number
   thinking?: 'enabled' | 'disabled'
-): Parameters<VolcengineLargeLanguageModel['getChatModel']>[0] {
+}
+
+function createCopilotModel(options?: VolcengineModelOptions): Parameters<VolcengineLargeLanguageModel['getChatModel']>[0] {
   return {
     model: 'doubao-seed-2-0-mini-260215',
-    options: thinking ? { thinking } : undefined,
+    options,
     copilot: {
       role: AiProviderRole.Primary,
       modelProvider: {
@@ -52,7 +58,7 @@ describe('Volcengine model adapter', () => {
   const llm = new VolcengineLargeLanguageModel(new VolcengineProviderStrategy())
 
   it('converts the disabled thinking selector to the Ark request body', () => {
-    const model = llm.getChatModel(createCopilotModel('disabled'))
+    const model = llm.getChatModel(createCopilotModel({ thinking: 'disabled' }))
 
     expect(model.invocationParams()).toEqual({
       thinking: {
@@ -63,7 +69,7 @@ describe('Volcengine model adapter', () => {
   })
 
   it('passes the enabled thinking selector without overriding reasoning effort', () => {
-    const model = llm.getChatModel(createCopilotModel('enabled'))
+    const model = llm.getChatModel(createCopilotModel({ thinking: 'enabled' }))
 
     expect(model.invocationParams()).toEqual({
       thinking: {
@@ -76,6 +82,12 @@ describe('Volcengine model adapter', () => {
     const model = llm.getChatModel(createCopilotModel())
 
     expect(model.invocationParams()).toEqual({})
+  })
+
+  it('forwards the configured max tokens to the Ark request', () => {
+    const model = llm.getChatModel(createCopilotModel({ max_tokens: 2048 }))
+
+    expect(model.invocationParams()).toEqual({ max_tokens: 2048 })
   })
 
   it('inlines local schema references that cross anyOf array members', () => {

--- a/xpertai/models/volcengine/src/llm/llm.ts
+++ b/xpertai/models/volcengine/src/llm/llm.ts
@@ -154,6 +154,7 @@ export class VolcengineLargeLanguageModel extends LargeLanguageModel {
       {
         ...params,
         model,
+        maxTokens: copilotModel.options?.['max_tokens'],
         modelKwargs: buildVolcengineModelKwargs(copilotModel.options?.['thinking']),
         // include token usage in the stream. this will include an additional chunk at the end of the stream with the token usage.
         streamUsage: true


### PR DESCRIPTION
## Summary

- forward configured `max_tokens` values through the Volcengine chat adapter
- raise Doubao Seed 2.0 Mini's configurable output default to 4096 and maximum to 131072
- add a patch changeset for `@xpert-ai/plugin-volcengine`

## Problem

The model schema exposed a `max_tokens` control, but the Volcengine adapter did not pass the selected value into the Ark request. The shared parameter template also capped the model-specific control at 2048.

## Root cause

`VolcengineLargeLanguageModel.getChatModel()` built the OpenAI-compatible client without reading `copilotModel.options.max_tokens`. The model YAML relied solely on the generic `max_tokens` template.

## Fix

Pass the option as `maxTokens`, add a focused adapter regression test, and override the model YAML with default 4096 and maximum 131072.

## Validation

- Volcengine TypeScript build
- 26 Volcengine tests passed
- spec TypeScript typecheck
- plugin lifecycle harness
- built YAML uniqueness and content validation
- changeset status and Git diff checks

## Manual validation

Not run in a browser or against a live Ark account. The provider may enforce a lower effective output limit depending on total context and account or model limits.
